### PR TITLE
G4.14 Genus Ontology Service

### DIFF
--- a/trpcultivate_phenotypes/config/install/trpcultivate_phenotypes.settings.yml
+++ b/trpcultivate_phenotypes/config/install/trpcultivate_phenotypes.settings.yml
@@ -42,10 +42,6 @@ trpcultivate:
         - '/ = div'
         - '? = unsure'
         - '- = to'
-    
-    ontology:
-      cvdbon:
-      allownew: true
 
     # trpcultivate.phenotypes.watermark:
     # Configurations relating to the watermarking of charts.
@@ -59,7 +55,7 @@ trpcultivate:
         - 'gif'
     
     # trpcultivate.phenotypes.ontology:
-    # Configure vocabulary term, databse and term used by many processes of phenotypes module.
+    # Configure vocabulary term, database and term used by many processes of phenotypes module.
     # - terms: terms used when inserting phenotypic data.
     # - cvdbon: CV, Database and Ontology used to house traits.
     ontology:
@@ -76,6 +72,8 @@ trpcultivate:
         experiment_replicate: 0          
         unit: 0
         experiment_year: 0
+      cvdbon:
+      allownew: true
 
   phenoshare: null
   phenocollect: null

--- a/trpcultivate_phenotypes/config/install/trpcultivate_phenotypes.settings.yml
+++ b/trpcultivate_phenotypes/config/install/trpcultivate_phenotypes.settings.yml
@@ -43,6 +43,10 @@ trpcultivate:
         - '? = unsure'
         - '- = to'
     
+    ontology:
+      cvdbon:
+      allownew: true
+
     # trpcultivate.phenotypes.watermark:
     # Configurations relating to the watermarking of charts.
     # - charts: True, all charts will be watermarked and False, otherwise.
@@ -53,6 +57,7 @@ trpcultivate:
       file_ext:
         - 'png'
         - 'gif'
+    
 
   phenoshare: null
   phenocollect: null

--- a/trpcultivate_phenotypes/config/schema/trpcultivate_phenotypes.schema.yml
+++ b/trpcultivate_phenotypes/config/schema/trpcultivate_phenotypes.schema.yml
@@ -69,36 +69,36 @@ trpcultivate_phenotypes.settings:
                   sequence:
                     type: string
                     label: 'File extensions'
-              ontology:
-                type: mapping
-                label: 'CV Terms, Terms, and DB'
-                mapping:
-                  cvdbon:
-                    type: sequence
-                    label: 'CV, DB and Ontology'
-                    nullable: True
-                    sequence: 
-                      type: mapping
-                      label: 'Genus-based CV, DB and Ontology'
-                      mapping: 
-                        trait:
-                          type: integer
-                          label: 'CV: traits'
-                        method:
-                          type: integer
-                          label: 'CV: methods'
-                        unit:
-                          type: integer
-                          label: 'CV: unit'
-                        database:
-                          type: integer
-                          label: 'Database'
-                        crop_ontology:
-                          type: integer
-                          label: 'CV: ontology'
-                  allownew:
-                    type: boolean
-                    label: 'Allow new traits added during upload'
+            ontology:
+              type: mapping
+              label: 'CV Terms, Terms, and DB'
+              mapping:
+                cvdbon:
+                  type: sequence
+                  label: 'CV, DB and Ontology'
+                  nullable: True
+                  sequence: 
+                    type: mapping
+                    label: 'Genus-based CV, DB and Ontology'
+                    mapping: 
+                      trait:
+                        type: integer
+                        label: 'CV: traits'
+                      method:
+                        type: integer
+                        label: 'CV: methods'
+                      unit:
+                        type: integer
+                        label: 'CV: unit'
+                      database:
+                        type: integer
+                        label: 'Database'
+                      crop_ontology:
+                        type: integer
+                        label: 'CV: ontology'
+                allownew:
+                  type: boolean
+                  label: 'Allow new traits added during upload'
                     
         phenoshare:
           type: string

--- a/trpcultivate_phenotypes/config/schema/trpcultivate_phenotypes.schema.yml
+++ b/trpcultivate_phenotypes/config/schema/trpcultivate_phenotypes.schema.yml
@@ -69,6 +69,37 @@ trpcultivate_phenotypes.settings:
                   sequence:
                     type: string
                     label: 'File extensions'
