### PR TITLE
Fixes missing genus post-install

### DIFF
--- a/trpcultivate_phenotypes/src/Form/TripalCultivatePhenotypesOntologySettingsForm.php
+++ b/trpcultivate_phenotypes/src/Form/TripalCultivatePhenotypesOntologySettingsForm.php
@@ -238,8 +238,20 @@ class TripalCultivatePhenotypesOntologySettingsForm extends ConfigFormBase {
       // Get genus ontology configuration set of values.
       $config_value = $this->service_genusontology
         ->getGenusOntologyConfigValues($genus);
-      if (is_array($config_value)) {
 
+      // Genus configurations are created during install and any additional 
+      // organism inserted post-install should be accounted for.
+      if (is_null($config_value)) {
+        // Detected a genus with a null value for all configuration
+        // variables. Register this genus as a new genus configuration entry.
+        $new_genus[ $genus ] = array_fill_keys($vars, 0);
+        $this->service_genusontology->saveGenusOntologyConfigValues($new_genus);
+
+        $config_value = $this->service_genusontology
+          ->getGenusOntologyConfigValues($genus);
+      }
+
+      if (is_array($config_value)) {
         // Label - Genus.
         $form['ontology_fieldset']['wrapper']['table_fields'][ $i ][ $genus . '_label' ] = [
           '#type' => 'item',


### PR DESCRIPTION
[**Issue #[35]**](https://github.com/TripalCultivate/TripalCultivate-Phenotypes/issues/35) BUG: genus missing past install.

## Motivation

<!-- This can usually be copied from the issue. Please do not just say, go see issue but instead copy the relevant details here. -->

## What does this PR do?
*Please describe each things this PR does. For example, a PR may 1) solve a specific bug, 2) create an auomated test to ensure it doesn't return.*

1. This  PR fixes a bug in configuration for genus ontology form where inserted/created organism past install is missing from the list of genus.

## Testing

### Automated Testing
*Please describe each automated test this PR creates and provide a list of the assertions it makes using casual language.*
*Do not just say things like "asserts the array is not empty" but rather say "Ensures that the return value of method X with these parameters is not an empty array".*


### Manual Testing
*Describe in detail how someone should manually test this functionality.*
*Make sure to include whether they need to build a docker from scratch, create any records, etc.*

1. Create organism
2. Install Tripal Cultivate Phenotypes module
3. Execute job requirements for Term and genus ontology install
4. Access genus ontology configuration form [ my tripal site/admin/tripal/extension/tripal-cultivate/phenotypes/ontology ]
At this point, it will only show the genus created in step 1.
5. Insert or create another organism
6. Refresh configuration page to update genus list with the newly inserted genus.
