### PR TITLE
G4.48 column headers validator

### DIFF
--- a/trpcultivate_phenoshare/src/Plugin/TripalImporter/TripalCultivatePhenoshareImporter.php
+++ b/trpcultivate_phenoshare/src/Plugin/TripalImporter/TripalCultivatePhenoshareImporter.php
@@ -459,11 +459,10 @@ class TripalCultivatePhenoshareImporter extends ChadoImporterBase implements Con
         $project = $form_state_values['project'];
         $genus = $form_state_values['genus'];
         $file = $form_state_values['file_upload'];
-        // @TODO: load headers in validators that require reference to the headers.
-        $headers = [];
+        $headers = array_keys($this->headers);
 
         if ($stage == 1) {
-          $scopes = ['PROJECT', 'GENUS', 'FILE'];
+          $scopes = ['PROJECT', 'GENUS', 'FILE', 'HEADERS'];
 
           // Array to hold all validation result for each level.
           // Each result is keyed by the scope.

--- a/trpcultivate_phenotypes/src/Plugin/Validators/Headers.php
+++ b/trpcultivate_phenotypes/src/Plugin/Validators/Headers.php
@@ -78,6 +78,7 @@ class Headers extends TripalCultivatePhenotypesValidatorBase implements Containe
     // Headers:
     //   - Header line is not empty.
     //   - No missing headers.
+    $file_column_headers = [];
 
     // Open file and read the first line, the column headers line.
     $file = File::load($this->file_id);

--- a/trpcultivate_phenotypes/src/Plugin/Validators/Headers.php
+++ b/trpcultivate_phenotypes/src/Plugin/Validators/Headers.php
@@ -98,6 +98,10 @@ class Headers extends TripalCultivatePhenotypesValidatorBase implements Containe
       }
     }  
     