+              ontology:
+                type: mapping
+                label: 'CV Terms, Terms, and DB'
+                mapping:
+                  cvdbon:
+                    type: sequence
+                    label: 'CV, DB and Ontology'
+                    nullable: True
+                    sequence: 
+                      type: mapping
+                      label: 'Genus-based CV, DB and Ontology'
+                      mapping: 
+                        trait:
+                          type: integer
+                          label: 'CV: traits'
+                        method:
+                          type: integer
+                          label: 'CV: methods'
+                        unit:
+                          type: integer
+                          label: 'CV: unit'
+                        database:
+                          type: integer
+                          label: 'Database'
+                        crop_ontology:
+                          type: integer
+                          label: 'CV: ontology'
+                  allownew:
+                    type: boolean
+                    label: 'Allow new traits added during upload'
+                    
         phenoshare:
           type: string
           label: 'Phenotypes Share (Analyzed) Configuration'

--- a/trpcultivate_phenotypes/config/schema/trpcultivate_phenotypes.schema.yml
+++ b/trpcultivate_phenotypes/config/schema/trpcultivate_phenotypes.schema.yml
@@ -76,11 +76,12 @@ trpcultivate_phenotypes.settings:
                 cvdbon:
                   type: sequence
                   label: 'CV, DB and Ontology'
+                  description: 'The key of this sequence is the sanitized genus and the value mapping indicates the values for this genus.'
                   nullable: True
-                  sequence: 
+                  sequence:
                     type: mapping
                     label: 'Genus-based CV, DB and Ontology'
-                    mapping: 
+                    mapping:
                       trait:
                         type: integer
                         label: 'CV: traits'
@@ -99,7 +100,7 @@ trpcultivate_phenotypes.settings:
                 allownew:
                   type: boolean
                   label: 'Allow new traits added during upload'
-                    
+
         phenoshare:
           type: string
           label: 'Phenotypes Share (Analyzed) Configuration'

--- a/trpcultivate_phenotypes/src/Service/TripalCultivatePhenotypesGenusOntologyService.php
+++ b/trpcultivate_phenotypes/src/Service/TripalCultivatePhenotypesGenusOntologyService.php
@@ -1,0 +1,91 @@
+<?php
+
+/**
+ * @file
+ * Tripal Cultivate Phenotypes Genus Ontology service definition.
+ */
+
+namespace Drupal\trpcultivate_phenotypes\Service;
+
+use \Drupal\Core\Config\ConfigFactoryInterface;
+use \Drupal\tripal_chado\Database\ChadoConnection;
+
+/**
+ * Class TripalCultivatePhenotypesOntologyService.
+ */
+class TripalCultivatePhenotypesOntologyService {
+  
+  /**
+   * Chado DB and Module configuration.
+   */
+  protected $config;
+  protected $chado;
+
+  /**
+   * Holds genus - ontology configuration variable.
+   */
+  private $genus_ontology;
+
+  /**
+   * Configuration hierarchy for configuration: cvdbon.
+   */
+  private $sysvar_ontology;
+
+  /**
+   * Constructor.
+   */
+  public function __construct(ConfigFactoryInterface $config_factory, ChadoConnection $chado) {
+    // Configuration.
+    $this->sysvar_ontology = 'trpcultivate.phenotypes.ontology.cvdbon';
+    $module_settings = 'trpcultivate_phenotypes.settings';
+    $this->config = $config_factory->getEditable($module_settings);
+    
+    // Chado database.
+    $this->chado = $chado
+    
+    // Define all default terms.
+    $this->genus_ontology = $this->defineGenusOntology();
+  }
+
+  /**
+   * Fetch all genus from chado.organism in the host site and construct a genus ontology
+   * configuration values described above. Each genus will contain a configuration value 
+   * for trait+unit+method, database and crop ontology.
+   *
+   * @return array
+   *    Associative array where each element is keyed by genus and configuration values
+   *    for trait, unit, method, database and crop ontology stored in a array as the value.
+   * 
+   *    ie: [genus_a] = [
+   *           trait,
+   *           unit,
+   *           method,
+   *           database,
+   *           crop_ontology
+   *        ];
+   */
+  public function defineGenusOntology() {
+    $genus_ontology = [];
+
+    // Fetch genus in host site.
+    $query = "SELECT genus FROM {1:organism} GROUP BY genus ORDER BY genus ASC";
+    $result = $this->chado->query($query);
+
+    if ($result) {
+      foreach($result as $genus) {
+        // genus-ontology configuration.
+        $config_genus = $this->formatGenus($genus->genus);
+
+        $genus_ontology[ $config_genus ] = [
+          'trait',
+          'method',
+          'unit',
+          'database',
+          'crop_ontology'
+        ];
+      }
+    }
+
+    return $genus_ontology;
+  }
+}

