### PR TITLE
Update Workflow testing grid to match Tripal core versions

### DIFF
--- a/.github/workflows/ALL-PHPUnit.yml
+++ b/.github/workflows/ALL-PHPUnit.yml
@@ -16,17 +16,27 @@ jobs:
         php-version:
           - "8.0"
           - "8.1"
+          - "8.2"
         pgsql-version:
           - "13"
         drupal-version:
-          - "9.3.x-dev"
           - "9.4.x-dev"
           - "9.5.x-dev"
-          # - "10.0.x-dev"
-#        exclude:
-#          - php-version: "8.0"
-#            pgsql-version: "13"
-#            drupal-version: "10.0.x-dev"
+          - "10.0.x-dev"
+          - "10.1.x-dev"
+        exclude:
+          - php-version: "8.2"
+            pgsql-version: "13"
+            drupal-version: "9.4.x-dev"
+          - php-version: "8.2"
+            pgsql-version: "13"
+            drupal-version: "9.5.x-dev"
+          - php-version: "8.0"
+            pgsql-version: "13"
+            drupal-version: "10.0.x-dev"
+          - php-version: "8.0"
+            pgsql-version: "13"
+            drupal-version: "10.1.x-dev"
 
     steps:
       # Check out the repo

--- a/.github/workflows/ALL-PHPUnit.yml
+++ b/.github/workflows/ALL-PHPUnit.yml
@@ -1,5 +1,5 @@
 
-name: PHPUnit
+name: PHPUnit Full Test Suite
 on: [push]
 
 env:

--- a/.github/workflows/MAIN-phpunit-Grid1A.yml
+++ b/.github/workflows/MAIN-phpunit-Grid1A.yml
@@ -5,7 +5,7 @@ on:
       - 4.x
       - g5.18-workflows
 jobs:
-  run-tests:
+  grid-1A:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository

--- a/.github/workflows/MAIN-phpunit-Grid1A.yml
+++ b/.github/workflows/MAIN-phpunit-Grid1A.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - 4.x
-      - customize-template
+      - g5.18-workflows
 jobs:
   run-tests:
     runs-on: ubuntu-latest
@@ -17,4 +17,4 @@ jobs:
           modules: 'trpcultivate_phenotypes trpcultivate_phenocollect trpcultivate_phenoshare'
           php-version: '8.0'
           pgsql-version: '13'
-          drupal-version: '9.3.x-dev'
+          drupal-version: '9.4.x-dev'

--- a/.github/workflows/MAIN-phpunit-Grid1B.yml
+++ b/.github/workflows/MAIN-phpunit-Grid1B.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - 4.x
-      - customize-template
+      - g5.18-workflows
 jobs:
   run-tests:
     runs-on: ubuntu-latest
@@ -17,4 +17,4 @@ jobs:
           modules: 'trpcultivate_phenotypes trpcultivate_phenocollect trpcultivate_phenoshare'
           php-version: '8.0'
           pgsql-version: '13'
-          drupal-version: '9.4.x-dev'
+          drupal-version: '9.5.x-dev'

--- a/.github/workflows/MAIN-phpunit-Grid1B.yml
+++ b/.github/workflows/MAIN-phpunit-Grid1B.yml
@@ -5,7 +5,7 @@ on:
       - 4.x
       - g5.18-workflows
 jobs:
-  run-tests:
+  grid-1B:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository

--- a/.github/workflows/MAIN-phpunit-Grid2A.yml
+++ b/.github/workflows/MAIN-phpunit-Grid2A.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - 4.x
-      - customize-template
+      - g5.18-workflows
 jobs:
   run-tests:
     runs-on: ubuntu-latest
@@ -17,4 +17,4 @@ jobs:
           modules: 'trpcultivate_phenotypes'
           php-version: '8.1'
           pgsql-version: '13'
-          drupal-version: '9.3.x-dev'
+          drupal-version: '9.4.x-dev'

--- a/.github/workflows/MAIN-phpunit-Grid2A.yml
+++ b/.github/workflows/MAIN-phpunit-Grid2A.yml
@@ -5,7 +5,7 @@ on:
       - 4.x
       - g5.18-workflows
 jobs:
-  run-tests:
+  grid-2A:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository

--- a/.github/workflows/MAIN-phpunit-Grid2A.yml
+++ b/.github/workflows/MAIN-phpunit-Grid2A.yml
@@ -13,8 +13,8 @@ jobs:
       - name: Run Automated testing
         uses: tripal/test-tripal-action@v1.0
         with:
-          directory-name: 'TripalCultivate-Phenotypes trpcultivate_phenocollect trpcultivate_phenoshare'
-          modules: 'trpcultivate_phenotypes'
+          directory-name: 'TripalCultivate-Phenotypes'
+          modules: 'trpcultivate_phenotypes trpcultivate_phenocollect trpcultivate_phenoshare'
           php-version: '8.1'
           pgsql-version: '13'
           drupal-version: '9.4.x-dev'

--- a/.github/workflows/MAIN-phpunit-Grid2B.yml
+++ b/.github/workflows/MAIN-phpunit-Grid2B.yml
@@ -5,7 +5,7 @@ on:
       - 4.x
       - g5.18-workflows
 jobs:
