### PR TITLE
Updates our testing to include PHP 8.3 and Drupal 10.2

### DIFF
--- a/.github/workflows/ALL-PHPUnit.yml
+++ b/.github/workflows/ALL-PHPUnit.yml
@@ -16,11 +16,20 @@ jobs:
         php-version:
           - "8.1"
           - "8.2"
+          - "8.3"
         pgsql-version:
           - "13"
         drupal-version:
           - "10.0.x-dev"
           - "10.1.x-dev"
+          - "10.2.x-dev"
+        exclude:
+          - php-version: "8.3"
+            pgsql-version: "13"
+            drupal-version: "10.0.x-dev"
+          - php-version: "8.3"
+            pgsql-version: "13"
+            drupal-version: "10.1.x-dev"
 
     steps:
       # Check out the repo

--- a/.github/workflows/ALL-PHPUnit.yml
+++ b/.github/workflows/ALL-PHPUnit.yml
@@ -34,10 +34,10 @@ jobs:
     steps:
       # Check out the repo
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       # Here we pull the development tripaldocker image for this combo in our matrix
       - name: Run Automated testing
-        uses: tripal/test-tripal-action@v1.2
+        uses: tripal/test-tripal-action@v1.3
         with:
           directory-name: $PKG_NAME
           modules: $MODULES

--- a/.github/workflows/ALL-testCoverage-codeclimate.yml
+++ b/.github/workflows/ALL-testCoverage-codeclimate.yml
@@ -5,7 +5,7 @@ on: [push]
 env:
   PKG_NAME: TripalCultivate-Phenotypes
   MODULES: "trpcultivate_phenotypes trpcultivate_phenocollect trpcultivate_phenoshare"
-  IMAGE_TAG: drupal10.1.x-dev-php8.2-pgsql13
+  IMAGE_TAG: drupal10.2.x-dev-php8.3-pgsql13
   SIMPLETEST_BASE_URL: "http://localhost"
   SIMPLETEST_DB: "pgsql://drupaladmin:drupaldevelopmentonlylocal@localhost/sitedb"
   BROWSER_OUTPUT_DIRECTORY: "/var/www/drupal/web/sites/default/files/simpletest"

--- a/.github/workflows/ALL-testCoverage-codeclimate.yml
+++ b/.github/workflows/ALL-testCoverage-codeclimate.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       # Check out the repo
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       # Here we pull the development tripaldocker image for this combo in our matrix
       - name: Pull TripalDocker Image
         run: |

--- a/.github/workflows/MAIN-phpunit-Grid1A.yml
+++ b/.github/workflows/MAIN-phpunit-Grid1A.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run Automated testing
-        uses: tripal/test-tripal-action@v1.2
+        uses: tripal/test-tripal-action@v1.3
         with:
           directory-name: 'TripalCultivate-Phenotypes'
           modules: 'trpcultivate_phenotypes trpcultivate_phenocollect trpcultivate_phenoshare'

--- a/.github/workflows/MAIN-phpunit-Grid1A.yml
+++ b/.github/workflows/MAIN-phpunit-Grid1A.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - 4.x
-      - g5.18-workflows
+
 jobs:
   grid-1A:
     runs-on: ubuntu-latest

--- a/.github/workflows/MAIN-phpunit-Grid1B.yml
+++ b/.github/workflows/MAIN-phpunit-Grid1B.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - 4.x
-      - g5.18-workflows
+
 jobs:
   grid-1B:
     runs-on: ubuntu-latest

--- a/.github/workflows/MAIN-phpunit-Grid1B.yml
+++ b/.github/workflows/MAIN-phpunit-Grid1B.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run Automated testing
-        uses: tripal/test-tripal-action@v1.2
+        uses: tripal/test-tripal-action@v1.3
         with:
           directory-name: 'TripalCultivate-Phenotypes'
           modules: 'trpcultivate_phenotypes trpcultivate_phenocollect trpcultivate_phenoshare'

--- a/.github/workflows/MAIN-phpunit-Grid1C.yml
+++ b/.github/workflows/MAIN-phpunit-Grid1C.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run Automated testing
-        uses: tripal/test-tripal-action@v1.2
+        uses: tripal/test-tripal-action@v1.3
         with:
           directory-name: 'TripalCultivate-Phenotypes'
           modules: 'trpcultivate_phenotypes trpcultivate_phenocollect trpcultivate_phenoshare'