--- a/trpcultivate_phenotypes/tests/src/Kernel/ServiceGenusOntologyTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/ServiceGenusOntologyTest.php
@@ -49,8 +49,6 @@ class ServiceGenusOntologyTest extends ChadoTestKernelBase {
 
   public function testGenusOntologyService() {
     \Drupal::state()->set('is_a_test_environment', TRUE);
-    // This line will create install schema.
-    $this->installSchema('tripal_chado', ['chado_installations']);
 
     // Class created.
     $this->assertNotNull($this->service);

--- a/trpcultivate_phenotypes/tests/src/Kernel/ServiceGenusOntologyTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/ServiceGenusOntologyTest.php
@@ -26,6 +26,17 @@ class ServiceGenusOntologyTest extends KernelTestBase {
     parent::setUp();
     $this->installConfig(['trpcultivate_phenotypes']);
 
+    $test_insert_genus = ['Lens', 'Cicer'];
+    $chado = \Drupal::service('tripal_chado.database');
+    $ins_genus = "
+      INSERT INTO {1:organism} (genus, species, type_id)
+      VALUES 
+        ('$test_insert_genus[0]', 'culinaris', 1), 
+        ('$test_insert_genus[1]', 'arientinum', 1)
+    ";
+
+    $chado->query($ins_genus);
+    
     $this->service = \Drupal::service('trpcultivate_phenotypes.genus_ontology');
   }
 
@@ -44,15 +55,6 @@ class ServiceGenusOntologyTest extends KernelTestBase {
 
     // Created genus of type null (id: 1).
     $test_insert_genus = ['Lens', 'Cicer'];
-    $chado = \Drupal::service('tripal_chado.database');
-    $ins_genus = "
-      INSERT INTO {1:organism} (genus, species, type_id)
-      VALUES 
-        ('$test_insert_genus[0]', 'culinaris', 1), 
-        ('$test_insert_genus[1]', 'arientinum', 1)
-    ";
-
-    $chado->query($ins_genus);
 
     // #Test defineGenusOntology().
     $define_genusontology = $this->service->defineGenusOntology();

--- a/trpcultivate_phenotypes/tests/src/Kernel/ServiceGenusOntologyTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/ServiceGenusOntologyTest.php
@@ -7,16 +7,19 @@
 
 namespace Drupal\Tests\trpcultivate_phenotypes\Kernel;
 
-use Drupal\trpcultivate_phenotypes\Service\TripalCultivatePhenotypesGenusOntologyService;
 use Drupal\KernelTests\KernelTestBase;
+use Drupal\tripal\Services\TripalLogger;
 
 /**
   *  Class definition ServiceGenusOntologyTest.
   */
 class ServiceGenusOntologyTest extends KernelTestBase {
   protected $service;
-  public static $modules = [
-   'tripal', 'trpcultivate_phenotypes'  
+  
+  protected static $modules = [
+   'tripal', 
+   'tripal_chado',
+   'trpcultivate_phenotypes'  
   ];
 
   protected function setUp() {
@@ -26,8 +29,71 @@ class ServiceGenusOntologyTest extends KernelTestBase {
     $this->service = \Drupal::service('trpcultivate_phenotypes.genus_ontology');
   }
 
-  public function testGenusOntology() {
-    $m = $this->service->defineGenusOntology();
-    var_dump($m);
+  public function testGenusOntologyService() {
+    \Drupal::state()->set('is_a_test_environment', TRUE);
+    // This line will create install schema.
+    $this->installSchema('tripal_chado', ['chado_installations']);
+   
+    // Class created.
+    $this->assertNotNull($this->service);
+
+    // Test when no genus in host Tripal site.
+    $no_genus = $this->service->defineGenus();
+    $is_empty = (empty($define_genusontology)) ? TRUE : FALSE;
+
+
+    
+
+
+
+    // Create genus records since a clean Tripal site has 
+    // no organism/genus records and re-run routines carried out
+    // during install process. 
+
+    // Created genus of type null (id: 1).
+    $test_genus = ['Lens', 'Cicer'];
+    $chado = \Drupal::service('tripal_chado.database');
+    $ins_genus = "
+      INSERT INTO {1:organism} (genus, species, type_id)
+      VALUES 
+        ('$test_genus[0]', 'culinaris', 1), 
+        ('$test_genus[1]', 'arientinum', 1)
+    ";
+
+    $chado->query($ins_genus);
+
+    // #Test defineGenusOntology().
+    $define_genusontology = $this->service->defineGenusOntology();
+    $this->assertNotNull($define_genusontology);
+    // Is an array.
+    $is_array = (is_array($define_genusontology)) ? TRUE : FALSE;
+    $this->assertTrue($is_array);
+
+    foreach($test_genus as $g) {
+      $key = $this->service->formatGenus($g);
+      $this->assertNotNull($define_genusontology[ $key ]);
+    }
+    
+    // #Test formatGenus().
+    // Genus = formatting applied by formatGenus().
+    $test_genus = [
+      'Lens' => 'lens',
+      'Hello Genus' => 'hello_genus',
+      'WOW GENUS' => 'wow_genus',
+      'beautiful_genus' => 'beautiful_genus',
+      'a genus ' => 'a_genus',
+      'Y' => 'y',
+      '     Not cool genus    ' => 'not_cool_genus',
+      ' ' => null
+    ];
+
+    foreach($test_genus as $base => $result) {
+      $format_genus = $this->service->formatGenus($base);
+      $this->assertEquals($format_genus, $result);
+    }
+
+    // #Test loadGenusOntology().
+
+
   }
 }

--- a/trpcultivate_phenotypes/tests/src/Kernel/ServiceGenusOntologyTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/ServiceGenusOntologyTest.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * @file
+ * Kernel test of Genus Ontology service.
+ */
+
+namespace Drupal\Tests\trpcultivate_phenotypes\Kernel;
+
+use Drupal\trpcultivate_phenotypes\Service\TripalCultivatePhenotypesGenusOntologyService;
+use Drupal\KernelTests\KernelTestBase;
+
+/**
+  *  Class definition ServiceGenusOntologyTest.
+  */
+class ServiceGenusOntologyTest extends KernelTestBase {
+  protected $service;
+  public static $modules = [
+   'tripal', 'trpcultivate_phenotypes'  
+  ];
+
+  protected function setUp() {
+    parent::setUp();
+    $this->installConfig(['trpcultivate_phenotypes']);
+
+    $this->service = \Drupal::service('trpcultivate_phenotypes.genus_ontology');
+  }
+
+  public function testGenusOntology() {
+    $m = $this->service->defineGenusOntology();
+    var_dump($m);
+  }
+}

--- a/trpcultivate_phenotypes/tests/src/Kernel/ServiceGenusOntologyTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/ServiceGenusOntologyTest.php
@@ -25,8 +25,12 @@ class ServiceGenusOntologyTest extends ChadoTestKernelBase {
    'trpcultivate_phenotypes'
   ];
 
-  protected function setUp() {
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() :void {
     parent::setUp();
+
     $this->installConfig(['trpcultivate_phenotypes']);
 
     $test_insert_genus = ['Lens', 'Cicer'];

--- a/trpcultivate_phenotypes/tests/src/Kernel/ServiceGenusOntologyTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/ServiceGenusOntologyTest.php
@@ -7,19 +7,22 @@
 
 namespace Drupal\Tests\trpcultivate_phenotypes\Kernel;
 
-use Drupal\KernelTests\KernelTestBase;
+use Drupal\Tests\tripal_chado\Kernel\ChadoTestKernelBase;
 use Drupal\tripal\Services\TripalLogger;
 
 /**
-  *  Class definition ServiceGenusOntologyTest.
-  */
-class ServiceGenusOntologyTest extends KernelTestBase {
+ * Tests associated with the Genus Ontology Service.
+ *
+ * Service: trpcultivate_phenotypes.genus_ontology
+ * Class: TripalCultivatePhenotypesGenusOntologyService
+ */
+class ServiceGenusOntologyTest extends ChadoTestKernelBase {
   protected $service;
-  
+
   protected static $modules = [
-   'tripal', 
+   'tripal',
    'tripal_chado',
-   'trpcultivate_phenotypes'  
+   'trpcultivate_phenotypes'
   ];
 
   protected function setUp() {
@@ -30,13 +33,13 @@ class ServiceGenusOntologyTest extends KernelTestBase {
     $chado = \Drupal::service('tripal_chado.database');
     $ins_genus = "
       INSERT INTO {1:organism} (genus, species, type_id)
-      VALUES 
-        ('$test_insert_genus[0]', 'culinaris', 1), 
+      VALUES
+        ('$test_insert_genus[0]', 'culinaris', 1),
         ('$test_insert_genus[1]', 'arientinum', 1)
     ";
 
     $chado->query($ins_genus);
-    
+
     $this->service = \Drupal::service('trpcultivate_phenotypes.genus_ontology');
   }
 
@@ -44,14 +47,14 @@ class ServiceGenusOntologyTest extends KernelTestBase {
     \Drupal::state()->set('is_a_test_environment', TRUE);
     // This line will create install schema.
     $this->installSchema('tripal_chado', ['chado_installations']);
-   
+
     // Class created.
     $this->assertNotNull($this->service);
 
     // TEST WHEN THERE IS A GENUS RECORD.
-    // Create genus records since a clean Tripal site has 
+    // Create genus records since a clean Tripal site has
     // no organism/genus records and re-run routines carried out
-    // during install process. 
+    // during install process.
 
     // Created genus of type null (id: 1).
     $test_insert_genus = ['Lens', 'Cicer'];
@@ -67,7 +70,7 @@ class ServiceGenusOntologyTest extends KernelTestBase {
       $key = $this->service->formatGenus($g);
       $this->assertNotNull($define_genusontology[ $key ]);
     }
-    
+
     // #Test formatGenus().
     // Genus = formatting applied by formatGenus().
     $test_genus = [
@@ -121,12 +124,12 @@ class ServiceGenusOntologyTest extends KernelTestBase {
     // #Test saveGenusOntologyConfigValues().
     // loadGenusOntology() sets all configuration values for all genus to a default value
     // 0. This test will set every configuration to null cv (id: 1) and null db (id: 1).
-    
+
     // This would have came from a form submit method.
     $null_id = 1;
     $genus_ontology_values = [];
 
-    foreach($define_genusontology as $genus_key => $config_values) {      
+    foreach($define_genusontology as $genus_key => $config_values) {
       foreach($config_values as $config_name) {
         $genus_ontology_values[ $genus_key ][ $config_name ] = $null_id;
       }

--- a/trpcultivate_phenotypes/tests/src/Kernel/ServiceGenusOntologyTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/ServiceGenusOntologyTest.php
@@ -30,7 +30,6 @@ class ServiceGenusOntologyTest extends KernelTestBase {
   }
 
   public function testGenusOntologyService() {
-    $chado = \Drupal::service('tripal_chado.database');
     \Drupal::state()->set('is_a_test_environment', TRUE);
     // This line will create install schema.
     $this->installSchema('tripal_chado', ['chado_installations']);
@@ -45,6 +44,7 @@ class ServiceGenusOntologyTest extends KernelTestBase {
 
     // Created genus of type null (id: 1).
     $test_insert_genus = ['Lens', 'Cicer'];
+    $chado = \Drupal::service('tripal_chado.database');
     $ins_genus = "
       INSERT INTO {1:organism} (genus, species, type_id)
       VALUES 

--- a/trpcultivate_phenotypes/trpcultivate_phenotypes.services.yml
+++ b/trpcultivate_phenotypes/trpcultivate_phenotypes.services.yml
@@ -1,0 +1,4 @@
+services:
+  trpcultivate_phenotypes.genus_ontology:
+    class: 'Drupal\trpcultivate_phenotypes\Service\TripalCultivatePhenotypesGenusOntologyService'
+    arguments: ['@config.factory']

--- a/trpcultivate_phenotypes/trpcultivate_phenotypes.services.yml
+++ b/trpcultivate_phenotypes/trpcultivate_phenotypes.services.yml
@@ -1,4 +1,4 @@
 services:
   trpcultivate_phenotypes.genus_ontology:
     class: 'Drupal\trpcultivate_phenotypes\Service\TripalCultivatePhenotypesGenusOntologyService'
-    arguments: ['@config.factory']
+    arguments: ['@config.factory', '@tripal_chado.database', '@tripal.logger']


### PR DESCRIPTION
This PR sets up Genus Ontology Service described in this Issue https://github.com/TripalCultivate/TripalCultivate-Phenotypes/issues/14

With the addition of a method to save configuration values coming from a form submit.

```
/**
 * Get genus ontology configuration values.
 *
 * @param string $genus
 *   Genus
 *
 * @return array
 *   Associated genus configuration values trait, unit, method, database and crop ontology.
 */
public function getGenusOntologyConfigValues($genus)
```

Included is a kernel test that tests all methods of the service.