-  run-tests:
+  grid-2B:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository

--- a/.github/workflows/MAIN-phpunit-Grid2B.yml
+++ b/.github/workflows/MAIN-phpunit-Grid2B.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - 4.x
-      - customize-template
+      - g5.18-workflows
 jobs:
   run-tests:
     runs-on: ubuntu-latest
@@ -17,4 +17,4 @@ jobs:
           modules: 'trpcultivate_phenotypes trpcultivate_phenocollect trpcultivate_phenoshare'
           php-version: '8.1'
           pgsql-version: '13'
-          drupal-version: '9.4.x-dev'
+          drupal-version: '9.5.x-dev'

--- a/.github/workflows/MAIN-phpunit-Grid2C.yml
+++ b/.github/workflows/MAIN-phpunit-Grid2C.yml
@@ -5,7 +5,7 @@ on:
       - 4.x
       - g5.18-workflows
 jobs:
-  run-tests:
+  grid-2C:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository

--- a/.github/workflows/MAIN-phpunit-Grid2D.yml
+++ b/.github/workflows/MAIN-phpunit-Grid2D.yml
@@ -5,7 +5,7 @@ on:
       - 4.x
       - g5.18-workflows
 jobs:
-  run-tests:
+  grid-2D:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository

--- a/.github/workflows/MAIN-phpunit-Grid2D.yml
+++ b/.github/workflows/MAIN-phpunit-Grid2D.yml
@@ -17,4 +17,4 @@ jobs:
           modules: 'trpcultivate_phenotypes trpcultivate_phenocollect trpcultivate_phenoshare'
           php-version: '8.1'
           pgsql-version: '13'
-          drupal-version: '10.0.x-dev'
+          drupal-version: '10.1.x-dev'

--- a/.github/workflows/MAIN-phpunit-Grid3C.yml
+++ b/.github/workflows/MAIN-phpunit-Grid3C.yml
@@ -15,6 +15,6 @@ jobs:
         with:
           directory-name: 'TripalCultivate-Phenotypes'
           modules: 'trpcultivate_phenotypes trpcultivate_phenocollect trpcultivate_phenoshare'
-          php-version: '8.1'
+          php-version: '8.2'
           pgsql-version: '13'
           drupal-version: '10.0.x-dev'

--- a/.github/workflows/MAIN-phpunit-Grid3C.yml
+++ b/.github/workflows/MAIN-phpunit-Grid3C.yml
@@ -5,7 +5,7 @@ on:
       - 4.x
       - g5.18-workflows
 jobs:
-  run-tests:
+  grid-3C:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository

--- a/.github/workflows/MAIN-phpunit-Grid3D.yml
+++ b/.github/workflows/MAIN-phpunit-Grid3D.yml
@@ -5,7 +5,7 @@ on:
       - 4.x
       - g5.18-workflows
 jobs:
-  run-tests:
+  grid-3D:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository

--- a/.github/workflows/MAIN-phpunit-Grid3D.yml
+++ b/.github/workflows/MAIN-phpunit-Grid3D.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - 4.x
-      - customize-template
+      - g5.18-workflows
 jobs:
   run-tests:
     runs-on: ubuntu-latest
@@ -15,6 +15,6 @@ jobs:
         with:
           directory-name: 'TripalCultivate-Phenotypes'
           modules: 'trpcultivate_phenotypes trpcultivate_phenocollect trpcultivate_phenoshare'
-          php-version: '8.0'
+          php-version: '8.2'
           pgsql-version: '13'
-          drupal-version: '9.5.x-dev'
+          drupal-version: '10.1.x-dev'

--- a/README.md
+++ b/README.md
@@ -62,10 +62,11 @@ maintainability issues and test coverage.
 
 The following compatibility is proven via automated testing workflows.
 
-| Drupal | 9.3.x | 9.4.x | 9.5.x | 10.0.x |
-|--------|-------|-------|-------|--------|
-| **PHP 8.0** | ![Grid1A-Badge] | ![Grid1B-Badge] | ![Grid1C-Badge] |  |
-| **PHP 8.1** | ![Grid2A-Badge] | ![Grid2B-Badge] | ![Grid2C-Badge] |  |
+|  Drupal     |  9.4.x          |  9.5.x          |  10.0.x         |  10.1.x         |
+|-------------|-----------------|-----------------|-----------------|-----------------|
+| **PHP 8.0** | ![Grid1A-Badge] | ![Grid1B-Badge] |                 |                 |
+| **PHP 8.1** | ![Grid2A-Badge] | ![Grid2B-Badge] | ![Grid2C-Badge] | ![Grid2D-Badge] |
+| **PHP 8.2** |                 |                 | ![Grid3C-Badge] | ![Grid3D-Badge] |
 
 [our CodeClimate project page]: https://github.com/TripalCultivate/TripalCultivate-Phenotypes
 [MaintainabilityBadge]: https://api.codeclimate.com/v1/badges/03fa542e0d95dedb97e8/maintainability
