### PR TITLE
Build our own dockerfile with testchado schema name.

### DIFF
--- a/.github/workflows/ALL-PHPUnit.yml
+++ b/.github/workflows/ALL-PHPUnit.yml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/checkout@v3
       # Here we pull the development tripaldocker image for this combo in our matrix
       - name: Run Automated testing
-        uses: tripal/test-tripal-action@v1.0
+        uses: tripal/test-tripal-action@v1.1
         with:
           directory-name: $PKG_NAME
           modules: $MODULES

--- a/.github/workflows/ALL-PHPUnit.yml
+++ b/.github/workflows/ALL-PHPUnit.yml
@@ -48,6 +48,8 @@ jobs:
         with:
           directory-name: $PKG_NAME
           modules: $MODULES
+          build-image: TRUE
+          dockerfile: 'Dockerfile'
           php-version: ${{ matrix.php-version }}
           pgsql-version: ${{ matrix.pgsql-version }}
           drupal-version: ${{ matrix.drupal-version }}

--- a/.github/workflows/MAIN-phpunit-Grid1A.yml
+++ b/.github/workflows/MAIN-phpunit-Grid1A.yml
@@ -15,6 +15,8 @@ jobs:
         with:
           directory-name: 'TripalCultivate-Phenotypes'
           modules: 'trpcultivate_phenotypes trpcultivate_phenocollect trpcultivate_phenoshare'
+          build-image: TRUE
+          dockerfile: 'Dockerfile'
           php-version: '8.0'
           pgsql-version: '13'
           drupal-version: '9.4.x-dev'

--- a/.github/workflows/MAIN-phpunit-Grid1A.yml
+++ b/.github/workflows/MAIN-phpunit-Grid1A.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v3
       - name: Run Automated testing
-        uses: tripal/test-tripal-action@v1.0
+        uses: tripal/test-tripal-action@v1.1
         with:
           directory-name: 'TripalCultivate-Phenotypes'
           modules: 'trpcultivate_phenotypes trpcultivate_phenocollect trpcultivate_phenoshare'

--- a/.github/workflows/MAIN-phpunit-Grid1B.yml
+++ b/.github/workflows/MAIN-phpunit-Grid1B.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v3
       - name: Run Automated testing
-        uses: tripal/test-tripal-action@v1.0
+        uses: tripal/test-tripal-action@v1.1
         with:
           directory-name: 'TripalCultivate-Phenotypes'
           modules: 'trpcultivate_phenotypes trpcultivate_phenocollect trpcultivate_phenoshare'

--- a/.github/workflows/MAIN-phpunit-Grid1B.yml
+++ b/.github/workflows/MAIN-phpunit-Grid1B.yml
@@ -15,6 +15,8 @@ jobs:
         with:
           directory-name: 'TripalCultivate-Phenotypes'
           modules: 'trpcultivate_phenotypes trpcultivate_phenocollect trpcultivate_phenoshare'
+          build-image: TRUE
+          dockerfile: 'Dockerfile'
           php-version: '8.0'
           pgsql-version: '13'
           drupal-version: '9.5.x-dev'

--- a/.github/workflows/MAIN-phpunit-Grid2A.yml
+++ b/.github/workflows/MAIN-phpunit-Grid2A.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v3
       - name: Run Automated testing
-        uses: tripal/test-tripal-action@v1.0
+        uses: tripal/test-tripal-action@v1.1
         with:
           directory-name: 'TripalCultivate-Phenotypes'
           modules: 'trpcultivate_phenotypes trpcultivate_phenocollect trpcultivate_phenoshare'

--- a/.github/workflows/MAIN-phpunit-Grid2A.yml
+++ b/.github/workflows/MAIN-phpunit-Grid2A.yml
@@ -15,6 +15,8 @@ jobs:
         with:
           directory-name: 'TripalCultivate-Phenotypes'
           modules: 'trpcultivate_phenotypes trpcultivate_phenocollect trpcultivate_phenoshare'
+          build-image: TRUE
+          dockerfile: 'Dockerfile'
           php-version: '8.1'
           pgsql-version: '13'
           drupal-version: '9.4.x-dev'

--- a/.github/workflows/MAIN-phpunit-Grid2B.yml
+++ b/.github/workflows/MAIN-phpunit-Grid2B.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v3
       - name: Run Automated testing
-        uses: tripal/test-tripal-action@v1.0
+        uses: tripal/test-tripal-action@v1.1
         with:
           directory-name: 'TripalCultivate-Phenotypes'
           modules: 'trpcultivate_phenotypes trpcultivate_phenocollect trpcultivate_phenoshare'