--- a/.github/workflows/MAIN-phpunit-Grid1C.yml
+++ b/.github/workflows/MAIN-phpunit-Grid1C.yml
@@ -1,0 +1,22 @@
+name: PHPUnit
+on:
+  push:
+    branches:
+      - 4.x
+      - g5.18-workflows
+jobs:
+  grid-1A:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+      - name: Run Automated testing
+        uses: tripal/test-tripal-action@v1.2
+        with:
+          directory-name: 'TripalCultivate-Phenotypes'
+          modules: 'trpcultivate_phenotypes trpcultivate_phenocollect trpcultivate_phenoshare'
+          build-image: TRUE
+          dockerfile: 'Dockerfile'
+          php-version: '8.1'
+          pgsql-version: '13'
+          drupal-version: '10.2.x-dev'

--- a/.github/workflows/MAIN-phpunit-Grid1C.yml
+++ b/.github/workflows/MAIN-phpunit-Grid1C.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - 4.x
-      - g5.18-workflows
+
 jobs:
   grid-1A:
     runs-on: ubuntu-latest

--- a/.github/workflows/MAIN-phpunit-Grid2A.yml
+++ b/.github/workflows/MAIN-phpunit-Grid2A.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run Automated testing
-        uses: tripal/test-tripal-action@v1.2
+        uses: tripal/test-tripal-action@v1.3
         with:
           directory-name: 'TripalCultivate-Phenotypes'
           modules: 'trpcultivate_phenotypes trpcultivate_phenocollect trpcultivate_phenoshare'

--- a/.github/workflows/MAIN-phpunit-Grid2A.yml
+++ b/.github/workflows/MAIN-phpunit-Grid2A.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - 4.x
-      - g5.18-workflows
+
 jobs:
   grid-2A:
     runs-on: ubuntu-latest

--- a/.github/workflows/MAIN-phpunit-Grid2B.yml
+++ b/.github/workflows/MAIN-phpunit-Grid2B.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run Automated testing
-        uses: tripal/test-tripal-action@v1.2
+        uses: tripal/test-tripal-action@v1.3
         with:
           directory-name: 'TripalCultivate-Phenotypes'
           modules: 'trpcultivate_phenotypes trpcultivate_phenocollect trpcultivate_phenoshare'

--- a/.github/workflows/MAIN-phpunit-Grid2B.yml
+++ b/.github/workflows/MAIN-phpunit-Grid2B.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - 4.x
-      - g5.18-workflows
+
 jobs:
   grid-2B:
     runs-on: ubuntu-latest

--- a/.github/workflows/MAIN-phpunit-Grid2C.yml
+++ b/.github/workflows/MAIN-phpunit-Grid2C.yml
@@ -1,0 +1,22 @@
+name: PHPUnit
+on:
+  push:
+    branches:
+      - 4.x
+      - g5.18-workflows
+jobs:
+  grid-1A:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+      - name: Run Automated testing
+        uses: tripal/test-tripal-action@v1.2
+        with:
+          directory-name: 'TripalCultivate-Phenotypes'
+          modules: 'trpcultivate_phenotypes trpcultivate_phenocollect trpcultivate_phenoshare'
+          build-image: TRUE
+          dockerfile: 'Dockerfile'
+          php-version: '8.2'
+          pgsql-version: '13'
+          drupal-version: '10.2.x-dev'

--- a/.github/workflows/MAIN-phpunit-Grid2C.yml
+++ b/.github/workflows/MAIN-phpunit-Grid2C.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run Automated testing
-        uses: tripal/test-tripal-action@v1.2
+        uses: tripal/test-tripal-action@v1.3
         with:
           directory-name: 'TripalCultivate-Phenotypes'
           modules: 'trpcultivate_phenotypes trpcultivate_phenocollect trpcultivate_phenoshare'

--- a/.github/workflows/MAIN-phpunit-Grid2C.yml
+++ b/.github/workflows/MAIN-phpunit-Grid2C.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - 4.x
-      - g5.18-workflows
+
 jobs:
   grid-1A:
     runs-on: ubuntu-latest

