### PR TITLE
Dockerfile in `contrib/` and using Drupal 10.0.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM tripalproject/tripaldocker:latest
 
-COPY . /var/www/drupal9/web/modules/TripalCultivate-Phenotypes
+COPY . /var/www/drupal9/web/modules/contrib/TripalCultivate-Phenotypes
 
-WORKDIR /var/www/drupal9/web/modules/TripalCultivate-Phenotypes
+WORKDIR /var/www/drupal9/web/modules/contrib/TripalCultivate-Phenotypes
 
 RUN service postgresql restart \
   && drush en trpcultivate_phenotypes trpcultivate_phenocollect trpcultivate_phenoshare --yes

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM tripalproject/tripaldocker:latest
+FROM tripalproject/tripaldocker:drupal10.0.x-dev-php8.1-pgsql13
 
 COPY . /var/www/drupal9/web/modules/contrib/TripalCultivate-Phenotypes
 


### PR DESCRIPTION
This PR updates the dockerfile to use the same path structure as the automated testing workflows. This is needed to ensure that the PHPUnit.xml config works for both.

This changes the run command for this docker:
```
docker run --publish=80:80 -tid --name=$containerName --volume=$(pwd):/var/www/drupal9/web/modules/contrib/TripalCultivate-Phenotypes $imageName
```

Additionally, this PR updates the Drupal version used in the docker to Drupal 10.0.x-dev and PHP 8.1 specifically.

## Testing

Simply confirm that you can build the docker and run it using the following commands:

```
docker build --tag=trpcultivate-pheno:dockerfile-test ./
docker run --publish=80:80 -tid --name=dockerfile-test --volume=$(pwd):/var/www/drupal9/web/modules/contrib/TripalCultivate-Phenotypes trpcultivate-pheno:dockerfile-test
docker exec dockerfile-test service postgresql restart
docker exec dockerfile-test phpunit
```