### PR TITLE
G4.37 validation api

### DIFF
--- a/trpcultivate_phenoshare/src/Plugin/TripalImporter/TripalCultivatePhenoshareImporter.php
+++ b/trpcultivate_phenoshare/src/Plugin/TripalImporter/TripalCultivatePhenoshareImporter.php
@@ -8,6 +8,8 @@
 namespace Drupal\trpcultivate_phenoshare\Plugin\TripalImporter;
 
 use Drupal\tripal_chado\TripalImporter\ChadoImporterBase;
+use Drupal\tripal_chado\Controller\ChadoCVTermAutocompleteController;
+
 
 /**
  * Tripal Cultivate Phenotypes - Share Importer.
@@ -43,6 +45,10 @@ class TripalCultivatePhenoshareImporter extends ChadoImporterBase {
   // each stage accordingly (form, validation, etc.).
   private $current_stage = 'current_stage';
 
+  // Reference the validation result summary values in Drupal storage
+  // system using this variable.
+  private $validation_result = 'validation_result';
+
   // Headers required by this importer.
   private $headers = [
     'Header 1' => 'Header 1 Description',
@@ -72,6 +78,19 @@ class TripalCultivatePhenoshareImporter extends ChadoImporterBase {
 
     // Cacheing of stage number:
     // Cache current stage and id field to allow script to reference this value.
+
+    // Account for failed validation.
+    // Refer to Drupal $storage system for validation result values saved.
+    $storage = $form_state->getStorage();
+    // Full validation result.
+
+    $validation_result = [];
+    $has_fail = FALSE;
+
+    if (isset($storage[ $this->validation_result ])) {
+      $has_fail = $this->hasFailedValidation($storage[ $this->validation_result ]); 
+    }
+
     $triggering_element = $form_state->getTriggeringElement();
     $valid_triggering_element = [
       'Validate Data File', // Stage 1
@@ -79,7 +98,7 @@ class TripalCultivatePhenoshareImporter extends ChadoImporterBase {
       'Skip' // Stage 2
     ];
 
-    $stage = ($form_state->getValue('trigger_element') && in_array($triggering_element['#value'], $valid_triggering_element))
+    $stage = (!$has_fail && $form_state->getValue('trigger_element') && in_array($triggering_element['#value'], $valid_triggering_element))
       ? (int) $form_state->getValue( $this->current_stage ) + 1
       : 1;
     
@@ -95,7 +114,7 @@ class TripalCultivatePhenoshareImporter extends ChadoImporterBase {
     // stage accordion layout. Each stage is a method titled stage + stage no (ie. stage1).
     $stage_methods = get_class_methods(get_class($this));
     $total_stages = 0;
-
+  
     foreach ($stage_methods as $method) {
       if (preg_match('/stage([1-9])/', $method, $matches)) {
         if ($stage_no = $matches[1]) {
@@ -124,7 +143,6 @@ class TripalCultivatePhenoshareImporter extends ChadoImporterBase {
     // By default, is disabled in the plugin annotation definition: submit_disabled
     // and enabled one less stage of the total stages.
     if ($stage > ($total_stages - 1)) {
-      $storage = $form_state->getStorage();
       $storage['disable_TripalImporter_submit'] = FALSE;
       $form_state->setStorage($storage);
     }
@@ -177,11 +195,31 @@ class TripalCultivatePhenoshareImporter extends ChadoImporterBase {
     $form[ $fld_wrapper ] = $this->createStageAccordion($stage);
     
     // Validation result.
-    $form[ $fld_wrapper ]['validation_result'] = [
-      '#type' => 'inline_template',
-      '#theme' => 'result_window',
-      '#data' => [],
-      '#weight' => -100
+    $storage = $form_state->getStorage();
+    // Full validation result.
+    if (isset($storage[ $this->validation_result ])) {
+      $validation_result = $storage[ $this->validation_result ];
+
+      $form[ $fld_wrapper ]['validation_result'] = [
+        '#type' => 'inline_template',
+        '#theme' => 'result_window',
+        '#data' => [
+          'validation_result' => $validation_result
+        ],
+        '#weight' => -100
+      ];
+    }
+
+    // Other relevant fields here.
+    // Select experiment, Genus field will reflect the genus project is set to.
+    $form[ $fld_wrapper ]['project'] = [
+      '#title' => t('Project/Experiment'),
+      '#type' => 'textfield',
+      '#description' => t('Type in the experiment or project title your data is specific to.'),
+      '#weight' => -100,      
+      '#attributes' => ['placeholder' => 'Project/Experiment Name', 'class' => ['tcp-autocomplete']],
+      '#autocomplete_route_name' => 'tripal_chado.project_autocomplete',
+      '#autocomplete_route_parameters' => ['type_id' => 0, 'count' => 5],
     ];
 
     // Apply field stage field wrapper to file upload element.
@@ -293,6 +331,45 @@ class TripalCultivatePhenoshareImporter extends ChadoImporterBase {
    */
   public function formValidate($form, &$form_state) {
     $form_state_values = $form_state->getValues();
+    
+    // Current stage.
+    if ($stage = $form_state_values[ $this->current_stage ]) {
+      if ($stage > 0) {
+        // Validate only when stage is 1 or higher.
+        
+        // Counter, count number of validators that failed.
+        $failed_validator = 0;
+
+        // Test validator plugin.
+        $manager = \Drupal::service('plugin.manager.trpcultivate_validator');
+        $plugins = $manager->getDefinitions();
+        $plugin_definitions = array_values($plugins);
+
+        // All values will be accessible to every instance of the validator Plugin.
+        $project = $form_state_values['project'];
+        // @TODO: this will be a select field.
+        $genus = 'Lens';
+        $file = $form_state_values['file_upload'];
+
+        if ($stage == 1) {
+          $scope = 'PROJECT';
+
+          $plugin_key = array_search($scope, array_column($plugin_definitions, 'validator_scope'));
+          $validator = $plugin_definitions[ $plugin_key ]['id'];
+          
+          $instance = $manager->createInstance($validator);
+          $instance->loadAssets($project, $genus, $file);
+          
+          // Perform Project Level validation.
+          $validation[ $scope ] = $instance->validate();
+          
+          // Save validation result.
+          $storage = $form_state->getStorage();
+          $storage[ $this->validation_result ] = $validation;
+          $form_state->setStorage($storage);
+        }
+      }
+    }
   }
 
   /**
@@ -362,5 +439,35 @@ class TripalCultivatePhenoshareImporter extends ChadoImporterBase {
     ];
     
     return $markup;
+  }
+
+  /**
+   * Check if validation failed.
+   * 
+   * @param $validation_result
+   *   An associative array where each element is the validation summary of each 
+   *   level (PROJECT, GENUS, FILE etc.).
+   *   [level => [
+   *       'status' => 'fail', // pass, todo
+   *       'detail' => 'String, describing more details about the failed validation'
+   *     ],
+   *    ...
+   *   ]
+   */  
+  public function hasFailedValidation($validation_result = []) {
+    $has_fail = FALSE;
+
+    if ($validation_result) {
+      foreach($validation_result as $validator) {
+        // Inspect the validation result summary and if any one level
+        // failed validation should suffice to stop import.
+        if ($validator['status'] == 'fail') {
+          $has_fail = TRUE;
+          break;
+        }
+      }
+    }
+
+    return $has_fail;
   }
 }