--- a/.github/workflows/MAIN-phpunit-Grid3C.yml
+++ b/.github/workflows/MAIN-phpunit-Grid3C.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run Automated testing
-        uses: tripal/test-tripal-action@v1.2
+        uses: tripal/test-tripal-action@v1.3
         with:
           directory-name: 'TripalCultivate-Phenotypes'
           modules: 'trpcultivate_phenotypes trpcultivate_phenocollect trpcultivate_phenoshare'

--- a/.github/workflows/MAIN-phpunit-Grid3C.yml
+++ b/.github/workflows/MAIN-phpunit-Grid3C.yml
@@ -1,0 +1,22 @@
+name: PHPUnit
+on:
+  push:
+    branches:
+      - 4.x
+      - g5.18-workflows
+jobs:
+  grid-1A:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+      - name: Run Automated testing
+        uses: tripal/test-tripal-action@v1.2
+        with:
+          directory-name: 'TripalCultivate-Phenotypes'
+          modules: 'trpcultivate_phenotypes trpcultivate_phenocollect trpcultivate_phenoshare'
+          build-image: TRUE
+          dockerfile: 'Dockerfile'
+          php-version: '8.3'
+          pgsql-version: '13'
+          drupal-version: '10.2.x-dev'

--- a/.github/workflows/MAIN-phpunit-Grid3C.yml
+++ b/.github/workflows/MAIN-phpunit-Grid3C.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - 4.x
-      - g5.18-workflows
+
 jobs:
   grid-1A:
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 ARG drupalversion='10.2.x-dev'
-FROM tripalproject/tripaldocker:drupal${drupalversion}-php8.3-pgsql13-noChado
+ARG phpversion='8.3'
+FROM tripalproject/tripaldocker:drupal${drupalversion}-php${phpversion}-pgsql13-noChado
 
 ARG chadoschema='testchado'
 COPY . /var/www/drupal/web/modules/contrib/TripalCultivate-Phenotypes

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-ARG drupalversion='10.0.x-dev'
-FROM tripalproject/tripaldocker:drupal${drupalversion}-php8.1-pgsql13-noChado
+ARG drupalversion='10.2.x-dev'
+FROM tripalproject/tripaldocker:drupal${drupalversion}-php8.3-pgsql13-noChado
 
 ARG chadoschema='testchado'
 COPY . /var/www/drupal/web/modules/contrib/TripalCultivate-Phenotypes
@@ -12,4 +12,5 @@ RUN service postgresql restart \
   && drush tripal:trp-import-types --username=drupaladmin --collection_id=general_chado \
   && drush tripal:trp-import-types --username=drupaladmin --collection_id=germplasm_chado \
   && drush en trpcultivate_phenotypes trpcultivate_phenocollect trpcultivate_phenoshare --yes \
-  && drush tripal:trp-run-jobs --username=drupaladmin
+  && drush tripal:trp-run-jobs --username=drupaladmin \
+  && drush cr

--- a/README.md
+++ b/README.md
@@ -62,10 +62,11 @@ maintainability issues and test coverage.
 
 The following compatibility is proven via automated testing workflows.
 
-|  Drupal     |  10.0.x         |  10.1.x         |
-|-------------|-----------------|-----------------|
-| **PHP 8.1** | ![Grid1A-Badge] | ![Grid1B-Badge] |
-| **PHP 8.2** | ![Grid2A-Badge] | ![Grid2B-Badge] |
+|  Drupal     |  10.0.x         |  10.1.x         |  10.2.x         |
+|-------------|-----------------|-----------------|-----------------|
+| **PHP 8.1** | ![Grid1A-Badge] | ![Grid1B-Badge] | ![Grid1C-Badge] |
+| **PHP 8.2** | ![Grid2A-Badge] | ![Grid2B-Badge] | ![Grid2C-Badge] |
+| **PHP 8.3** |                 |                 | ![Grid3C-Badge] |
 
 [our CodeClimate project page]: https://github.com/TripalCultivate/TripalCultivate-Phenotypes
 [MaintainabilityBadge]: https://api.codeclimate.com/v1/badges/03fa542e0d95dedb97e8/maintainability