@@ -73,9 +74,11 @@ The following compatibility is proven via automated testing workflows.
 
 [Grid1A-Badge]: https://github.com/TripalCultivate/TripalCultivate-Phenotypes/actions/workflows/MAIN-phpunit-Grid1A.yml/badge.svg
 [Grid1B-Badge]: https://github.com/TripalCultivate/TripalCultivate-Phenotypes/actions/workflows/MAIN-phpunit-Grid1B.yml/badge.svg
-[Grid1C-Badge]: https://github.com/TripalCultivate/TripalCultivate-Phenotypes/actions/workflows/MAIN-phpunit-Grid1C.yml/badge.svg
 
 [Grid2A-Badge]: https://github.com/TripalCultivate/TripalCultivate-Phenotypes/actions/workflows/MAIN-phpunit-Grid2A.yml/badge.svg
 [Grid2B-Badge]: https://github.com/TripalCultivate/TripalCultivate-Phenotypes/actions/workflows/MAIN-phpunit-Grid2B.yml/badge.svg
 [Grid2C-Badge]: https://github.com/TripalCultivate/TripalCultivate-Phenotypes/actions/workflows/MAIN-phpunit-Grid2C.yml/badge.svg
 [Grid2D-Badge]: https://github.com/TripalCultivate/TripalCultivate-Phenotypes/actions/workflows/MAIN-phpunit-Grid2D.yml/badge.svg
+
+[Grid3C-Badge]: https://github.com/TripalCultivate/TripalCultivate-Phenotypes/actions/workflows/MAIN-phpunit-Grid3C.yml/badge.svg
+[Grid3D-Badge]: https://github.com/TripalCultivate/TripalCultivate-Phenotypes/actions/workflows/MAIN-phpunit-Grid3D.yml/badge.svg

--- a/trpcultivate_phenocollect/tests/src/Functional/InstallTest.php
+++ b/trpcultivate_phenocollect/tests/src/Functional/InstallTest.php
@@ -13,7 +13,7 @@ use Drupal\Tests\tripal_chado\Functional\ChadoTestBrowserBase;
  */
 class InstallTest extends ChadoTestBrowserBase {
 
-  protected $defaultTheme = 'stable';
+  protected $defaultTheme = 'stark';
 
   /**
    * Modules to enable.

--- a/trpcultivate_phenoshare/tests/src/Functional/InstallTest.php
+++ b/trpcultivate_phenoshare/tests/src/Functional/InstallTest.php
@@ -13,7 +13,7 @@ use Drupal\Tests\tripal_chado\Functional\ChadoTestBrowserBase;
  */
 class InstallTest extends ChadoTestBrowserBase {
 
-  protected $defaultTheme = 'stable';
+  protected $defaultTheme = 'stark';
 
   /**
    * Modules to enable.

--- a/trpcultivate_phenotypes/tests/src/Functional/ConfigWatermarkTest.php
+++ b/trpcultivate_phenotypes/tests/src/Functional/ConfigWatermarkTest.php
@@ -19,7 +19,7 @@ use Drupal\file\Entity\File;
 class ConfigWatermarkTest extends BrowserTestBase {
   /**
    * Modules to enabled
-   * 
+   *
    * @var array
    */
   protected static $modules = ['trpcultivate_phenotypes'];
@@ -40,10 +40,10 @@ class ConfigWatermarkTest extends BrowserTestBase {
 
   /**
    * Test watermark configuration page.
-   * 
+   *
    * NOTE: unable to test file upload field, This test only when
    * choosing not to watermark any charts.
-   * 
+   *
    * @see unit test and kernel test of this form where file field
    * and upload are tested.
    */
@@ -56,7 +56,7 @@ class ConfigWatermarkTest extends BrowserTestBase {
       'administer site configuration',
       'administer tripal'
     ]);
-    
+
     // Login admin user.
     $this->drupalLogin($admin_user);
 
@@ -86,11 +86,11 @@ class ConfigWatermarkTest extends BrowserTestBase {
     $this->submitForm($update_watermark, 'Save configuration');
 
     // Assert configuration saved.
-    $this->assertRaw('The configuration options have been saved.');
+    $this->assertSession()->responseContains('The configuration options have been saved.');
 
     // Assert Fields reflect the updated configuration.
     $session->fieldValueEquals('charts', $update_watermark['charts']);
-    
+
     $this->drupalLogout();
   }
 }


### PR DESCRIPTION
Issue #18 

This PR updates the automated testing grid on the readme to show the new compliment of workflows. It also updates our existing workflows and adds more to allow the full testing of PHP 8.0, 8.1, 8.2 and Drupal 9.4, 9.5, 10.0, 10.1.

Finally, I made one fix to the watermark test as the assertRaw() method was removed in Drupal 10.

<img width="559" alt="Screenshot 2023-06-22 at 3 03 37 PM" src="https://github.com/TripalCultivate/TripalCultivate-Phenotypes/assets/1566301/743ff764-0f6e-4efd-ab51-f52b4748bb66">

Note: Grid 2A actually passes but you see failure in this screenshot just because the fix hasn't been merged to master yet.

## Testing

Confirm that all the tests pass and do a quick code review to ensure it looks right.