--- a/trpcultivate_phenoshare/src/Plugin/TripalImporter/TripalCultivatePhenoshareImporter.php
+++ b/trpcultivate_phenoshare/src/Plugin/TripalImporter/TripalCultivatePhenoshareImporter.php
@@ -342,7 +342,9 @@ class TripalCultivatePhenoshareImporter extends ChadoImporterBase {
 
     // NOTE: $this->current_stage is the name of the field in the formstate that holds
     // the current stage value (cacheing of stage no.). See $current_stage property.
-    if ($stage = $form_state_values[ $this->current_stage ]) {
+    if (array_key_exists($this->current_stage, $form_state_values)) {      
+      $stage = $form_state_values[ $this->current_stage ];
+
       if ($stage == 1) {
         // Validate Stage 1.
         

--- a/trpcultivate_phenoshare/src/Plugin/TripalImporter/TripalCultivatePhenoshareImporter.php
+++ b/trpcultivate_phenoshare/src/Plugin/TripalImporter/TripalCultivatePhenoshareImporter.php
@@ -348,7 +348,7 @@ class TripalCultivatePhenoshareImporter extends ChadoImporterBase {
         // All values will be accessible to every instance of the validator Plugin.
         $project = $form_state_values['project'];
         // @TODO: this will be a select field.
-        $genus = 'Lens';
+        $genus = '#';
         $file = $form_state_values['file_upload'];
 
         if ($stage == 1) {

--- a/trpcultivate_phenoshare/src/Plugin/TripalImporter/TripalCultivatePhenoshareImporter.php
+++ b/trpcultivate_phenoshare/src/Plugin/TripalImporter/TripalCultivatePhenoshareImporter.php
@@ -333,18 +333,25 @@ class TripalCultivatePhenoshareImporter extends ChadoImporterBase {
     $form_state_values = $form_state->getValues();
     
     // Current stage.
+    // Get the cached stage value from the formstate values and perform validation
+    // when it is set to a value. Starting with index 1 - as stage 1, index 2 as stage 2
+    // and so on to the last stage.
+
+    // NOTE: not all stages require a validation and a subsequent condition will
+    // target a specific stage to perform pertinent validation.
+
+    // NOTE: $this->current_stage is the name of the field in the formstate that holds
+    // the current stage value (cacheing of stage no.). See $current_stage property.
     if ($stage = $form_state_values[ $this->current_stage ]) {
-      if ($stage > 0) {
-        // Validate only when stage is 1 or higher.
+      if ($stage == 1) {
+        // Validate Stage 1.
         
         // Counter, count number of validators that failed.
         $failed_validator = 0;
 
-        // Test validator plugin.
+        // Call validator manager service.
         $manager = \Drupal::service('plugin.manager.trpcultivate_validator');
-        $plugins = $manager->getDefinitions();
-        $plugin_definitions = array_values($plugins);
-
+       
         // All values will be accessible to every instance of the validator Plugin.
         $project = $form_state_values['project'];
         // @TODO: this will be a select field.
@@ -353,10 +360,8 @@ class TripalCultivatePhenoshareImporter extends ChadoImporterBase {
 
         if ($stage == 1) {
           $scope = 'PROJECT';
-
-          $plugin_key = array_search($scope, array_column($plugin_definitions, 'validator_scope'));
-          $validator = $plugin_definitions[ $plugin_key ]['id'];
-          
+          // Create instance of the scope-specific plugin and perform validation.
+          $validator = $manager->getValidatorIdWithScope($scope);
           $instance = $manager->createInstance($validator);
           $instance->loadAssets($project, $genus, $file);
           

--- a/trpcultivate_phenotypes/css/trpcultivate-phenotypes-style-result-window.css
+++ b/trpcultivate_phenotypes/css/trpcultivate-phenotypes-style-result-window.css
@@ -5,7 +5,7 @@
 
 /* Result window */
 .tcp-result-window {
-  border: 1px solid #aaa;
+  border: 1px solid #AAAAAA;
   border-radius: 4px;
   padding: 0.5em 0.5em 0;
 }
@@ -14,7 +14,7 @@
   font-weight: bold;
   margin: -0.5em -0.5em 0;
   padding: 0.5em;
-  border-bottom: 1px solid #aaa;
+  border-bottom: 1px solid #AAAAAA;
   margin-bottom: 0.5em;
 }
 
@@ -27,6 +27,13 @@
 .tcp-result-window ul li {
   margin: 10px 0;
   padding: 0 0 0 25px;
+}
+
+.tcp-result-window ul li p {
+  margin: 0;
+  padding: 0;
+  font-size: 0.8em;
+  font-style: italic;
 }
 
 /* Iconography - validation result */
@@ -43,7 +50,7 @@
   background-position: 0 1px;
 }
 
-.tcp-validate-failed {
+.tcp-validate-fail {
   background-image: url(../images/tcp-validate-failed.jpg);
   background-repeat: no-repeat;
   background-position: 0 1px;

--- a/trpcultivate_phenotypes/src/Annotation/TripalCultivatePhenotypesValidator.php
+++ b/trpcultivate_phenotypes/src/Annotation/TripalCultivatePhenotypesValidator.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\trpcultivate_phenotypes\Annotation\TripalCultivatePhenotypesValidator.
+ * 
+ * @see Plugin manager in src\TripalCultivatePhenotypesValidatorManager.php
+ */
+
+namespace Drupal\trpcultivate_phenotypes\Annotation;
+
+use Drupal\Component\Annotation\Plugin;
+
+/**
+ * Defines a data validator annotation object.
+ * 
+ * @see Drupal\trpcultivate_phenotypes\TripalCultivatePhenotypesValidatorManager
+ * @see Drupal\trpcultivate_phenotypes\TripalCultivatePhenotypesValidatorInterface
+ * 
+ * @Annotation
+ */
+class TripalCultivatePhenotypesValidator extends Plugin {
+  /**
+   * The validator plugin ID.
+   * 
+   * @var string.
+   */
+  public $id;
+
+  /**
+   * The validator human-readable name.
+   * 
+   * @var string.
+   */
+  public $validator_name;
+
+  /**
+   * The scope a validator will perform a check
+   * ie. FILE level check, Project/Genus level check or Data Values level check.
+   * 
+   * @var string.
+   */
+  public $validator_scope;
+}

--- a/trpcultivate_phenotypes/src/Plugin/Validators/Project.php
+++ b/trpcultivate_phenotypes/src/Plugin/Validators/Project.php
@@ -1,0 +1,106 @@
+<?php
+
+/**
+ * @file
+ * Contains validator plugin definition.
+ */
+
+namespace Drupal\trpcultivate_phenotypes\Plugin\Validators;
+
+use Drupal\trpcultivate_phenotypes\TripalCultivatePhenotypesValidatorBase;
+use Drupal\trpcultivate_phenotypes\Service\TripalCultivatePhenotypesGenusProjectService;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\tripal_chado\Controller\ChadoProjectAutocompleteController;
+
+/**
+ * Validate Project.
+ * 
+ * @TripalCultivatePhenotypesValidator(
+ *   id = "trpcultivate_phenotypes_validator_project",
+ *   validator_name = @Translation("Project Validator"),
+ *   validator_scope = "PROJECT",
+ * )
+ */
+class Project extends TripalCultivatePhenotypesValidatorBase implements ContainerFactoryPluginInterface {
+  /**
+   * Genus Project Service.
+   */
+  protected $service_genus_project;
+
+  /**
+   * Constructor.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, TripalCultivatePhenotypesGenusProjectService $service_genus_project) { 
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    
+    // DI project-related service.
+    $this->service_genus_project = $service_genus_project;
+  }
+  
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition){
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('trpcultivate_phenotypes.genus_project')
+    );
+  }
+
+  /**
+   * Validate items in the phenotypic data upload assets.
+   * 
+   * @TODO Structure:
+   *    1. Determine service you need + initialize this. Should be added via DI.
+   *    2. Massage values from importer to match needs of service.
+   *    3. Call service with parameters to get our answer (is valid?)
+   *    4. Interpret response and return valid or not.
+   *
+   * @return array
+   *   An associative array with the following keys.
+   *   - title: string, section or title of the validation as it appears in the result window.
+   *   - status: string, pass if it passed the validation check/test, fail string otherwise and todo string if validation was not applied.
+   *   - details: details about the offending field/value.
+   */
+  public function validate() {
+    // Validate ...
+    $validator_status = [
+      'title' => 'Project/Experiment Exists',
+      'status' => 'pass',
+      'details' => ''
+    ];
+
+    // Project:
+    //   - Is not empty
+    //   - Exists in chado.project
+    //   - Has genus paired/set
+
+    if (empty($this->project)) {
+      $validator_status['status']  = 'fail';
+      $validator_status['details'] = 'Project/Experiment field is empty. Please enter a value and try again.';
+    }
+    else {
+      // Has a project, check if it existed in chado.projects table.
+      $project_id = ChadoProjectAutocompleteController::getProjectId($this->project);
+      
+      if (!$project_id) {
+        $validator_status['status']  = 'fail';
+        $validator_status['details'] = 'Project/Experiment does not exist. Please enter a value and try again.';
+      }
+      else {
+        // Check if it has a genus set.
+        $genus = $this->service_genus_project->getGenusOfProject($project_id);
+
+        if (!$genus || $genus['genus'] != $this->genus) {
+          $validator_status['status']  = 'fail';
+          $validator_status['details'] = 'Project/Experiment entered does not have a genus set in the configuration. Please enter a value and try again.';
+        }
+      }
+    }
+
+    return $validator_status;
+  }
+}

--- a/trpcultivate_phenotypes/src/Plugin/Validators/Project.php
+++ b/trpcultivate_phenotypes/src/Plugin/Validators/Project.php
@@ -52,12 +52,6 @@ class Project extends TripalCultivatePhenotypesValidatorBase implements Containe
 
   /**
    * Validate items in the phenotypic data upload assets.
-   * 
-   * @TODO Structure:
-   *    1. Determine service you need + initialize this. Should be added via DI.
-   *    2. Massage values from importer to match needs of service.
-   *    3. Call service with parameters to get our answer (is valid?)
-   *    4. Interpret response and return valid or not.
    *
    * @return array
    *   An associative array with the following keys.

--- a/trpcultivate_phenotypes/src/Plugin/Validators/Project.php
+++ b/trpcultivate_phenotypes/src/Plugin/Validators/Project.php
@@ -76,7 +76,7 @@ class Project extends TripalCultivatePhenotypesValidatorBase implements Containe
     // Project:
     //   - Is not empty
     //   - Exists in chado.project
-    //   - Has genus paired/set
+    //   - Has genus
 
     if (empty($this->project)) {
       $validator_status['status']  = 'fail';
@@ -94,7 +94,7 @@ class Project extends TripalCultivatePhenotypesValidatorBase implements Containe
         // Check if it has a genus set.
         $genus = $this->service_genus_project->getGenusOfProject($project_id);
 
-        if (!$genus || $genus['genus'] != $this->genus) {
+        if (!$genus) {
           $validator_status['status']  = 'fail';
           $validator_status['details'] = 'Project/Experiment entered does not have a genus set in the configuration. Please enter a value and try again.';
         }

--- a/trpcultivate_phenotypes/src/TripalCultivatePhenotypesValidatorBase.php
+++ b/trpcultivate_phenotypes/src/TripalCultivatePhenotypesValidatorBase.php
@@ -9,7 +9,7 @@ namespace Drupal\trpcultivate_phenotypes;
 
 use Drupal\Component\Plugin\PluginBase;
 
-class TripalCultivatePhenotypesValidatorBase extends PluginBase implements TripalCultivatePhenotypesValidatorInterface {
+abstract class TripalCultivatePhenotypesValidatorBase extends PluginBase implements TripalCultivatePhenotypesValidatorInterface {
   /**
    * Project name/title.
    */

--- a/trpcultivate_phenotypes/src/TripalCultivatePhenotypesValidatorBase.php
+++ b/trpcultivate_phenotypes/src/TripalCultivatePhenotypesValidatorBase.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * @file
+ * Contains Drupal\TripalCultivatePhenotypes\TripalCultivatePhenotypesValidatorBase.
+ */
+
+namespace Drupal\trpcultivate_phenotypes;
+
+use Drupal\Component\Plugin\PluginBase;
+
+class TripalCultivatePhenotypesValidatorBase extends PluginBase implements TripalCultivatePhenotypesValidatorInterface {
+  /**
+   * Project name/title.
+   */
+  public $project;
+
+  /**
+   * Genus.
+   */
+  public $genus;
+
+  /**
+   * Drupal File ID Number.
+   */
+  public $file_id;
+
+  /**
+   * Load phenotypic data upload assets to validated.
+   * 
+   * @param $project
+   *   String, Project name/title - chado.project: name.
+   * @param $genus
+   *   String, Genus - chado.organism: genus.
+   * @param $file_id
+   *   Integer, Drupal file id number.
+   */
+  public function loadAssets($project, $genus, $file_id) {
+    // Prepare assets, query db, or load file.
+    $this->project = $project;
+    $this->genus = $genus;
+    $this->file_id = $file_id;
+  }
+
+  /**
+   * Get validator plugin validator_name definition annotation value.
+   * 
+   * @return string
+   *   The validator plugin name annotation definition value.
+   */
+  public function getValidatorName() {
+    return $this->pluginDefinition['validator_name'];
+  }
+
+  /**
+   * Get validator plugin validator_scope definition annotation value.
+   * 
+   * @return string
+   *   The validator plugin scope annotation definition value.
+   */
+  public function getValidatorScope() {
+    return $this->pluginDefinition['validator_scope'];
+  }
+}

--- a/trpcultivate_phenotypes/src/TripalCultivatePhenotypesValidatorInterface.php
+++ b/trpcultivate_phenotypes/src/TripalCultivatePhenotypesValidatorInterface.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\trpcultivate_phenotypes\Interface\TripalCultivatePhenotypesValidatorInterface.
+ * 
+ * @see Plugin manager in src\TripalCultivatePhenotypesValidatorManager.php
+ */
+
+namespace Drupal\trpcultivate_phenotypes;
+
+use Drupal\Component\Plugin\PluginInspectionInterface;
+
+/**
+ * Defines an interface for data validator plugin.
+ */
+interface TripalCultivatePhenotypesValidatorInterface extends PluginInspectionInterface {
+  /**
+   * Return the name of the validator.
+   *
+   * @return string.
+   */    
+  public function getValidatorName();
+
+  /**
+   * Return the scope of the validator.
+   *
+   * @return string.
+   */    
+  public function getValidatorScope();
+
+  /**
+   * Load data file import assets Project title, Genus and Data File Id
+   * as entered in the Importer form.
+   * 
+   * @param $project
+   *   String, Project name/title - chado.project: name.
+   * @param $genus
+   *   String, Genus - chado.organism: genus.
+   * @param $file_id
+   *   Integer, Drupal file id number. 
+   * 
+   * @return void.
+   */
+  public function loadAssets($project, $genus, $file_id);
+}

--- a/trpcultivate_phenotypes/src/TripalCultivatePhenotypesValidatorInterface.php
+++ b/trpcultivate_phenotypes/src/TripalCultivatePhenotypesValidatorInterface.php
@@ -43,4 +43,15 @@ interface TripalCultivatePhenotypesValidatorInterface extends PluginInspectionIn
    * @return void.
    */
   public function loadAssets($project, $genus, $file_id);
+
+  /**
+   * Validate items in the phenotypic data upload assets.
+   *
+   * @return array
+   *   An associative array with the following keys.
+   *   - title: string, section or title of the validation as it appears in the result window.
+   *   - status: string, pass if it passed the validation check/test, fail string otherwise and todo string if validation was not applied.
+   *   - details: details about the offending field/value.
+   */
+  public function validate();
 }

--- a/trpcultivate_phenotypes/src/TripalCultivatePhenotypesValidatorManager.php
+++ b/trpcultivate_phenotypes/src/TripalCultivatePhenotypesValidatorManager.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * @file
+ * Contains Tripal Cultivate Phenotypes Validator Plugin Manager.
+ */
+
+namespace Drupal\trpcultivate_phenotypes;
+
+use Drupal\Core\Plugin\DefaultPluginManager;
+use Drupal\Core\Cache\CacheBackendInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+
+/**
+ * Validator Plugin Manager.
+ */
+class TripalCultivatePhenotypesValidatorManager extends DefaultPluginManager {
+  /**
+   *  Constructs Validator Plugin Manager.
+   * 
+   *  @param \Traversable $namespaces
+   *    An object that implements \Traversable which contains the root paths
+   *    keyed by the corresponding namespace to look for plugin implementations.
+   *  @param \Drupal\Core\Cache\CacheBackendInterface $cache_backend
+   *    Cache backend instance to use.
+   *  @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
+   *    The module handler to invoke the alter hook.
+   */
+  public function __construct(\Traversable $namespaces, CacheBackendInterface $cache_backend, ModuleHandlerInterface $module_handler) {
+    parent::__construct(
+      'Plugin/Validators', 
+      $namespaces, 
+      $module_handler, 
+      'Drupal\trpcultivate_phenotypes\TripalCultivatePhenotypesValidatorInterface', 
+      'Drupal\trpcultivate_phenotypes\Annotation\TripalCultivatePhenotypesValidator'
+    );
+
+    // NOTES:
+    // Instance of validator in Drupal/trpcultivate_phenotypes/Plugin/Validator.
+    // Each instance is an implementation of Drupal\trpcultivate_phenotypes\TripalCultivatePhenotypesValidatorInterface.
+    // Use annotations defined by Drupal\trpcultivate_phenotypes\Annotation\TripalCultivatePhenotypesValidator.
+
+    // This is the hook name to alter information in this plugin.
+    $this->alterInfo('trpcultivate_phenotypes_validators_info');
+    $this->setCacheBackend($cache_backend, 'tripalcultivate_phenotypes_validators');
+  }
+}

--- a/trpcultivate_phenotypes/src/TripalCultivatePhenotypesValidatorManager.php
+++ b/trpcultivate_phenotypes/src/TripalCultivatePhenotypesValidatorManager.php
@@ -44,4 +44,25 @@ class TripalCultivatePhenotypesValidatorManager extends DefaultPluginManager {
     $this->alterInfo('trpcultivate_phenotypes_validators_info');
     $this->setCacheBackend($cache_backend, 'tripalcultivate_phenotypes_validators');
   }
+
+  /**
+   * Retrieve validator implementation with a specific scope.
+   * 
+   * @param string $scope
+   *   The validator_scope you are interested in.
+   * 
+   * @return string
+   *   The id of the validator with that scope based on it's annotation.
+   */
+  public function getValidatorIdWithScope($scope) {
+    $plugins = $this->getDefinitions();
+    $plugin_definitions = array_values($plugins);
+
+    $plugin_key = array_search(
+      $scope, 
+      array_column($plugin_definitions, 'validator_scope')
+    );
+
+    return $plugin_definitions[ $plugin_key ]['id'];
+  }
 }

--- a/trpcultivate_phenotypes/templates/trpcultivate-phenotypes-template-result-window.html.twig
+++ b/trpcultivate_phenotypes/templates/trpcultivate-phenotypes-template-result-window.html.twig
@@ -4,7 +4,10 @@
  * Theme result window.
  * 
  * Available variables:
- * 
+ * - validation_result: validation result from all validation levels (PROJECT, GENUS, FILE, TRAITS, VALUES).
+ *   Each validation result has the following keys:
+ *   - passed: boolean, true if validation passed and false otherwise.
+ *   - details: text details about failed validation, empty string if validation passed.
  */
 #}
 
@@ -13,8 +16,8 @@
 <details open="true" class="tcp-result-window">
   <summary>Validation Result</summary>
   <ul>
-    <li class="tcp-validate-pass">Experiment/Project Exists</li>
-    <li class="tcp-validate-failed">Genus Exists</li>
-    <li class="tcp-validate-todo">File is a valid tab-separated values (.tsv)</li>
+    {% for level,result in data.validation_result %}
+      <li class="tcp-validate-{{ result.status }}">{{ result.title }} <p>{{ result.details }}</p></li>
+    {% endfor %}
   </ul>
 </details>

--- a/trpcultivate_phenotypes/tests/src/Kernel/PluginValidatorTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/PluginValidatorTest.php
@@ -42,7 +42,7 @@ class PluginValidatorTest extends ChadoTestKernelBase {
    */
   private $test_records = [
     'genus' => '',
-    'project' => ''
+    'project' => '',
   ];
 
   /**
@@ -152,8 +152,16 @@ class PluginValidatorTest extends ChadoTestKernelBase {
     $validation[ $scope ] = $instance->validate();
     $this->assertEquals($validation[ $scope ]['status'], 'fail');
 
-    // Test validator with a project with incorrect genus.
-    $instance->loadAssets($project, 'NON-Existent-Genus', $file);
+    // Test validator with a project without genus configured.
+    $project = 'No Genus';
+    $this->chado->insert('1:project')
+      ->fields([
+        'name' => $project,
+        'description' => $project . ' : Description'   
+      ])
+      ->execute();
+
+    $instance->loadAssets($project, $genus, $file);
     $validation[ $scope ] = $instance->validate();
     $this->assertEquals($validation[ $scope ]['status'], 'fail');
   }

--- a/trpcultivate_phenotypes/tests/src/Kernel/PluginValidatorTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/PluginValidatorTest.php
@@ -1,0 +1,160 @@
+<?php
+
+/**
+ * @file
+ * Kernel test of Validator Plugin.
+ */
+
+namespace Drupal\Tests\trpcultivate_phenotypes\Kernel;
+
+use Drupal\Tests\tripal_chado\Kernel\ChadoTestKernelBase;
+use Drupal\tripal\Services\TripalLogger;
+
+ /**
+  * Test Tripal Cultivate Phenotypes Validator Plugin.
+  *
+  * @group trpcultivate_phenotypes
+  */
+class PluginValidatorTest extends ChadoTestKernelBase {
+  /**
+   * Term service.
+   * 
+   * @var object
+   */
+  protected $service;
+
+  /**
+   * Tripal DBX Chado Connection object
+   *
+   * @var ChadoConnection
+   */
+  protected $chado;
+
+  /**
+   * Configuration
+   * 
+   * @var config_entity
+   */
+  private $config;
+
+  /**
+   * Test genus and project.
+   */
+  private $test_records = [
+    'genus' => '',
+    'project' => ''
+  ];
+
+  /**
+   * Modules to enable.
+   */
+  protected static $modules = [
+    'tripal',
+    'tripal_chado',
+    'trpcultivate_phenotypes'
+  ];
+
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    // Set test environment.
+    \Drupal::state()->set('is_a_test_environment', TRUE);
+
+    // Install module configuration.
+    $this->installConfig(['trpcultivate_phenotypes']);
+    $this->config = \Drupal::configFactory()->getEditable('trpcultivate_phenotypes.settings');
+
+    // Set ontology.term: genus to null (id: 1).
+    $this->config->set('trpcultivate.phenotypes.ontology.terms.genus', 1);
+
+    // Test Chado database.
+    // Create a test chado instance and then set it in the container for use by our service.
+    $this->chado = $this->createTestSchema(ChadoTestKernelBase::PREPARE_TEST_CHADO);
+    $this->container->set('tripal_chado.database', $this->chado);
+
+    // Prepare by adding test records to genus, project and projectproperty
+    // to relate a genus to a project.
+    $project = 'Project - ' . uniqid();
+    $project_id = $this->chado->insert('1:project')
+      ->fields([
+        'name' => $project,
+        'description' => $project . ' : Description'   
+      ])
+      ->execute();
+
+    $this->test_records['project'] = $project;
+
+    $genus = 'Wild Genus ' . uniqid();
+    $this->chado->insert('1:organism')
+      ->fields([
+        'genus' => $genus,
+        'species' => 'Wild Species',
+        'type_id' => 1 
+      ])
+      ->execute();
+    
+    $this->test_records['genus'] = $genus;  
+
+    $this->chado->insert('1:projectprop')
+      ->fields([
+        'project_id' => $project_id,
+        'type_id' => 1,
+        'value' => $genus 
+      ])
+      ->execute();  
+
+    // Create Genus Ontology configuration. 
+    // All configuration and database value to null (id: 1).
+    $config_name = str_replace(' ', '_', strtolower($genus));
+    $genus_ontology_config = [
+      'trait' => 1,
+      'unit'   => 1,
+      'method'  => 1,
+      'database' => 1,
+      'crop_ontology' => 1
+    ];
+
+    $this->config->set('trpcultivate.phenotypes.ontology.cvdbon.' . $config_name, $genus_ontology_config);
+  }
+
+  public function testPluginValidator() {
+    // Assert genus and project records created.
+    foreach($this->test_records as $key => $value) {
+      $this->assertNotNull($value, $key . ' Test record not created.');
+    }
+
+    // Create instance of the validator plugin - Project.
+    $manager = \Drupal::service('plugin.manager.trpcultivate_validator');
+    $plugins = $manager->getDefinitions();
+    $plugin_definitions = array_values($plugins);
+    
+    $project = $this->test_records['project'];
+    $genus = $this->test_records['genus'];
+    $file = 1;
+    $scope = 'PROJECT';
+
+    $plugin_key = array_search($scope, array_column($plugin_definitions, 'validator_scope'));
+    $validator = $plugin_definitions[ $plugin_key ]['id'];
+          
+    $instance = $manager->createInstance($validator);
+    $instance->loadAssets($project, $genus, $file);
+          
+    // Perform Project Level validation.
+    $validation[ $scope ] = $instance->validate();
+    $this->assertEquals($validation[ $scope ]['status'], 'pass');    
+
+    // Test validator plugin with non-existent project.
+    $instance->loadAssets('NON-Existent-Project', $genus, $file);
+    $validation[ $scope ] = $instance->validate();
+    $this->assertEquals($validation[ $scope ]['status'], 'fail');
+
+    // Test validator with a project with incorrect genus.
+    $instance->loadAssets($project, 'NON-Existent-Genus', $file);
+    $validation[ $scope ] = $instance->validate();
+    $this->assertEquals($validation[ $scope ]['status'], 'fail');
+  }
+}

--- a/trpcultivate_phenotypes/trpcultivate_phenotypes.services.yml
+++ b/trpcultivate_phenotypes/trpcultivate_phenotypes.services.yml
@@ -11,3 +11,8 @@ services:
   trpcultivate_phenotypes.genus_project:
     class: 'Drupal\trpcultivate_phenotypes\Service\TripalCultivatePhenotypesGenusProjectService'
     arguments: ['@config.factory', '@tripal_chado.database', '@tripal.logger']
+
+  plugin.manager.trpcultivate_validator:
+    class: 'Drupal\trpcultivate_phenotypes\TripalCultivatePhenotypesValidatorManager'
+    parent: default_plugin_manager
+    arguments: ['@tripal_chado.database']


### PR DESCRIPTION
**Issue #37** Validation API

## Motivation

<!-- This can usually be copied from the issue. Please do not just say, go see issue but instead copy the relevant details here. -->

This is a Drupal Plugin-based validation API that will be used to validate imported data file in all levels: PROJECT, GENUS, FILE, TRAITS and VALUES.

For this PR it is confined to validating project (PROJECT level) only.

## What does this PR do?
*Please describe each things this PR does. For example, a PR may 1) solve a specific bug, 2) create an auomated test to ensure it doesn't return.*

1. Validate project as entered in stage 1 of the importer for empty field, non-existent project and project that does not have a genus paired to.
2. Setup a Drupal Plugin type (validator), plugin factory (in the formValidate() method) and an instance in /Plugin/validator/Project.php that performs validation mentioned in item 1.
3. Store validation result using Drupal Storage system and deliver to validation result window in stage 1
4. Kernel test - tests plugin instance and perform validation of project.
5. Functional test - tests the Importer can navigate from one stage to another with pertinent stage elements enabled/disabled/expanded based on validation result.

## Testing

### Automated Testing
*Please describe each automated test this PR creates and provide a list of the assertions it makes using casual language.*
*Do not just say things like "asserts the array is not empty" but rather say "Ensures that the return value of method X with these parameters is not an empty array".*

Functional Test:
1. Navigate from one stage to the next. A pre-configured project and genus information used to trigger a passing validation result to allow from stage 1 to the next stage.
2. Caching of stage is verified in every stage.
3. Stage is correctly styled to indicate the current stage, completed stage or upcoming stage.

Kernel Test:
1. Create instance of the plugin for validating Project.
2. Test the plugin for empty project value, non-existent project and project without genus configured.

### Manual Testing
*Describe in detail how someone should manually test this functionality.*
*Make sure to include whether they need to build a docker from scratch, create any records, etc.*

1. Create test genus record (ie. Lens).
2. Install module and execute Tripal Job required.
3. Configure genus ontology in my site/admin/tripal/extension/tripal-cultivate/phenotypes/ontology
4. Create test project records. One with genus set and the other without.
```
in my site/devel/php

// Set the genus of the project. Use configured genus as the method 
// has checks to make sure only configured genus can be paired to a project.
$service = \Drupal::service('trpcultivate_phenotypes.genus_project');
$service->setGenusToProject(PROJECT ID, 'Lens');

```
6. Load page my site/admin/tripal/loaders/trpcultivate-phenotypes-share
and test Project/Experiment field with:

A. Empty project, non-existent project and project without genus set
B. Project with genus set.


A - should trigger validation error and keep you in the same stage (stage 1)
B - should take you to the next stage and no validation error