@@ -73,6 +74,10 @@ The following compatibility is proven via automated testing workflows.
 
 [Grid1A-Badge]: https://github.com/TripalCultivate/TripalCultivate-Phenotypes/actions/workflows/MAIN-phpunit-Grid1A.yml/badge.svg
 [Grid1B-Badge]: https://github.com/TripalCultivate/TripalCultivate-Phenotypes/actions/workflows/MAIN-phpunit-Grid1B.yml/badge.svg
+[Grid1C-Badge]: https://github.com/TripalCultivate/TripalCultivate-Phenotypes/actions/workflows/MAIN-phpunit-Grid1C.yml/badge.svg
 
 [Grid2A-Badge]: https://github.com/TripalCultivate/TripalCultivate-Phenotypes/actions/workflows/MAIN-phpunit-Grid2A.yml/badge.svg
 [Grid2B-Badge]: https://github.com/TripalCultivate/TripalCultivate-Phenotypes/actions/workflows/MAIN-phpunit-Grid2B.yml/badge.svg
+[Grid2C-Badge]: https://github.com/TripalCultivate/TripalCultivate-Phenotypes/actions/workflows/MAIN-phpunit-Grid2C.yml/badge.svg
+
+[Grid3C-Badge]: https://github.com/TripalCultivate/TripalCultivate-Phenotypes/actions/workflows/MAIN-phpunit-Grid3C.yml/badge.svg

