### PR TITLE
G4.47 datafile validator

### DIFF
--- a/trpcultivate_phenoshare/src/Plugin/TripalImporter/TripalCultivatePhenoshareImporter.php
+++ b/trpcultivate_phenoshare/src/Plugin/TripalImporter/TripalCultivatePhenoshareImporter.php
@@ -463,7 +463,7 @@ class TripalCultivatePhenoshareImporter extends ChadoImporterBase implements Con
         $headers = [];
 
         if ($stage == 1) {
-          $scopes = ['PROJECT', 'GENUS'];
+          $scopes = ['PROJECT', 'GENUS', 'FILE'];
 
           // Array to hold all validation result for each level.
           // Each result is keyed by the scope.

--- a/trpcultivate_phenotypes/src/Plugin/Validators/DataFile.php
+++ b/trpcultivate_phenotypes/src/Plugin/Validators/DataFile.php
@@ -1,0 +1,102 @@
+<?php
+
+/**
+ * @file
+ * Contains validator plugin definition.
+ */
+
+namespace Drupal\trpcultivate_phenotypes\Plugin\Validators;
+
+use Drupal\trpcultivate_phenotypes\TripalCultivatePhenotypesValidatorBase;
+use Drupal\file\Entity\File;
+
+/**
+ * Validate Data File.
+ * 
+ * @TripalCultivatePhenotypesValidator(
+ *   id = "trpcultivate_phenotypes_validator_datafile",
+ *   validator_name = @Translation("Data File Validator"),
+ *   validator_scope = "FILE",
+ * )
+ */
+class DataFile extends TripalCultivatePhenotypesValidatorBase {
+  /**
+   * Validate items in the phenotypic data upload assets.
+   *
+   * @return array
+   *   An associative array with the following keys.
+   *   - title: string, section or title of the validation as it appears in the result window.
+   *   - status: string, pass if it passed the validation check/test, fail string otherwise and todo string if validation was not applied.
+   *   - details: details about the offending field/value.
+   */
+  public function validate() {
+    // Validate ...
+    $validator_status = [
+      'title' => 'File is a Valid Tab-separated Values (TSV) or Plain Text-based (TXT) file.',
+      'status' => 'pass',
+      'details' => ''
+    ];
+    
+    // Instructed to skip this validation. This will set this validator as upcoming or todo.
+    // This happens when other prior validation failed and this validation could only proceed
+    // when input values in the failed validator have been rectified.  
+    if ($this->skip) {
+      $validator_status['status'] = 'todo';
+      return $validator_status;
+    }
+
+    // Data File:
+    //   - Has Drupal File Id assigned/created.
+    //   - A valid TSV or TXT file extension.
+    //   - File Id created/assigned can be loaded.
+    //   - Is not empty file.
+
+    if ($this->file_id <= 0) {
+      // No file has been uploaded into the data file field.
+      $validator_status['status']  = 'fail';
+      $validator_status['details'] = 'No file has been uploaded. Please upload a file and try again.';
+    }
+    else {
+      // Has file, check to make sure the correct file type.
+      $file = FILE::load($this->file_id);
+
+      if (!$file) {
+        // Could not load file.
+        $validator_status['status']  = 'fail';
+        $validator_status['details'] = 'File could not be loaded. Please upload a file and try again.';   
+      }
+      else {
+        // Ensure correct file type is tsv or txt and no pretentious image/pdf file as tsv/txt.
+        $file_type = $file->getMimeType();
+        
+        if (!in_array($file_type, ['text/tab-separated-values', 'text/plain'])) {
+          $validator_status['status']  = 'fail';
+          $validator_status['details'] = 'The file uploaded does not have the expected file format of TSV or TXT file. Please upload a file and try again.';       
+        }
+        else {
+          // Is there something in the file? - not empty file check.
+          $file_size = filesize($file->getFileUri());
+
+          if ($file_size <= 0) {
+            $validator_status['status']  = 'fail';
+            $validator_status['details'] = 'The file uploaded is an empty file. Please upload a file and try again.';         
+          }
+          else {
+            // Check if it can be opened and read the contents.
+            $file_uri = $file->getFileUri();
+            $handle = fopen($file_uri, 'r');
+            
+            if (!$handle) {
+              $validator_status['status']  = 'fail';
+              $validator_status['details'] = 'The file uploaded could not be opened. Please upload a file and try again.';           
+            }
+
+            fclose($handle);
+          }
+        }
+      }
+    }
+
+    return $validator_status;
+  }
+}


### PR DESCRIPTION
**Issue #47 Data File Validator** 

## Motivation

<!-- This can usually be copied from the issue. Please do not just say, go see issue but instead copy the relevant details here. -->

This PR adds another validation scope or level. The Data File validator (could not simplify it it to just File since File is a Drupal reserved keyword/word) validates files provided to the file field in the importer.

This PR is dependent on (https://github.com/TripalCultivate/TripalCultivate-Phenotypes/pull/42) Genus Validator

## What does this PR do?
*Please describe each things this PR does. For example, a PR may 1) solve a specific bug, 2) create an auomated test to ensure it doesn't return.*

1. Updates the scopes array in the validateForm() method of the Importer to include the key/scope 'FILE'.
2. Adds a plugin into the plugin directory that corresponds to the FILE validator scope.

## Testing

### Automated Testing
*Please describe each automated test this PR creates and provide a list of the assertions it makes using casual language.*
*Do not just say things like "asserts the array is not empty" but rather say "Ensures that the return value of method X with these parameters is not an empty array".*

This PR has automated test included to test the following:
1. Kernel Test: Test files for:
  - File is of the expected file type/format of tsv (default file type) or txt (alternative). 
  - A file with 0 file size.
  - A valid extension of tsv file format but is with incorrect file format/mime.
  - Skip validation, set validator as todo/upcoming.

### Manual Testing
*Describe in detail how someone should manually test this functionality.*
*Make sure to include whether they need to build a docker from scratch, create any records, etc.*

1. Install/Enable Tripal Cultivate Phenotypes Module.
2. Create test data
Create a project
Create a genus
Pair the project - genus in project prop using the genus term in the configuration as the type, alternatively with the module properly configured use the service below.

```
\Drupal::service('trpcultivate_phenotypes.genus_project')
  ->setGenusToProject(PROJECT ID, 'GENUS', TRUE);
```
3. Execute Tripal Job created by the install.
4. Configure module.
5. Load Tripal Cultivate PhenoShare Importer page.
mysite/admin/tripal/loaders/trpcultivate-phenotypes-share

6. Download a template file provided in the importer and use it as test file. Alternatively, sample test files are in this attachment.

[Test Files.zip](https://github.com/TripalCultivate/TripalCultivate-Phenotypes/files/13444248/Test.Files.zip)