--- a/.github/workflows/MAIN-phpunit-Grid2B.yml
+++ b/.github/workflows/MAIN-phpunit-Grid2B.yml
@@ -15,6 +15,8 @@ jobs:
         with:
           directory-name: 'TripalCultivate-Phenotypes'
           modules: 'trpcultivate_phenotypes trpcultivate_phenocollect trpcultivate_phenoshare'
+          build-image: TRUE
+          dockerfile: 'Dockerfile'
           php-version: '8.1'
           pgsql-version: '13'
           drupal-version: '9.5.x-dev'

--- a/.github/workflows/MAIN-phpunit-Grid2C.yml
+++ b/.github/workflows/MAIN-phpunit-Grid2C.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v3
       - name: Run Automated testing
-        uses: tripal/test-tripal-action@v1.0
+        uses: tripal/test-tripal-action@v1.1
         with:
           directory-name: 'TripalCultivate-Phenotypes'
           modules: 'trpcultivate_phenotypes trpcultivate_phenocollect trpcultivate_phenoshare'

--- a/.github/workflows/MAIN-phpunit-Grid2C.yml
+++ b/.github/workflows/MAIN-phpunit-Grid2C.yml
@@ -15,6 +15,8 @@ jobs:
         with:
           directory-name: 'TripalCultivate-Phenotypes'
           modules: 'trpcultivate_phenotypes trpcultivate_phenocollect trpcultivate_phenoshare'
+          build-image: TRUE
+          dockerfile: 'Dockerfile'
           php-version: '8.1'
           pgsql-version: '13'
           drupal-version: '10.0.x-dev'

--- a/.github/workflows/MAIN-phpunit-Grid2D.yml
+++ b/.github/workflows/MAIN-phpunit-Grid2D.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v3
       - name: Run Automated testing
-        uses: tripal/test-tripal-action@v1.0
+        uses: tripal/test-tripal-action@v1.1
         with:
           directory-name: 'TripalCultivate-Phenotypes'
           modules: 'trpcultivate_phenotypes trpcultivate_phenocollect trpcultivate_phenoshare'

--- a/.github/workflows/MAIN-phpunit-Grid2D.yml
+++ b/.github/workflows/MAIN-phpunit-Grid2D.yml
@@ -15,6 +15,8 @@ jobs:
         with:
           directory-name: 'TripalCultivate-Phenotypes'
           modules: 'trpcultivate_phenotypes trpcultivate_phenocollect trpcultivate_phenoshare'
+          build-image: TRUE
+          dockerfile: 'Dockerfile'
           php-version: '8.1'
           pgsql-version: '13'
           drupal-version: '10.1.x-dev'

--- a/.github/workflows/MAIN-phpunit-Grid3C.yml
+++ b/.github/workflows/MAIN-phpunit-Grid3C.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v3
       - name: Run Automated testing
-        uses: tripal/test-tripal-action@v1.0
+        uses: tripal/test-tripal-action@v1.1
         with:
           directory-name: 'TripalCultivate-Phenotypes'
           modules: 'trpcultivate_phenotypes trpcultivate_phenocollect trpcultivate_phenoshare'

--- a/.github/workflows/MAIN-phpunit-Grid3C.yml
+++ b/.github/workflows/MAIN-phpunit-Grid3C.yml
@@ -15,6 +15,8 @@ jobs:
         with:
           directory-name: 'TripalCultivate-Phenotypes'
           modules: 'trpcultivate_phenotypes trpcultivate_phenocollect trpcultivate_phenoshare'
+          build-image: TRUE
+          dockerfile: 'Dockerfile'
           php-version: '8.2'
           pgsql-version: '13'
           drupal-version: '10.0.x-dev'

--- a/.github/workflows/MAIN-phpunit-Grid3D.yml
+++ b/.github/workflows/MAIN-phpunit-Grid3D.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v3
       - name: Run Automated testing
-        uses: tripal/test-tripal-action@v1.0
+        uses: tripal/test-tripal-action@v1.1
         with:
           directory-name: 'TripalCultivate-Phenotypes'
           modules: 'trpcultivate_phenotypes trpcultivate_phenocollect trpcultivate_phenoshare'

--- a/.github/workflows/MAIN-phpunit-Grid3D.yml
+++ b/.github/workflows/MAIN-phpunit-Grid3D.yml
@@ -15,6 +15,8 @@ jobs:
         with:
           directory-name: 'TripalCultivate-Phenotypes'
           modules: 'trpcultivate_phenotypes trpcultivate_phenocollect trpcultivate_phenoshare'