--- a/trpcultivate_phenocollect/tests/src/Functional/InstallTest.php
+++ b/trpcultivate_phenocollect/tests/src/Functional/InstallTest.php
@@ -72,7 +72,11 @@ class InstallTest extends ChadoTestBrowserBase {
     $some_extected_text = self::$help_text_excerpt;
 
     // Ensure we have an admin user.
-    $user = $this->drupalCreateUser(['access administration pages', 'administer modules', 'access help pages']);
+    $permissions = ['access administration pages', 'administer modules'];
+    if (strncmp(\Drupal::VERSION, '10.2', 4) === 0) {
+      $permissions[] = 'access help pages';
+    }
+    $user = $this->drupalCreateUser($permissions);
     $this->drupalLogin($user);
 
     $context = '(modules installed: ' . implode(',', self::$modules) . ')';

--- a/trpcultivate_phenocollect/tests/src/Functional/InstallTest.php
+++ b/trpcultivate_phenocollect/tests/src/Functional/InstallTest.php
@@ -72,7 +72,7 @@ class InstallTest extends ChadoTestBrowserBase {
     $some_extected_text = self::$help_text_excerpt;
 
     // Ensure we have an admin user.
-    $user = $this->drupalCreateUser(['access administration pages', 'administer modules']);
+    $user = $this->drupalCreateUser(['access administration pages', 'administer modules', 'access help pages']);
     $this->drupalLogin($user);
 
     $context = '(modules installed: ' . implode(',', self::$modules) . ')';

--- a/trpcultivate_phenoshare/tests/src/Functional/InstallTest.php
+++ b/trpcultivate_phenoshare/tests/src/Functional/InstallTest.php
@@ -72,7 +72,11 @@ class InstallTest extends ChadoTestBrowserBase {
     $some_extected_text = self::$help_text_excerpt;
 
     // Ensure we have an admin user.
-    $user = $this->drupalCreateUser(['access administration pages', 'administer modules', 'access help pages']);
+    $permissions = ['access administration pages', 'administer modules'];
+    if (strncmp(\Drupal::VERSION, '10.2', 4) === 0) {
+      $permissions[] = 'access help pages';
+    }
+    $user = $this->drupalCreateUser($permissions);
     $this->drupalLogin($user);
 
     $context = '(modules installed: ' . implode(',', self::$modules) . ')';

--- a/trpcultivate_phenoshare/tests/src/Functional/InstallTest.php
+++ b/trpcultivate_phenoshare/tests/src/Functional/InstallTest.php
@@ -72,7 +72,7 @@ class InstallTest extends ChadoTestBrowserBase {
     $some_extected_text = self::$help_text_excerpt;
 
     // Ensure we have an admin user.
-    $user = $this->drupalCreateUser(['access administration pages', 'administer modules']);
+    $user = $this->drupalCreateUser(['access administration pages', 'administer modules', 'access help pages']);
     $this->drupalLogin($user);
 
     $context = '(modules installed: ' . implode(',', self::$modules) . ')';

--- a/trpcultivate_phenotypes/tests/src/Functional/ImporterFileGeneratorLinkTest.php
+++ b/trpcultivate_phenotypes/tests/src/Functional/ImporterFileGeneratorLinkTest.php
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * Functional test of Tripal Cultivate Phenotypes Importer 
+ * Functional test of Tripal Cultivate Phenotypes Importer
  * template file generator download link.
  */
 
@@ -13,11 +13,13 @@ use Drupal\Tests\tripal_chado\Functional\ChadoTestBrowserBase;
 /**
  *  Class definition ImporterFileGeneratorLinkTest.
  */
-class ImporterFileGeneratorLinkTest extends ChadoTestBrowserBase {  
+class ImporterFileGeneratorLinkTest extends ChadoTestBrowserBase {
   protected $defaultTheme = 'stark';
 
   // Holds genus - ontology config names.
   private $genus_ontology;
+
+  protected $connection;
 
   /**
    * Modules to enabled
@@ -37,38 +39,38 @@ class ImporterFileGeneratorLinkTest extends ChadoTestBrowserBase {
    */
   protected function setUp() :void {
     parent::setUp();
-  
+
     // Ensure we see all logging in tests.
     \Drupal::state()->set('is_a_test_environment', TRUE);
 
     // Create a test schema.
-    $this->chado = $this->createTestSchema(ChadoTestBrowserBase::PREPARE_TEST_CHADO);
-    $this->container->set('tripal_chado.database', $this->chado);
+    $this->connection = $this->createTestSchema(ChadoTestBrowserBase::PREPARE_TEST_CHADO);
+    $this->container->set('tripal_chado.database', $this->connection);
 
     // Prepare by adding test records to genus and project.
     $project = 'Project - ' . uniqid();
-    $project_id = $this->chado->insert('1:project')
+    $project_id = $this->connection->insert('1:project')
       ->fields([
         'name' => $project,
-        'description' => $project . ' : Description'   
+        'description' => $project . ' : Description'
       ])
       ->execute();
 
     $genus = 'Wild Genus ' . uniqid();
-    $this->chado->insert('1:organism')
+    $this->connection->insert('1:organism')
       ->fields([
         'genus' => $genus,
         'species' => 'Wild Species',
-        'type_id' => 1 
+        'type_id' => 1
       ])
       ->execute();
-    
+
     // Install all default terms.
     $service_terms = \Drupal::service('trpcultivate_phenotypes.terms');
-    $service_terms->loadTerms(); 
+    $service_terms->loadTerms();
 
     // Define a genus ontology configuration value.
-    $service_genusontology = \Drupal::service('trpcultivate_phenotypes.genus_ontology');  
+    $service_genusontology = \Drupal::service('trpcultivate_phenotypes.genus_ontology');
     $service_genusontology->loadGenusOntology();
     $this->genus_ontology = $service_genusontology->defineGenusOntology();
 
@@ -90,7 +92,7 @@ class ImporterFileGeneratorLinkTest extends ChadoTestBrowserBase {
 
     // Login admin user.
     $this->drupalLogin($admin_user);
-    
+
     // Assert custom Phenotypes Share importer is an item in
     // admin/tripal/loaders page.
     // Link titled - Tripal Cultivate: Open Science Phenotypic Data
@@ -99,7 +101,7 @@ class ImporterFileGeneratorLinkTest extends ChadoTestBrowserBase {
     $session->statusCodeEquals(200);
     // There is a link to the the importer with this link description.
     $session->pageTextContains('Tripal Cultivate: Open Science Phenotypic Data');
-    
+
     // Configure genus ontology.
     foreach($this->genus_ontology as $genus => $vars) {
       foreach($vars as $i => $config) {
@@ -107,42 +109,42 @@ class ImporterFileGeneratorLinkTest extends ChadoTestBrowserBase {
         $values_genus_ontology[ $fld_name ] = 1;
       }
     }
-    
+
     // Setup genus ontology configuration through the interface.
     $this->drupalGet('admin/tripal/extension/tripal-cultivate/phenotypes/ontology');
     $this->submitForm($values_genus_ontology, 'Save configuration');
-    
+
     // Access Phenotypes Importer Share - this will create a template file.
     $this->drupalGet('admin/tripal/loaders/trpcultivate-phenotypes-share');
     $session = $this->assertSession();
     $session->statusCodeEquals(200);
     $session->pageTextContains('Tripal Cultivate: Open Science Phenotypic Data');
-     
+
     // Test if template file generator created a file. This is the link value
     // of the href attribute of the download a template file link in the header notes of the importer.
-    
+
     // Inspect the directory configured for template files in the settings.
     // @see config install and schema.
     $config = \Drupal::config('trpcultivate_phenotypes.settings');
-    $dir_template_file = $config->get('trpcultivate.phenotypes.directory.template_file'); 
+    $dir_template_file = $config->get('trpcultivate.phenotypes.directory.template_file');
     $dir_uri = \Drupal::service('file_system')->realpath($dir_template_file);
 
     // Scan the directory for tsv file.
     // tsv file, parent dir (..) then current dir (.).
     $template_file = scandir($dir_uri, SCANDIR_SORT_DESCENDING)[0];
     $template_file_uri = $dir_uri . '/' . $template_file;
-    
+
     // Template file is generated.
     $is_file = file_exists($template_file_uri);
     $this->assertTrue($is_file, 'Template generator failed to create a file.');
 
     // Template is not empty file.
     $this->assertGreaterThanOrEqual(1, filesize($template_file_uri), 'The template file generated is empty.');
-    
+
     // Template file has header row.
-    $file_content = file_get_contents($template_file_uri);    
+    $file_content = file_get_contents($template_file_uri);
     $this->assertNotNull($file_content, 'Template generator failed to add the header row.');
-    
+
     $this->drupalLogout();
   }
 }

--- a/trpcultivate_phenotypes/tests/src/Functional/InstallTest.php
+++ b/trpcultivate_phenotypes/tests/src/Functional/InstallTest.php
@@ -79,7 +79,7 @@ class InstallTest extends ChadoTestBrowserBase {
     $some_extected_text = self::$help_text_excerpt;
 
     // Ensure we have an admin user.
-    $user = $this->drupalCreateUser(['access administration pages', 'administer modules']);
+    $user = $this->drupalCreateUser(['access administration pages', 'administer modules', 'access help pages']);
     $this->drupalLogin($user);
 
     $context = '(modules installed: ' . implode(',', self::$modules) . ')';

--- a/trpcultivate_phenotypes/tests/src/Functional/InstallTest.php
+++ b/trpcultivate_phenotypes/tests/src/Functional/InstallTest.php
@@ -79,7 +79,11 @@ class InstallTest extends ChadoTestBrowserBase {
     $some_extected_text = self::$help_text_excerpt;
 
     // Ensure we have an admin user.
-    $user = $this->drupalCreateUser(['access administration pages', 'administer modules', 'access help pages']);
+    $permissions = ['access administration pages', 'administer modules'];
+    if (strncmp(\Drupal::VERSION, '10.2', 4) === 0) {
+      $permissions[] = 'access help pages';
+    }
+    $user = $this->drupalCreateUser($permissions);
     $this->drupalLogin($user);
 
     $context = '(modules installed: ' . implode(',', self::$modules) . ')';


### PR DESCRIPTION
**Issue #70**

## Motivation

There was just a PR merged in core that updates Tripal core to support PHP 8.3 and Drupal 10.2. Obviously we want to test on these versions as well to confirm our support. This PR does that :-) 

## What does this PR do?
*Please describe each things this PR does. For example, a PR may 1) solve a specific bug, 2) create an automated test to ensure it doesn't return.*

1. Updates the existing testing workflows to include PHP 8.3 and Drupal 10.2
2. Updates workflows to use checkout action v4 to remove nodejs version warning
3. Updates workflows to use test-tripal-action v1.3 so that we can have better control over versions of php used.
4. Expands the testing grid in the readme to include the new version combinations.
5. Makes the dockerfile default to php 8.3 and Drupal 10.2 since these are the versions we should be targeting now.
6. Drupal 10.2 added a new permission to access help pages and became more stringent on permissions for pages. We made fixes to our existing tests with this in mind.

## Testing

1. Make sure the automated testing passes on all versions.
2. Build the docker image both with and without phpversion build-args to ensure it pulls the correct tripal docker file.