### PR TITLE
Use new noChado Tripaldocker images.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 ARG drupalversion='10.0.x-dev'
-ARG chadoschema='testchado'
-FROM tripalproject/tripaldocker:drupal${drupalversion}-php8.1-pgsql13
+FROM tripalproject/tripaldocker:drupal${drupalversion}-php8.1-pgsql13-noChado
 
+ARG chadoschema='testchado'
 COPY . /var/www/drupal9/web/modules/contrib/TripalCultivate-Phenotypes
 
 WORKDIR /var/www/drupal9/web/modules/contrib/TripalCultivate-Phenotypes
 
 RUN service postgresql restart \
-  && drush trp-drop-chado --schema-name='chado' \
-  && drush trp-install-chado --schema-name='testchado' \
+  && drush trp-install-chado --schema-name=${chadoschema} \
+  && drush trp-prep-chado --schema-name=${chadoschema} \
   && drush en trpcultivate_phenotypes trpcultivate_phenocollect trpcultivate_phenoshare --yes


### PR DESCRIPTION
**Issue #31**

## Motivation

<!-- This can usually be copied from the issue. Please do not just say, go see issue but instead copy the relevant details here. -->

While the docker was able to build with no error, however, when I load the homepage it is a WSOD with the following error message:
```
Drupal\tripal\TripalDBX\Exceptions\SchemaException: Invalid or unsupported Chado schema version ''. in Drupal\tripal_chado\Database\ChadoSchema->getSchemaDef() (line 56 of modules/contrib/tripal/tripal_chado/src/Database/ChadoSchema.php).
```

The motivation for this PR is to fix that issue so we can actually use our docker site again ;-p 

## What does this PR do?
*Please describe each things this PR does. For example, a PR may 1) solve a specific bug, 2) create an automated test to ensure it doesn't return.*

1. Switches the dockerfile to use `-noChado` images from Tripal core added via https://github.com/tripal/tripal/pull/1575
2. Updates the dockerfile to both install and prepare chado based on the supplied arguement with a default of `testchado`.

## Testing

### Manual Testing
*Describe in detail how someone should manually test this functionality.*
*Make sure to include whether they need to build a docker from scratch, create any records, etc.*

1. Build the docker image
2. Ensure you can load the home page of the site by going to https://localhost