+          build-image: TRUE
+          dockerfile: 'Dockerfile'
           php-version: '8.2'
           pgsql-version: '13'
           drupal-version: '10.1.x-dev'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,12 @@
-FROM tripalproject/tripaldocker:drupal10.0.x-dev-php8.1-pgsql13
+ARG drupalversion='10.0.x-dev'
+ARG chadoschema='testchado'
+FROM tripalproject/tripaldocker:drupal${drupalversion}-php8.1-pgsql13
 
 COPY . /var/www/drupal9/web/modules/contrib/TripalCultivate-Phenotypes
 
 WORKDIR /var/www/drupal9/web/modules/contrib/TripalCultivate-Phenotypes
 
 RUN service postgresql restart \
+  && drush trp-drop-chado --schema-name='chado' \
+  && drush trp-install-chado --schema-name='testchado' --version=1.3 \
   && drush en trpcultivate_phenotypes trpcultivate_phenocollect trpcultivate_phenoshare --yes

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,5 @@ WORKDIR /var/www/drupal9/web/modules/contrib/TripalCultivate-Phenotypes
 
 RUN service postgresql restart \
   && drush trp-drop-chado --schema-name='chado' \
-  && drush trp-install-chado --schema-name='testchado' --version=1.3 \
+  && drush trp-install-chado --schema-name='testchado' \
   && drush en trpcultivate_phenotypes trpcultivate_phenocollect trpcultivate_phenoshare --yes


### PR DESCRIPTION
Issue #26 

## Motivation

Currently our dockerfile and testing use the default tripaldocker images. Unfortunately these images use `chado` as the name of the schema that Chado is installed in. This does not help us to confirm we are not making any assumptions of what the schema name is... this is an important assumption to test for since Tripal 4 allows the admin to name the schema anything and also supports multiple Chado instances. Testing on a site with no schema named `chado` makes it more likely we are compatible with multiple Chado instances.

## What does this PR do?

1. Updates our dockerfile to add a build argument to choose the Drupal version. For example, `docker build --tag=testing --build-arg drupalversion="9.5.x-dev" ./`. The default is to use Drupal 10.0.x-dev. There must already be a tripal docker image for the version of Drupal you ask for.
2. Updates our dockerfile to first drop the `chado` schema and then install Chado v1.3 in a `testchado` schema. This approach is not ideal but much faster and with less duplication of code than copying the entire Tripal docker.
3. Updates all the workflows to use our own dockerfile for testing rather than the tripal core docker image.

## Testing

### Automated Testing

The docker build will now be testing in every single workflow before the automated tests run. As such, this will actually be tested for every version of Drupal we test on.

## Manual Testing

Test that you can build a docker image using the following command on this branch:
```
docker build --tag=testing --build-arg drupalversion="9.5.x-dev" ./
docker run --publish=80:80 --name=trpcult-g5.26 -tid --volume=$(pwd):/var/www/drupal9/web/modules/contrib/TripalCultivate-Phenotypes testing
docker exec trpcult-g5.26 service postgresql restart
docker exec trpcult-g5.26 drush sql:query "SELECT nspname FROM pg_catalog.pg_namespace"
docker exec -it trpcult-g5.26 drush status
```

You should expect 
1. no errors in the build process
2. Query outputs pg_toast, pg_catalog, public, information_schema, testchado, genetic_code, so, frange.
3. Drush command outputs a lot of information including `Drupal version  :  9.5.10-dev`

Look at the automated testing logs to confirm that it is building our docker and not just pulling the tripaldocker.

```
Sending build context to Docker daemon  440.8kB

Step 1/6 : ARG drupalversion='10.0.x-dev'
Step 2/6 : ARG chadoschema='testchado'
Step 3/6 : FROM tripalproject/tripaldocker:drupal${drupalversion}-php8.1-pgsql13
Step 4/6 : COPY . /var/www/drupal9/web/modules/contrib/TripalCultivate-Phenotypes
Step 5/6 : WORKDIR /var/www/drupal9/web/modules/contrib/TripalCultivate-Phenotypes
Step 6/6 : RUN service postgresql restart   && drush trp-drop-chado --schema-name='chado'   && drush trp-install-chado --schema-name='testchado'   && drush en trpcultivate_phenotypes trpcultivate_phenocollect trpcultivate_phenoshare --yes
```