+    // First remove any empty array elements.
+    $file_column_headers = array_filter($file_column_headers);
+
+    // Then check if there are any.
     if (empty($file_column_headers)) {
       // No file has been uploaded into the data file field.
       $validator_status['status']  = 'fail';

--- a/trpcultivate_phenotypes/src/Plugin/Validators/Headers.php
+++ b/trpcultivate_phenotypes/src/Plugin/Validators/Headers.php
@@ -1,0 +1,125 @@
+<?php
+
+/**
+ * @file
+ * Contains validator plugin definition.
+ */
+
+namespace Drupal\trpcultivate_phenotypes\Plugin\Validators;
+
+use Drupal\trpcultivate_phenotypes\TripalCultivatePhenotypesValidatorBase;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\file\Entity\File;
+use Drupal\Core\File\FileSystemInterface;
+
+/**
+ * Validate Required Headers.
+ * 
+ * @TripalCultivatePhenotypesValidator(
+ *   id = "trpcultivate_phenotypes_validator_headers",
+ *   validator_name = @Translation("Headers Validator"),
+ *   validator_scope = "HEADERS",
+ * )
+ */
+class Headers extends TripalCultivatePhenotypesValidatorBase implements ContainerFactoryPluginInterface {
+  /**
+   * File System Service.
+   */
+  protected $service_file_system;
+
+  /**
+   * Constructor.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, FileSystemInterface $file_system) { 
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    
+    // DI Drupal file system service.
+    $this->service_file_system = $file_system;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition){
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('file_system')
+    );
+  }
+  
+  /**
+   * Validate items in the phenotypic data upload assets.
+   *
+   * @return array
+   *   An associative array with the following keys.
+   *   - title: string, section or title of the validation as it appears in the result window.
+   *   - status: string, pass if it passed the validation check/test, fail string otherwise and todo string if validation was not applied.
+   *   - details: details about the offending field/value.
+   */
+  public function validate() {
+    // Validate ...
+    $validator_status = [
+      'title' => 'File has All the Column Headers Expected',
+      'status' => 'pass',
+      'details' => ''
+    ];
+
+    // Instructed to skip this validation. This will set this validator as upcoming or todo.
+    // This happens when other prior validation failed and this validation could only proceed
+    // when input values in the failed validator have been rectified.  
+    if ($this->skip) {
+      $validator_status['status'] = 'todo';
+      return $validator_status;
+    }
+
+    // Headers:
+    //   - Header line is not empty.
+    //   - No missing headers.
+
+    // Open file and read the first line, the column headers line.
+    $file = File::load($this->file_id);
+    if ($file) {
+      $uri = $file->getFileUri();
+      $file_path = $this->service_file_system->realPath($uri);
+
+      if ($file_path) {
+        $file_handle = fopen($file_path, 'r');
+        if ($file_handle) {
+          // Get the first line - column headers only.
+          $file_column_headers = fgets($file_handle);
+          fclose($file_handle);
+
+          $file_column_headers = str_getcsv($file_column_headers, "\t");
+        }
+      }
+    }  
+    
+    if (empty($file_column_headers)) {
+      // No file has been uploaded into the data file field.
+      $validator_status['status']  = 'fail';
+      $validator_status['details'] = 'No column headers found in the file. Please upload a file and try again.';
+    }
+    else {
+      // This last check ensures that expected headers defined by the importer are 
+      // present in the data file for both share and collect importer. Collect importer
+      // may have more headers but the headers defined in the importer are assumed to
+      // be required headers and must exist in the data file.
+      
+      $missing_headers = array_filter($this->column_headers, function($h) use($file_column_headers) { 
+        return (!in_array($h, $file_column_headers));
+      });
+
+      if (count($missing_headers) > 0) {
+        // List the columns missing in relation to the required headers.
+        $list_missing_headers = implode(', ', $missing_headers);
+        $validator_status['status']  = 'fail';
+        $validator_status['details'] = 'Columns headers: ' . $list_missing_headers . ' is/are missing in the file. Please upload a file and try again.';
+      }
+    }
+  
+    return $validator_status;
+  }
+}

--- a/trpcultivate_phenotypes/tests/src/Kernel/PluginValidatorTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/PluginValidatorTest.php
@@ -390,7 +390,7 @@ class PluginValidatorTest extends ChadoTestKernelBase {
   /**
    * Test Headers Plugin Validator.
    */
-  public function testScopePluginValidator() {
+  public function testColumnHeaderPluginValidator() {
     $scope = 'HEADERS';
     $validator = $this->plugin_manager->getValidatorIdWithScope($scope);
     $instance = $this->plugin_manager->createInstance($validator);

--- a/trpcultivate_phenotypes/tests/src/Kernel/PluginValidatorTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/PluginValidatorTest.php
@@ -427,6 +427,14 @@ class PluginValidatorTest extends ChadoTestKernelBase {
     $validation[ $scope ] = $instance->validate();
     $this->assertEquals($validation[ $scope ]['status'], $status);
 
+    // Header row is missing.
+    file_put_contents($file_uri, '');
+
+    $instance->loadAssets($assets['project'], $assets['genus'], $file_id, $assets['headers'], $assets['skip']);
+    $validation[ $scope ] = $instance->validate();
+    $this->assertEquals($validation[ $scope ]['status'], $status);
+
+
     // TODO:
     $status = 'todo';
 


### PR DESCRIPTION
**Issue #48 Column Headers Validator** 

## Motivation

<!-- This can usually be copied from the issue. Please do not just say, go see issue but instead copy the relevant details here. -->

This PR adds another validation scope or level. The Column Headers Validator validates column headers in the file to matches the headers defined by the Importer.

This PR is dependent on (https://github.com/TripalCultivate/TripalCultivate-Phenotypes/pull/50) Data File Validator

## What does this PR do?
*Please describe each things this PR does. For example, a PR may 1) solve a specific bug, 2) create an auomated test to ensure it doesn't return.*

1. Updates the scopes array in the validateForm() method of the Importer to include the key/scope 'HEADERS'.
2. Adds a plugin into the plugin directory that corresponds to the HEADER validator scope.

## Testing

### Automated Testing
*Please describe each automated test this PR creates and provide a list of the assertions it makes using casual language.*
*Do not just say things like "asserts the array is not empty" but rather say "Ensures that the return value of method X with these parameters is not an empty array".*

This PR has automated test included to test the following:
1. Kernel Test: Tests headers for:
  - Headers row (line no.1 in the data file) is missing.
  - Mismatch column headers: Extra header and Missing header
  - Skip validation, set validator as todo/upcoming.

### Manual Testing
*Describe in detail how someone should manually test this functionality.*
*Make sure to include whether they need to build a docker from scratch, create any records, etc.*

1. Install/Enable Tripal Cultivate Phenotypes Module.
2. Create test data
Create a project
Create a genus
Pair the project - genus in project prop using the genus term in the configuration as the type, alternatively with the module properly configured use the service below.

```
\Drupal::service('trpcultivate_phenotypes.genus_project')
  ->setGenusToProject(PROJECT ID, 'GENUS', TRUE);
```
3. Execute Tripal Job created by the install.
4. Configure module.
5. Load Tripal Cultivate PhenoShare Importer page.
mysite/admin/tripal/loaders/trpcultivate-phenotypes-share

6. Download a template file provided in the importer and use it as test file.
7. Alter header row (line no.1 of the template file) to test validation.