### PR TITLE
G4.78 fix trait service getters

### DIFF
--- a/trpcultivate_phenotypes/src/Service/TripalCultivatePhenotypesTraitsService.php
+++ b/trpcultivate_phenotypes/src/Service/TripalCultivatePhenotypesTraitsService.php
@@ -442,7 +442,7 @@ class TripalCultivatePhenotypesTraitsService {
     // Make sure that each parameter has a valid value.
     foreach([$trait, $method, $unit] as $param) {
       if (empty($param) || $param <= 0) {
-        return 0;
+        throw \Exception('The trait, method and unit passed into getTraitMethodUnitCombo() is required; however, one of them was empty.');
       }
     }
 

--- a/trpcultivate_phenotypes/src/Service/TripalCultivatePhenotypesTraitsService.php
+++ b/trpcultivate_phenotypes/src/Service/TripalCultivatePhenotypesTraitsService.php
@@ -324,6 +324,7 @@ class TripalCultivatePhenotypesTraitsService {
    *   getTraitAsset()
    */
   public function getTrait($trait) {
+    // Since the trait is simply a cvterm, we can use our helper method to retrieve it.
     $trait_rec = $this->getTraitAsset($trait, 'trait');
     return $trait_rec;
   }

--- a/trpcultivate_phenotypes/src/Service/TripalCultivatePhenotypesTraitsService.php
+++ b/trpcultivate_phenotypes/src/Service/TripalCultivatePhenotypesTraitsService.php
@@ -80,19 +80,19 @@ class TripalCultivatePhenotypesTraitsService {
         $not_set[] = $config_key;
       }
     }
-    
+
     if ($not_set) {
       $terms_not_set = implode(', ', $not_set);
-      throw new \Exception(t('Term(s) [@term] used to create trait asset relationships was not configured. 
+      throw new \Exception(t('Term(s) [@term] used to create trait asset relationships was not configured.
         To configure terms, go to @url and set the controlled vocabulary associated with the term.',
         ['@term' => $terms_not_set, '@url' => Url::fromRoute('trpcultivate_phenotypes.settings_ontology')->toString()]
       ));
     }
-    
+
     // Genus configuration:
     // Fetch all configured genus (active genus).
     $active_genus = $this->service_genus_ontology->getConfiguredGenusList();
-    
+
     if ($active_genus && in_array($genus, $active_genus)) {
       $genus_config = $this->service_genus_ontology->getGenusOntologyConfigValues($genus);
 
@@ -159,7 +159,7 @@ class TripalCultivatePhenotypesTraitsService {
    * @return
    *   An array with the following keys where each value is the id of new cvterm:
    *   trait, method, unit.
-   * 
+   *
    * @dependencies
    *   getTraitAsset(), getMethodUnitDataType().
    */
@@ -169,7 +169,7 @@ class TripalCultivatePhenotypesTraitsService {
     if (!$genus_config) {
       // Genus not set.
       throw new \Exception(t('No genus has been set. See setting a genus in the Traits Service and make sure to
-        use a configured genus. To configure a genus or see all configured genus, go to @url.', 
+        use a configured genus. To configure a genus or see all configured genus, go to @url.',
         ['@url' => Url::fromRoute('trpcultivate_phenotypes.settings_ontology')->toString()]
       ));
     }
@@ -194,7 +194,7 @@ class TripalCultivatePhenotypesTraitsService {
     foreach($arr_trait as $type => $values) {
       // Inspect cvterm to see if the trait asset already existed.
       $trait_asset_rec = $this->getTraitAsset($values['name'], $type);
-      
+
       if ($trait_asset_rec) {
         // Trait asset found, reference the record and re-use.
         $arr_trait[ $type ]['id'] = $trait_asset_rec->cvterm_id;
@@ -211,8 +211,8 @@ class TripalCultivatePhenotypesTraitsService {
         $ins = chado_insert_cvterm($rec, [], $schema);
         if (!$ins) {
           // Could not insert cvterm.
-          $this->logger->error('Error. Failed to insert term @type : @term.', 
-            ['@type' => $type, '@term' => $values['name']], 
+          $this->logger->error('Error. Failed to insert term @type : @term.',
+            ['@type' => $type, '@term' => $values['name']],
             ['drupal_set_message' => TRUE]
           );
           throw new \Exception(t('A database error occurred while inserting a term.'));
@@ -234,7 +234,7 @@ class TripalCultivatePhenotypesTraitsService {
         $subject = $arr_trait['trait']['id'];
         $object  = $arr_trait['method']['id'];
 
-        // Fetch all method(s) linked to the trait.  
+        // Fetch all method(s) linked to the trait.
         $asset_rec = $this->getTraitMethod($subject);
       }
       else {
@@ -270,10 +270,10 @@ class TripalCultivatePhenotypesTraitsService {
             'object_id' => $object
           ])
           ->execute();
-        
+
         if (!$ins_rel) {
-          $this->logger->error('Error. Failed to create term relationship @type : subject id - @subject object id - @object.', 
-            ['@type' => $type, '@subject' => $subject, '@object' => $object], 
+          $this->logger->error('Error. Failed to create term relationship @type : subject id - @subject object id - @object.',
+            ['@type' => $type, '@subject' => $subject, '@object' => $object],
             ['drupal_set_message' => TRUE]
           );
           throw new \Exception(t('A database error occurred while inserting a term relationship.'));
@@ -293,7 +293,7 @@ class TripalCultivatePhenotypesTraitsService {
         ->execute();
 
       if (!$ins_type) {
-        $this->logger->error('Error. Failed to insert unit data type @unit : @data_type.', 
+        $this->logger->error('Error. Failed to insert unit data type @unit : @data_type.',
           ['@unit' => $type, '@data_type' => $trait['Unit']], ['drupal_set_message' => TRUE]
         );
         throw new \Exception(t('A database error occurred while inserting a unit data type.'));
@@ -314,12 +314,12 @@ class TripalCultivatePhenotypesTraitsService {
    * Get trait.
    *
    * @param string|int $trait
-   *   A string value is the trait name (cvterm.name), whereas an integer value 
+   *   A string value is the trait name (cvterm.name), whereas an integer value
    *   is the trait id number (cvterm.cvterm_id).
    *
    * @return object
    *   Matching record/line in cvterm table or 0 if trait record Was not found.
-   * 
+   *
    * @dependencies
    *   getTraitAsset()
    */
@@ -332,13 +332,13 @@ class TripalCultivatePhenotypesTraitsService {
    * Get trait method.
    *
    * @param string|int $trait
-   *   A string value is the trait name (cvterm.name), whereas an integer value 
+   *   A string value is the trait name (cvterm.name), whereas an integer value
    *   is the trait id number (cvterm.cvterm_id).
    *
    * @return array
    *   All matching records (object) in an array. 0 if no methods were found.
-   *   If there is only one result (method) returned access the value using index 0. 
-   * 
+   *   If there is only one result (method) returned access the value using index 0.
+   *
    * @dependencies
    *   getTraitAsset()
    */
@@ -348,7 +348,7 @@ class TripalCultivatePhenotypesTraitsService {
       // Trait was not found.
       return 0;
     }
-     
+
     // Inspect the relationship table where the trait has a trait - method relationship.
     $sql = "SELECT object_id AS id FROM {1:cvterm_relationship} WHERE subject_id = :s_id AND type_id = :t_id";
 
@@ -364,7 +364,7 @@ class TripalCultivatePhenotypesTraitsService {
     if (count($method_ids) > 0) {
       // Has methods.
       $methods = $this->chado->query(
-        "SELECT * FROM {1:cvterm} WHERE cvterm_id IN (:ids[])", 
+        "SELECT * FROM {1:cvterm} WHERE cvterm_id IN (:ids[])",
         [':ids[]' => array_values($method_ids)]
       )
         ->fetchAll();
@@ -377,12 +377,12 @@ class TripalCultivatePhenotypesTraitsService {
    * Get trait method unit.
    *
    * @param string|int $method
-   *   A string value is the method name (cvterm.name), whereas an integer value 
+   *   A string value is the method name (cvterm.name), whereas an integer value
    *   is the method id number (cvterm.cvterm_id).
    *
    * @return array
    *   All matching records (object) in an array. 0 if no units were found.
-   *   If there is only one result (unit) returned access the value using index 0. 
+   *   If there is only one result (unit) returned access the value using index 0.
    */
   public function getMethodUnit($method) {
     $method_rec = $this->getTraitAsset($method, 'method');
@@ -390,7 +390,7 @@ class TripalCultivatePhenotypesTraitsService {
       // Method was not found.
       return 0;
     }
-    
+
     // Inspect the relationship table where method has a method - unit relationship.
     $sql = "SELECT object_id AS id FROM {1:cvterm_relationship} WHERE subject_id = :s_id AND type_id = :t_id";
 
@@ -401,8 +401,8 @@ class TripalCultivatePhenotypesTraitsService {
 
     $unit_ids = $this->chado->query($sql, $args)
       ->fetchCol();
-   
-    $units = [];  
+
+    $units = [];
     if (count($unit_ids) > 0) {
       // Has units.
       $units = $this->chado->query(
@@ -411,19 +411,19 @@ class TripalCultivatePhenotypesTraitsService {
       )
         ->fetchAll();
     }
-    
+
     return ($units) ? $units : 0;
   }
 
   /**
    * Get Trait Method Unit data type.
-   * 
+   *
    * @param string|int $unit
-   *   A string value is the unit name (cvterm.name), whereas an integer value 
+   *   A string value is the unit name (cvterm.name), whereas an integer value
    *   is the unit id number (cvterm.cvterm_id).
    *
    * @return string
-   *   The data type of the unit, either quantitative or qualitative or 0 when the unit record was not found 
+   *   The data type of the unit, either quantitative or qualitative or 0 when the unit record was not found
    *   and was not set a data type.
    */
   public function getMethodUnitDataType($unit) {
@@ -432,23 +432,23 @@ class TripalCultivatePhenotypesTraitsService {
       // Unit was not found.
       return 0;
     }
-    
+
     // Inspect the relationship table where unit has a unit - data type relationship.
     $sql = "SELECT value FROM {1:cvtermprop} WHERE cvterm_id = :c_id AND type_id = :t_id";
-    
+
     $args = [
-      ':c_id' => $unit_rec->cvterm_id, 
+      ':c_id' => $unit_rec->cvterm_id,
       ':t_id' => $this->terms['unit_type']
     ];
-    
+
     $data_type = $this->chado->query($sql, $args)
       ->fetchCol();
-    
+
     if (count($data_type) > 1) {
       // Unit appears to multiple data types.
       $this->logger->error(
-        'Error. Failed to retrieve data type for unit : @unit in cv : @cv. Multiple data types found for the same unit.', 
-        ['@unit' => $unit, '@cv' => $genus_config['unit']['name']], 
+        'Error. Failed to retrieve data type for unit : @unit in cv : @cv. Multiple data types found for the same unit.',
+        ['@unit' => $unit, '@cv' => $genus_config['unit']['name']],
         ['drupal_set_message' => TRUE]
       );
       throw new \Exception(t('A multiple data type error occurred while retrieving a unit data type.'));
@@ -459,20 +459,20 @@ class TripalCultivatePhenotypesTraitsService {
 
   /**
    * Get trait, method and unit combination.
-   * 
+   *
    * @param string|int $trait
    *   A string value is the trait name, whereas an integer value is the trait id number.
    * @param string|int $method
    *   A string value is the trait method short name, whereas an integer value is the method id number.
    * @param string|int $unit
    *   A string value is the method unit name, whereas an integer value is the unit id number.
-   * 
+   *
    * @return array
    *   An associative array where the keys are trait, method and unit and the values
    *   are the cvterm records for each key.
-   * 
+   *
    *   0 if any one of trait, method or unit did not return any record.
-   * 
+   *
    * @dependencies
    *   getTraitAsset(), getMethodUnitDataType().
    */
@@ -482,7 +482,7 @@ class TripalCultivatePhenotypesTraitsService {
     if (!$trait_rec) {
       return 0;
     }
-    
+
     // Method.
     $method_rec = $this->getTraitAsset($method, 'method');
     if (!$method_rec) {
@@ -499,7 +499,7 @@ class TripalCultivatePhenotypesTraitsService {
     $unit_id = $unit_rec->cvterm_id;
     $unit_data_type = $this->getMethodUnitDataType($unit_id);
     $unit_rec->{'data_type'} = $unit_data_type;
-        
+
     return [
       'trait' => $trait_rec,
       'method' => $method_rec,
@@ -509,13 +509,13 @@ class TripalCultivatePhenotypesTraitsService {
 
   /**
    * Get trait asset - trait, method or unit.
-   * 
+   *
    * @param string|int $key
-   *   A string value is the name (cvterm.name), whereas an integer value 
+   *   A string value is the name (cvterm.name), whereas an integer value
    *   is the id number (cvterm.cvterm_id).
    * @param string $type
    *   trait, method or unit asset type. Trait is the default.
-   * 
+   *
    * @return object
    *   Trait asset record object or 0 if not found.
    */
@@ -525,7 +525,7 @@ class TripalCultivatePhenotypesTraitsService {
     if (!$genus_config) {
       // Genus not set.
       throw new \Exception(t('No genus has been set. See setting a genus in the Traits Service and make sure to
-        use a configured genus. To configure a genus or see all configured genus, go to @url.', 
+        use a configured genus. To configure a genus or see all configured genus, go to @url.',
         ['@url' => Url::fromRoute('trpcultivate_phenotypes.settings_ontology')->toString()]
       ));
     }
@@ -533,14 +533,14 @@ class TripalCultivatePhenotypesTraitsService {
     // Parameter check.
     if (!in_array($type, ['trait', 'method', 'unit'])) {
       // Not a valid parameter asset type value..
-      throw new \Exception(t('Not a valid trait asset type value provided. Trait asset getter expects type to be the 
+      throw new \Exception(t('Not a valid trait asset type value provided. Trait asset getter expects type to be the
         string trait, method or unit.'
-      ));   
+      ));
     }
 
     if (empty($key) || (is_numeric($key) && (int) $key < 0)) {
       // Not a valid asset key value (0, negative values or an empty string).
-      throw new \Exception(t('Not a valid @type key value provided. The trait asset getter expects a string name or 
+      throw new \Exception(t('Not a valid @type key value provided. The trait asset getter expects a string name or
         an integer id key value.', ['@type' => $type]
       ));
     }
@@ -570,13 +570,13 @@ class TripalCultivatePhenotypesTraitsService {
         [':value' => $key, ':cv' => $genus_config[ $type ]['id']]
       )
         ->fetchAll();
-      
+
       if ($asset_rec && count($asset_rec) > 1) {
         // Trait asset name requested appears to have copies in the cv: asset type (trait, method or unit) the genus was configured.
         // Log error for admin to resolve.
         $this->logger->error(
-          'Error. Failed to retrieve @type : @key in cv : @cv. Multiple copies of the same term found in the CV', 
-          ['@type' => $type, '@key' => $key, '@cv' => $genus_config[ $type ]['name']], 
+          'Error. Failed to retrieve @type : @key in cv : @cv. Multiple copies of the same term found in the CV',
+          ['@type' => $type, '@key' => $key, '@cv' => $genus_config[ $type ]['name']],
           ['drupal_set_message' => TRUE]
         );
         throw new \Exception(t('A duplicate term error occurred while retrieving a trait asset.'));

--- a/trpcultivate_phenotypes/src/Service/TripalCultivatePhenotypesTraitsService.php
+++ b/trpcultivate_phenotypes/src/Service/TripalCultivatePhenotypesTraitsService.php
@@ -309,7 +309,7 @@ class TripalCultivatePhenotypesTraitsService {
    */
   public function getTrait($trait) {
     // Since the trait is simply a cvterm, we can use our helper method to retrieve it.
-    $trait_rec = $this->getTraitAsset($trait, 'trait');
+    $trait_rec = $this->getPhenoCvterm($trait, 'trait');
     return $trait_rec;
   }
 

--- a/trpcultivate_phenotypes/src/Service/TripalCultivatePhenotypesTraitsService.php
+++ b/trpcultivate_phenotypes/src/Service/TripalCultivatePhenotypesTraitsService.php
@@ -60,12 +60,18 @@ class TripalCultivatePhenotypesTraitsService {
    * Set the genus configuration values to which all
    * methods will use to restrict any trait data operations.
    *
-   * @param $genus
-   *   String, a specific genus to reference in genus ontology configurations.
+   * @param string $genus
+   *   A specific genus to reference in genus ontology configurations.
    *
    * @return void
+   *
+   * @throws \Exception
+   *   And exception is thrown by this method if
+   *    - the terms used by this module are not configured
+   *    - the genus is not configured for use with phenotypes
+   *    - the genus does not exist in the chado organism table in the default chado instance.
    */
-  public function setTraitGenus($genus) {
+  public function setTraitGenus(string $genus) {
     // For this setter to work both Genus and Terms configuration must be configured.
     // Term configuration:
     $not_set = [];
@@ -142,23 +148,27 @@ class TripalCultivatePhenotypesTraitsService {
    *     (e.g. measured 5 plants from the plot and then averaged them.)
    *   - Unit: the full word describing the unit used in the method (e.g. centimeters)
    *   - Type: Quantitative or Qualitative.
-   * @param object $schema
-   *   Tripal DBX Chado Connection object
-   *
-   * @see Header property and Trait Importer.
-   * NOTE:
-   *   - Tripal Importer Plugin loading of file is performed using database transaction.
-   *   - Although Genus is collected in the Importer form, It is not saved as part of the terms/traits.
-   *     Genus functions as a pointer to which CV to save the terms as set in the Genus-ontology configuration.
+   * @param string $schema
+   *   The name of the schema that the terms are expected to live in. This is
+   *   passed to the legacy chado_insert_cvterm() and if NULL, the default
+   *   chado instance will be used.
    *
    * @return
    *   An array with the following keys where each value is the id of new cvterm:
    *   trait, method, unit.
    *
+   * @throws \Exception
+   *   An exception is thrown if
+   *    - the genus/terms are not configured
+   *    - the Trait Name, Method Short Name or Unit are not a non-empty string
+   *    - the Trait Name, Method Short Name or Unit are not unique
+   *    - chado_insert_cvterm() fails to insert the term
+   *    - we fail to insert a relationship or the unit type.
+   *
    * @dependencies
    *   getPhenoCvterm(), getMethodUnitDataType().
    */
-  public function insertTrait($trait, $schema = NULL) {
+  public function insertTrait(array $trait, string $schema = NULL) {
     // Configuration settings of the genus.
     $genus_config = $this->config;
     if (!$genus_config) {
@@ -258,7 +268,7 @@ class TripalCultivatePhenotypesTraitsService {
           ->execute();
 
         if (!$ins_rel) {
-          throw new \Exception(t('A database error occurred while inserting a term relationship. 
+          throw new \Exception(t('A database error occurred while inserting a term relationship.
             Failed to create term relationship @type : subject id - @subject object id - @object.',
             ['@type' => $type, '@subject' => $subject, '@object' => $object]
           ));
@@ -302,7 +312,15 @@ class TripalCultivatePhenotypesTraitsService {
    *   is the trait id number (cvterm.cvterm_id).
    *
    * @return object
-   *   Matching record/line in cvterm table or 0 if trait record Was not found.
+   *   Matching record (cvterm object) if the trait exists.
+   *   NULL if trait was not found.
+   *
+   * @throws \Exception
+   *   An exception is thrown by getPhenoCvterm() if any of the following apply
+   *   to the trait parameter.
+   *    - the genus/terms are not configured
+   *    - the key is not either a positive integer or a non-empty string.
+   *    - more than one cvterm was returned
    *
    * @dependencies
    *   getPhenoCvterm()
@@ -321,8 +339,16 @@ class TripalCultivatePhenotypesTraitsService {
    *   is the trait id number (cvterm.cvterm_id).
    *
    * @return array
-   *   All matching records (object) in an array. An empty array if no methods were found.
-   *   If there is only one result (method) returned access the value using index 0.
+   *   All matching records (cvterm object) in an array.
+   *   Empty array if there are no methods for this trait or if the trait doesn't exist.
+   *   If there is only one result (unit) returned access the value using index 0.
+   *
+   * @throws \Exception
+   *   An exception is thrown by getPhenoCvterm() if any of the following apply
+   *   to the trait parameter.
+   *    - the genus/terms are not configured
+   *    - the key is not either a positive integer or a non-empty string.
+   *    - more than one cvterm was returned
    *
    * @dependencies
    *   getPhenoCvterm()
@@ -366,8 +392,16 @@ class TripalCultivatePhenotypesTraitsService {
    *   is the method id number (cvterm.cvterm_id).
    *
    * @return array
-   *   All matching records (object) in an array. 0 if no units were found.
+   *   All matching records (cvterm object) in an array.
+   *   Empty array if there are no units for this method or if the method doesn't exist.
    *   If there is only one result (unit) returned access the value using index 0.
+   *
+   * @throws \Exception
+   *   An exception is thrown by getPhenoCvterm() if any of the following apply
+   *   to the method parameter.
+   *    - the genus/terms are not configured
+   *    - the key is not either a positive integer or a non-empty string.
+   *    - more than one cvterm was returned
    *
    * @dependencies
    *   getPhenoCvterm()
@@ -411,8 +445,16 @@ class TripalCultivatePhenotypesTraitsService {
    *   is the unit id number (cvterm.cvterm_id).
    *
    * @return string
-   *   The data type of the unit, either quantitative or qualitative or 0 when the unit record was not found
-   *   and was not set a data type.
+   *   The data type of the unit, either quantitative or qualitative.
+   *   NULL if the unit doesn't exist or there was no data type set for it.
+   *
+   * @throws \Exception
+   *   This method throws an exception if multiple data types are set for the given unit.
+   *   An exception is thrown by getPhenoCvterm() if any of the following apply
+   *   to the unit parameter.
+   *    - the genus/terms are not configured
+   *    - the key is not either a positive integer or a non-empty string.
+   *    - more than one cvterm was returned
    *
    * @dependencies
    *   getPhenoCvterm()
@@ -421,7 +463,7 @@ class TripalCultivatePhenotypesTraitsService {
     $unit_rec = $this->getPhenoCvterm($unit, 'unit');
     if (!$unit_rec) {
       // Unit was not found.
-      return 0;
+      return NULL;
     }
 
     // Inspect the relationship table where unit has a unit - data type relationship.
@@ -437,13 +479,13 @@ class TripalCultivatePhenotypesTraitsService {
 
     if (count($data_type) > 1) {
       // Unit appears to have multiple data types.
-      throw new \Exception(t('A multiple data type error occurred while retrieving a unit data type. 
+      throw new \Exception(t('A multiple data type error occurred while retrieving a unit data type.
         Failed to retrieve data type for unit : @unit in cv : @cv. Multiple data types found for the same unit.',
         ['@unit' => $unit, '@cv' => $genus_config['unit']['name']]
       ));
     }
 
-    return ($data_type) ? reset($data_type) : 0;
+    return ($data_type) ? reset($data_type) : NULL;
   }
 
   /**
@@ -459,8 +501,14 @@ class TripalCultivatePhenotypesTraitsService {
    * @return array
    *   An associative array where the keys are trait, method and unit and the values
    *   are the cvterm records for each key.
+   *   NULL if any one of trait, method or unit did not return any record.
    *
-   *   0 if any one of trait, method or unit did not return any record.
+   * @throws \Exception
+   *   An exception is thrown by getPhenoCvterm() if any of the following apply
+   *   to the trait, method or unit parameters.
+   *    - the genus/terms are not configured
+   *    - the key is not either a positive integer or a non-empty string.
+   *    - more than one cvterm was returned
    *
    * @dependencies
    *   getPhenoCvterm(), getMethodUnitDataType().
@@ -469,19 +517,19 @@ class TripalCultivatePhenotypesTraitsService {
     // Trait.
     $trait_rec = $this->getPhenoCvterm($trait, 'trait');
     if (!$trait_rec) {
-      return [];
+      return NULL;
     }
 
     // Method.
     $method_rec = $this->getPhenoCvterm($method, 'method');
     if (!$method_rec) {
-      return [];
+      return NULL;
     }
 
     // Unit.
     $unit_rec = $this->getPhenoCvterm($unit, 'unit');
     if (!$unit_rec) {
-      return [];
+      return NULL;
     }
 
     // Append unit data type to the unit data object.
@@ -506,7 +554,15 @@ class TripalCultivatePhenotypesTraitsService {
    *   trait, method or unit type. Trait is the default.
    *
    * @return object
-   *   A trait, method or unit cvterm object.
+   *   A cvterm object representing the trait, method or unit. If no cvterm is
+   *   found then NULL is returned.
+   *
+   * @throws \Exception
+   *   An exception is thrown by getPhenoCvterm() if
+   *    - the genus/terms are not configured
+   *    - the type is not one of 'trait', 'method' or 'unit'
+   *    - the key is not either a positive integer or a non-empty string.
+   *    - more than one cvterm was returned
    */
   protected function getPhenoCvterm($key, $type = 'trait') {
     // Configuration check.
@@ -563,7 +619,7 @@ class TripalCultivatePhenotypesTraitsService {
       if ($asset_rec && count($asset_rec) > 1) {
         // Trait asset name requested appears to have copies in the cv: asset type (trait, method or unit) the genus was configured.
         // Log error for admin to resolve.
-        throw new \Exception(t('A duplicate term error occurred while retrieving a trait asset. 
+        throw new \Exception(t('A duplicate term error occurred while retrieving a trait asset.
           Failed to retrieve @type : @key in cv : @cv. Multiple copies of the same term found in the CV',
           ['@type' => $type, '@key' => $key, '@cv' => $genus_config[ $type ]['name']]
         ));
@@ -571,8 +627,8 @@ class TripalCultivatePhenotypesTraitsService {
     }
 
     if(!$asset_rec) {
-      // Trait asset was not found.
-      return 0;
+      // cvterm was not found.
+      return NULL;
     }
 
     return reset($asset_rec);

--- a/trpcultivate_phenotypes/src/Service/TripalCultivatePhenotypesTraitsService.php
+++ b/trpcultivate_phenotypes/src/Service/TripalCultivatePhenotypesTraitsService.php
@@ -382,7 +382,10 @@ class TripalCultivatePhenotypesTraitsService {
    *
    * @return array
    *   All matching records (object) in an array. 0 if no units were found.
-   *   If there is only one result (unit) returned access the value using index 0. 
+   *   If there is only one result (unit) returned access the value using index 0.
+   *
+   * @dependencies
+   *   getTraitAsset()
    */
   public function getMethodUnit($method) {
     $method_rec = $this->getTraitAsset($method, 'method');
@@ -425,6 +428,9 @@ class TripalCultivatePhenotypesTraitsService {
    * @return string
    *   The data type of the unit, either quantitative or qualitative or 0 when the unit record was not found 
    *   and was not set a data type.
+   *
+   * @dependencies
+   *   getTraitAsset()
    */
   public function getMethodUnitDataType($unit) {
     $unit_rec = $this->getTraitAsset($unit, 'unit');

--- a/trpcultivate_phenotypes/src/Service/TripalCultivatePhenotypesTraitsService.php
+++ b/trpcultivate_phenotypes/src/Service/TripalCultivatePhenotypesTraitsService.php
@@ -418,4 +418,83 @@ class TripalCultivatePhenotypesTraitsService {
 
     return $data_type ?? 0;
   }
+
+  /**
+   * Get trait, method and unit combination.
+   * 
+   * @param $trait_name
+   *   String, the trait name.
+   * @param $method_short_name
+   *   String, the method short name.
+   * @param $unit_name
+   *   String, the unit name.
+   * 
+   * @return array
+   *   An associative array where the keys are trait, method and unit and the values
+   *   are the cvterm records for each key.
+   * 
+   *   null if any one of trait, method or unit did not return any record.
+   */
+  public function getTraitMethodUnitCombo($trait_name, $method_short_name, $unit_name) {
+    if ($trait_name && $method_short_name && $unit_name) {
+      // Trait:
+      $arr_trait = ['name' => $trait_name];
+      $trait = $this->getTrait($arr_trait);
+      
+      if (!$trait) {
+        return null;
+      }
+      
+      // Method:
+      $method = null;
+      if ($trait) {
+        $trait_methods = $this->getTraitMethod($arr_trait);
+
+        if ($trait_methods) {
+          foreach($trait_methods as $method_obj) {
+            if ($method_obj->name == $method_short_name) {
+              $method = $method_obj;
+              break;
+            }
+          }
+
+          if (!$method) {
+            return null;
+          }
+        }
+      }
+
+      // Unit:
+      $unit = null;
+      if ($method) {
+        $method_id = $method->cvterm_id;
+        $method_units = $this->getMethodUnit($method_id);
+        
+        if ($method_units) {
+          foreach($method_units as $unit_obj) {
+            if ($unit_obj->name == $unit_name) {
+              $unit = $unit_obj;
+              break;
+            }
+          }
+        }
+        
+        if (!$unit) {
+          return null;
+        }
+
+        // Append unit data type to the unit data object.
+        $unit_id = $unit->cvterm_id;
+        $unit_data_type = $this->getMethodUnitDataType($unit_id);
+        $unit->{'data_type'} = $unit_data_type;
+      }
+      
+
+      return [
+        'trait' => $trait,
+        'method' => $method,
+        'unit'  => $unit
+      ];
+    }
+  }
 }

--- a/trpcultivate_phenotypes/src/Service/TripalCultivatePhenotypesTraitsService.php
+++ b/trpcultivate_phenotypes/src/Service/TripalCultivatePhenotypesTraitsService.php
@@ -422,78 +422,86 @@ class TripalCultivatePhenotypesTraitsService {
   /**
    * Get trait, method and unit combination.
    * 
-   * @param $trait_name
-   *   String, the trait name.
-   * @param $method_short_name
-   *   String, the method short name.
-   * @param $unit_name
-   *   String, the unit name.
+   * @param string|int $trait
+   *   A string value is the trait name, whereas an integer value is the trait id number.
+   * @param string|int $method
+   *   A string value is the trait method short name, whereas an integer value is the method id number.
+   * @param string|int $unit
+   *   A string value is the method unit name, whereas an integer value is the unit id number.
    * 
    * @return array
    *   An associative array where the keys are trait, method and unit and the values
    *   are the cvterm records for each key.
    * 
    *   null if any one of trait, method or unit did not return any record.
+   * 
+   * @dependencies
+   *   getTrait(), getTraitMethod(), getMethodUnit() and getMethodUnitDataType().
    */
-  public function getTraitMethodUnitCombo($trait_name, $method_short_name, $unit_name) {
-    if ($trait_name && $method_short_name && $unit_name) {
+  public function getTraitMethodUnitCombo(string|int $trait, string|int $method, string|int $unit) {
+    if ($trait && $method && $unit) {
       // Trait:
-      $arr_trait = ['name' => $trait_name];
-      $trait = $this->getTrait($arr_trait);
+      $key = (is_string($trait)) ? 'name' : 'id';
+      $arr_trait = [$key => $trait];
+      $trait_val = $this->getTrait($arr_trait);
       
       if (!$trait) {
         return null;
       }
       
       // Method:
-      $method = null;
+      $method_val = null;
       if ($trait) {
         $trait_methods = $this->getTraitMethod($arr_trait);
 
         if ($trait_methods) {
+          $key = (is_string($method)) ? 'name' : 'cvterm_id';
+
           foreach($trait_methods as $method_obj) {
-            if ($method_obj->name == $method_short_name) {
-              $method = $method_obj;
+            if ($method_obj->{$key} == $method) {
+              $method_val = $method_obj;
               break;
             }
           }
 
-          if (!$method) {
+          if (!$method_val) {
             return null;
           }
         }
       }
 
       // Unit:
-      $unit = null;
-      if ($method) {
-        $method_id = $method->cvterm_id;
+      $unit_val = null;
+      if ($method_val) {
+        $method_id = $method_val->cvterm_id;
         $method_units = $this->getMethodUnit($method_id);
         
         if ($method_units) {
+          $key = (is_string($unit)) ? 'name' : 'cvterm_id';
+
           foreach($method_units as $unit_obj) {
-            if ($unit_obj->name == $unit_name) {
-              $unit = $unit_obj;
+            if ($unit_obj->{$key} == $unit) {
+              $unit_val = $unit_obj;
               break;
             }
           }
         }
         
-        if (!$unit) {
+        if (!$unit_val) {
           return null;
         }
 
         // Append unit data type to the unit data object.
-        $unit_id = $unit->cvterm_id;
+        $unit_id = $unit_val->cvterm_id;
         $unit_data_type = $this->getMethodUnitDataType($unit_id);
-        $unit->{'data_type'} = $unit_data_type;
+        $unit_val->{'data_type'} = $unit_data_type;
       }
       
 
       return [
-        'trait' => $trait,
-        'method' => $method,
-        'unit'  => $unit
+        'trait' => $trait_val,
+        'method' => $method_val,
+        'unit'  => $unit_val
       ];
     }
   }

--- a/trpcultivate_phenotypes/src/Service/TripalCultivatePhenotypesTraitsService.php
+++ b/trpcultivate_phenotypes/src/Service/TripalCultivatePhenotypesTraitsService.php
@@ -369,10 +369,10 @@ class TripalCultivatePhenotypesTraitsService {
       return 0;
     }
 
-    $unit = 0;
+    $units = [];
 
     // Get unit.
-    $sql = "SELECT object_id FROM {1:cvterm_relationship} WHERE subject_id = :s_id AND type_id = :t_id";
+    $sql = "SELECT object_id AS id FROM {1:cvterm_relationship} WHERE subject_id = :s_id AND type_id = :t_id";
 
     // Query values.
     $args = [
@@ -381,16 +381,20 @@ class TripalCultivatePhenotypesTraitsService {
     ];
 
     // Query unit.
-    $unit_id = $this->chado->query($sql, $args)
-      ->fetchField();
+    $unit_ids = $this->chado->query($sql, $args);
+    $sql = "SELECT * FROM {1:cvterm} WHERE cvterm_id = :id AND cv_id = :c_id LIMIT 1";
 
-    if ($unit_id) {
-      $sql = "SELECT * FROM {1:cvterm} WHERE cvterm_id = :id AND cv_id = :c_id LIMIT 1";
-      $unit = $this->chado->query($sql, [':id' => $unit_id, ':c_id' => $genus_config['unit']['id']])
+    foreach($unit_ids as $unit_id) {
+      // Resolve the unit id.
+      $unit = $this->chado->query($sql, [':id' => $unit_id->id, ':c_id' => $genus_config['unit']['id']])
         ->fetchObject();
-    }
 
-    return $unit;
+      if ($unit) {
+        $units[] = $unit;
+      }
+    }
+    
+    return count($units) > 0 ? $units : 0;
   }
 
   /**

--- a/trpcultivate_phenotypes/src/Service/TripalCultivatePhenotypesTraitsService.php
+++ b/trpcultivate_phenotypes/src/Service/TripalCultivatePhenotypesTraitsService.php
@@ -583,7 +583,7 @@ class TripalCultivatePhenotypesTraitsService {
       ));
     }
 
-    if (empty($key) || (is_numeric($key) && (int) $key < 0)) {
+    if (empty($key) || (is_numeric($key) && (int) $key < 0) || (!is_numeric($key) && !is_string($key))) {
       // Not a valid asset key value (0, negative values or an empty string).
       throw new \Exception(t('Not a valid @type key value provided. The trait asset getter expects a string name or
         an integer id key value.', ['@type' => $type]

--- a/trpcultivate_phenotypes/src/Service/TripalCultivatePhenotypesTraitsService.php
+++ b/trpcultivate_phenotypes/src/Service/TripalCultivatePhenotypesTraitsService.php
@@ -591,7 +591,8 @@ class TripalCultivatePhenotypesTraitsService {
     }
 
 
-    // Query trait asset.
+    // If we are given an integer then assume it is the cvterm_id...
+    $asset_rec = NULL;
     if (is_numeric($key)) {
       // Asset parameter key is the id number.
       $asset_rec = $this->chado->query(
@@ -608,7 +609,10 @@ class TripalCultivatePhenotypesTraitsService {
         ));
       }
     }
-    else {
+
+    // If the key provided is a string OR if there was no matching cvterm_id
+    // then assume we are given the term name...
+    if (!$asset_rec) {
       // Asses parameter key is the name.
       $asset_rec = $this->chado->query(
         "SELECT * FROM {1:cvterm} WHERE name = :value AND cv_id = :cv",

--- a/trpcultivate_phenotypes/tests/src/Kernel/Services/Traits/ValidTraitTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Services/Traits/ValidTraitTest.php
@@ -244,8 +244,8 @@ class ValidTraitTest extends ChadoTestKernelBase {
    */
   public function testTraitsServiceGetters() {
     // Set the genus.
-    $this->service_traits->setTraitGenus($this->genus); 
-    
+    $this->service_traits->setTraitGenus($this->genus);
+
     // Test Data.
     // Keys.
     $keys = [
@@ -345,14 +345,14 @@ class ValidTraitTest extends ChadoTestKernelBase {
 
     // Construct trait asset array.
     foreach($test_combo as $i => $combo) {
-      $data_type = ($i % 2 == 0) ? 'Qualitative' : 'Quantitative'; 
-      
+      $data_type = ($i % 2 == 0) ? 'Qualitative' : 'Quantitative';
+
       // Force E Unit to be Quantitative for the test.
       if ($combo['Unit'] == 'E Unit') {
         $data_type = 'Quantitative';
       }
 
-      $ins_trait = [ 
+      $ins_trait = [
         'Trait Name' => $combo['Trait Name'],
         'Trait Description' => $combo['Trait Name']  . ' Description',
         'Method Short Name' => $combo['Method Short Name'],
@@ -366,20 +366,20 @@ class ValidTraitTest extends ChadoTestKernelBase {
       $trait_assets = $this->service_traits->insertTrait($ins_trait);
       // Check trait assets got inserted.
       $trait_combo = $this->service_traits->getTraitMethodUnitCombo($combo['Trait Name'], $combo['Method Short Name'], $combo['Unit']);
-      
+
       // Trait.
-      $this->assertEquals($trait_assets['trait'], $trait_combo['trait']->cvterm_id, 
+      $this->assertEquals($trait_assets['trait'], $trait_combo['trait']->cvterm_id,
         'Test trait '. $combo['Trait Name'] .' was not inserted.');
       // Method.
-      $this->assertEquals($trait_assets['method'], $trait_combo['method']->cvterm_id, 
+      $this->assertEquals($trait_assets['method'], $trait_combo['method']->cvterm_id,
         'Test ' . $combo['Method Short Name'] . ' was not inserted.');
       // Unit.
-      $this->assertEquals($trait_assets['unit'], $trait_combo['unit']->cvterm_id, 
+      $this->assertEquals($trait_assets['unit'], $trait_combo['unit']->cvterm_id,
         'Test unit ' . $combo['Unit'] . ' was not inserted.');
     }
-    
+
     // At this point, all traits should be in, test the relationships, connections and all.
-    
+
     // Test nothing got inserted more than once and re-using a trait asset meant
     // that it just referenced existing asset and not creating another copy
     // in the same cv the genus is configured.
@@ -391,7 +391,7 @@ class ValidTraitTest extends ChadoTestKernelBase {
 
     foreach($reuse_test as $asset => $name) {
       $exception_message = '';
-      
+
       try {
         // Use string trait asset name as parameter.
         $this->service_traits->getTraitAsset($name, $asset);
@@ -401,11 +401,11 @@ class ValidTraitTest extends ChadoTestKernelBase {
         // of the same name in the same cv the genus is configured.
         $exception_message = $e->getMessage();
       }
-      
+
       $this->assertEmpty($exception_message, 'Test trait asset ' . $asset . ':' . $name . ' was inserted more than once.');
     }
-    
-    // Test that any trait asset can be retrieved either by using 
+
+    // Test that any trait asset can be retrieved either by using
     // name or id number as parameter using getTraitAsset() method.
 
     // Test that by using id number and the id provided is an id for a trait asset that belongs
@@ -420,15 +420,15 @@ class ValidTraitTest extends ChadoTestKernelBase {
     catch (Exception $e) {
       $exception_message = $e->getMessage();
     }
-    
-    $this->assertMatchesRegularExpression('/The requested trait asset (trait|method|unit)/', $exception_message, 
+
+    $this->assertMatchesRegularExpression('/The requested trait asset (trait|method|unit)/', $exception_message,
       'Trait asset id provided returned an asset not in the cv the genus was configured.');
     */
 
     foreach($test_combo as $combo) {
       foreach($keys as $key => $title) {
         // Each combo, retrieve assets - trait, method and unit.
-        
+
         // By string parameter.
         $asset = $this->service_traits->getTraitAsset($combo[ $title ], $key);
         $asset_bystring_id = (int) $asset->cvterm_id;
@@ -438,10 +438,10 @@ class ValidTraitTest extends ChadoTestKernelBase {
         $asset = $this->service_traits->getTraitAsset($asset_bystring_id, $key);
         $asset_byinteger_id = (int) $asset->cvterm_id;
         $this->assertNotEquals($asset_byinteger_id, 0, 'Failed to fetch trait asset' . $key . ' : ' . $combo[ $title ] . ' (by integer id parameter).');
-    
+
         // Either cases both should match.
-        $this->assertEquals($asset_bystring_id, $asset_byinteger_id, 
-          'Trait id returned by trait asset getter with string and integer parameters do not match.');      
+        $this->assertEquals($asset_bystring_id, $asset_byinteger_id,
+          'Trait id returned by trait asset getter with string and integer parameters do not match.');
       }
     }
 
@@ -449,24 +449,24 @@ class ValidTraitTest extends ChadoTestKernelBase {
     // to getTrait() method.
     foreach($test_combo as $combo) {
       $name_key = 'Trait Name';
-      
+
       // By string parameter.
       $trait = $this->service_traits->getTrait($combo[ $name_key ]);
       $trait_id = (int) $trait->cvterm_id;
       $this->assertNotEquals($trait->cvterm_id, 0, 'Failed to fetch trait ' .  $combo[ $name_key ] . ' (by trait name parameter).');
-      
+
       // By id number parameter.
       $trait = $this->service_traits->getTrait($trait->cvterm_id);
       $this->assertNotEquals($trait->cvterm_id, 0, 'Failed to fetch trait ' .  $combo[ $name_key ] . ' (by trait id parameter).');
-    
+
       // Either cases both should match.
-      $this->assertEquals($trait_id, (int) $trait->cvterm_id, 
-        'Trait id returned by trait getter with string and integer parameters do not match.'); 
+      $this->assertEquals($trait_id, (int) $trait->cvterm_id,
+        'Trait id returned by trait getter with string and integer parameters do not match.');
     }
 
     // Test get trait method using trait name or trait id as parameter
     // to getTraitMethod() method.
-    
+
     // Based on the summary of traits assets above, test the following.
     // 1. A Trait has 3 methods - A, B, C Method.
     // 2. C Trait has 1 method - D Method.
@@ -476,12 +476,12 @@ class ValidTraitTest extends ChadoTestKernelBase {
 
     // Assert that in both cases, the returned set of methods was the same.
     // Then proceed to assert that methods returned are the expected methods.
-    $this->assertEquals($a_trait_methods_byname, $a_trait_methods_byid, 
+    $this->assertEquals($a_trait_methods_byname, $a_trait_methods_byid,
       'A Trait methods returned by methods getter with name and id as parameter do not match.');
 
     // 3 methods in the set?
     $methods_count = count($a_trait_methods_byid);
-    $this->assertEquals($methods_count, 3, 'A Trait methods returned by methods getter does not match expected count (3).'); 
+    $this->assertEquals($methods_count, 3, 'A Trait methods returned by methods getter does not match expected count (3).');
 
     foreach(['A', 'B', 'C'] as $expected) {
       $method_name = $expected . ' Method';
@@ -496,20 +496,20 @@ class ValidTraitTest extends ChadoTestKernelBase {
 
       $this->assertTrue($a_found, 'The method ' . $method_name . ' was not found in the trait methods.');
     }
-    
+
     // The same steps for C Trait.
     $c_trait_methods_byname = $this->service_traits->getTraitMethod('C Trait');
     $c_trait = $this->service_traits->getTraitAsset('C Trait', 'trait');
     $c_trait_methods_byid   = $this->service_traits->getTraitMethod($c_trait->cvterm_id);
-    
-    $this->assertEquals($c_trait_methods_byname, $c_trait_methods_byid, 
+
+    $this->assertEquals($c_trait_methods_byname, $c_trait_methods_byid,
       'C Trait methods returned by methods getter with name and id as parameter do not match.');
-    
+
     $methods_count = count($c_trait_methods_byid);
-    $this->assertEquals($methods_count, 1, 'C Trait methods returned by methods getter does not match expected count (1).'); 
-    
+    $this->assertEquals($methods_count, 1, 'C Trait methods returned by methods getter does not match expected count (1).');
+
     $this->assertEquals($c_trait_methods_byid[0]->name, 'D Method', 'The method D Method was not found in the trait methods.');
-    
+
     // Test get unit method using method name or method id as parameter
     // to getMethodUnit() method.
 
@@ -521,9 +521,9 @@ class ValidTraitTest extends ChadoTestKernelBase {
     $b_method = $this->service_traits->getTraitAsset('B Method', 'method');
     $b_method_units_byid   = $this->service_traits->getMethodUnit($b_method->cvterm_id);
 
-    $this->assertEquals($b_method_units_byname, $b_method_units_byid, 
+    $this->assertEquals($b_method_units_byname, $b_method_units_byid,
       'B Method units returned by units getter with name and id as parameter do not match.');
-    
+
     $units_count = count($b_method_units_byid);
     $this->assertEquals($units_count, 4, 'B Method units returned by units getter does not match expected count (4).');
 
@@ -546,7 +546,7 @@ class ValidTraitTest extends ChadoTestKernelBase {
     $d_method = $this->service_traits->getTraitAsset('D Method', 'method');
     $d_method_units_byid   = $this->service_traits->getMethodUnit($d_method->cvterm_id);
 
-    $this->assertEquals($d_method_units_byname, $d_method_units_byid, 
+    $this->assertEquals($d_method_units_byname, $d_method_units_byid,
       'D Method units returned by units getter with name and id as parameter do not match.');
 
     $units_count = count($d_method_units_byid);
@@ -562,11 +562,11 @@ class ValidTraitTest extends ChadoTestKernelBase {
     $e_unit_type_byid   = $this->service_traits->getMethodUnitDataType($e_unit->cvterm_id);
 
     // Assert that in both cases, the returned data types were the same.
-    $this->assertEquals($e_unit_type_byname, $e_unit_type_byid, 
+    $this->assertEquals($e_unit_type_byname, $e_unit_type_byid,
       'E Unit data type returned by unit type getter with name and id as parameter do not match.');
-    
+
     // Is it Quantitative?
-    $this->assertEquals($e_unit_type_byid, 'Quantitative', 
+    $this->assertEquals($e_unit_type_byid, 'Quantitative',
       'E Unit data type returned by unit type getter does not match expected data type (Quantitative).');
   }
 
@@ -576,8 +576,8 @@ class ValidTraitTest extends ChadoTestKernelBase {
    */
   public function testTraitsServiceComboGetters() {
     // Set genus to use by the traits service.
-    $this->service_traits->setTraitGenus($this->genus);    
-    
+    $this->service_traits->setTraitGenus($this->genus);
+
     // Generate some fake combination.
     $trait = [
       'trait' => 'Trait Name Combo' . uniqid(),
@@ -588,8 +588,8 @@ class ValidTraitTest extends ChadoTestKernelBase {
     $combo = [
       'Trait Name' => $trait['trait'],
       'Trait Description' => 'A trait name combo',
-      'Method Short Name' => $trait['method'],    
-      'Collection Method' => 'A trait method collection method', 
+      'Method Short Name' => $trait['method'],
+      'Collection Method' => 'A trait method collection method',
       'Unit' => $trait['unit'],
       'Type' => 'Quantitative'
     ];
@@ -604,14 +604,14 @@ class ValidTraitTest extends ChadoTestKernelBase {
     // Invalid parameter error. For all 3 trait asset - trait, method and unit
     // No 0, empty string or negative number.
     $test_missing_param = [
-      ['', $method_id, $unit_id], 
-      [$trait_id, '', $unit_id],  
+      ['', $method_id, $unit_id],
+      [$trait_id, '', $unit_id],
       [$trait_id, $method_id, ''],
-      ['', '', ''], 
+      ['', '', ''],
       [0, $method_id, $unit_id],
       [$trait_id, 0, $unit_id],
       [$trait_id, $method_id, 0],
-      [0, 0, 0], 
+      [0, 0, 0],
       [-1, $method_id, $unit_id],
       [$trait_id, -1, $unit_id],
       [$trait_id, $method_id, -1],
@@ -622,7 +622,7 @@ class ValidTraitTest extends ChadoTestKernelBase {
       $trait_val  = $test[0];
       $method_val = $test[1];
       $unit_val   = $test[2];
-      
+
       $exception_caught  = FALSE;
       $exception_message = '';
       try {

--- a/trpcultivate_phenotypes/tests/src/Kernel/Services/Traits/ValidTraitTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Services/Traits/ValidTraitTest.php
@@ -30,6 +30,13 @@ class ValidTraitTest extends ChadoTestKernelBase {
    */
   protected $chado;
 
+  /**
+   * Configuration
+   *
+   * @var config_entity
+   */
+  protected $config;
+
   // Genus.
   private $genus;
 

--- a/trpcultivate_phenotypes/tests/src/Kernel/Services/Traits/ValidTraitTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Services/Traits/ValidTraitTest.php
@@ -332,4 +332,31 @@ class ValidTraitTest extends ChadoTestKernelBase {
       }
     }
   }
+
+  /**
+   * Test that we can retrieve a trait we just inserted by providing
+   * trait, method and unit combination, of which each can either be the id or name.
+   */
+  public function testTraitsServiceComboGetters() {
+    // Set genus to use by the traits service.
+    $this->service_traits->setTraitGenus($this->genus);    
+    
+    // Generate some fake combination.
+    $trait = [
+      'trait' => 'Trait Name Combo' . uniqid(),
+      'method' => 'Method Name Combo' . uniqid(),
+      'unit' => 'Unit Name Combo' . uniqid(),
+    ];
+
+    $combo = [
+      'Trait Name' => $trait['trait'],
+      'Trait Description' => 'A trait name combo',
+      'Method Short Name' => $trait['method'],    
+      'Collection Method' => 'A trait method collection method', 
+      'Unit' => $trait['unit'],
+      'Type' => 'Quantitative'
+    ];
+
+    $trait_assets = $this->service_traits->insertTrait($combo);
+  }
 }

--- a/trpcultivate_phenotypes/tests/src/Kernel/Services/Traits/ValidTraitTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Services/Traits/ValidTraitTest.php
@@ -30,7 +30,7 @@ class ValidTraitTest extends ChadoTestKernelBase {
    *
    * @var ChadoConnection
    */
-  protected $chado;
+  protected $connection;
 
   /**
    * Configuration

--- a/trpcultivate_phenotypes/tests/src/Kernel/Services/Traits/ValidTraitTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Services/Traits/ValidTraitTest.php
@@ -396,7 +396,7 @@ class ValidTraitTest extends ChadoTestKernelBase {
         // Use string trait asset name as parameter.
         $this->service_traits->getTraitAsset($name, $asset);
       }
-      catch (Exception $e) {
+      catch (\Exception $e) {
         // The getter will throw an exception when it detected multiple copies
         // of the same name in the same cv the genus is configured.
         $exception_message = $e->getMessage();
@@ -412,18 +412,16 @@ class ValidTraitTest extends ChadoTestKernelBase {
     // to a cv not the cv set for the genus.
 
     // term null with id 1 not in the genus.
-    /* Does not seem to catch and would kill the tests.
     $exception_message = '';
     try {
-      $this->service_traits->getTraitAsset(1, 'trait');
+      $temp = $this->service_traits->getTraitAsset(1, 'trait');
     }
-    catch (Exception $e) {
+    catch (\Exception $e) {
       $exception_message = $e->getMessage();
     }
     
-    $this->assertMatchesRegularExpression('/The requested trait asset (trait|method|unit)/', $exception_message, 
+    $this->assertEquals('The requested trait asset trait : id 1 CV value does not match the CV the genus was configured.', $exception_message, 
       'Trait asset id provided returned an asset not in the cv the genus was configured.');
-    */
 
     foreach($test_combo as $combo) {
       foreach($keys as $key => $title) {

--- a/trpcultivate_phenotypes/tests/src/Kernel/Services/Traits/ValidTraitTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Services/Traits/ValidTraitTest.php
@@ -82,7 +82,7 @@ class ValidTraitTest extends ChadoTestKernelBase {
 
     // Install module configuration/settings.
     $this->installConfig(['trpcultivate_phenotypes']);
-    
+
     // Configure the module.
     $this->genus = 'Tripalus';
     $organism_id = $this->connection->insert('1:organism')
@@ -91,7 +91,7 @@ class ValidTraitTest extends ChadoTestKernelBase {
       'species' => 'databasica',
     ])
     ->execute();
-    
+
     $this->assertIsNumeric($organism_id, 'We were not able to create an organism for testing.');
     $this->cvdbon = $this->setOntologyConfig($this->genus);
     $this->terms = $this->setTermConfig();
@@ -153,8 +153,8 @@ class ValidTraitTest extends ChadoTestKernelBase {
         ->fetchObject();
       $this->assertIsObject($rec,
         "We were unable to retrieve the $type record from chado based on the cvterm_id $value provided by the service.");
-      
-    
+
+
       // The was configured in setUp and is keyed by the type.
       $expected_cv = $this->cvdbon[$type]['cv_id'];
       // Ensure it was inserted into the correct cv the genus is configured for.
@@ -338,7 +338,7 @@ class ValidTraitTest extends ChadoTestKernelBase {
       // Set genus to use by the traits service.
       // This method will return the inserted cvterm ids.
       $trait_assets = $this->service_traits->insertTrait($ins_trait);
-      
+
       // Track the ids.
       $expected_cvterms[ $combo['Trait Name'] ] = $trait_assets['trait'];
       $expected_cvterms[ $combo['Method Short Name'] ] = $trait_assets['method'];
@@ -384,7 +384,7 @@ class ValidTraitTest extends ChadoTestKernelBase {
       // Either cases both should match.
       $this->assertEquals($trait_id, (int) $trait->cvterm_id,
         'Trait id returned by trait getter with string and integer parameters do not match.');
-      
+
       // Id number is the id number that got created by the insert method.
       $this->assertEquals($trait_id, $expected_cvterms[ $combo['Trait Name'] ],
         'Trait id returned by trait getter does not match the trait id inserted.');
@@ -571,7 +571,7 @@ class ValidTraitTest extends ChadoTestKernelBase {
       $unit_val   = $test[2];
 
       $combo = $this->service_traits->getTraitMethodUnitCombo($trait_val, $method_val, $unit_val);
-      $this->assertEquals($combo, [], 'Combo getter must return an empty array on non-existent record.');
+      $this->assertEquals($combo, NULL, 'The combo getter should have returned null for a non existent combo.');
     }
 
     unset($combo);
@@ -595,7 +595,7 @@ class ValidTraitTest extends ChadoTestKernelBase {
 
     // Check that the unit has extra property data type.
     $this->assertEquals($combo['unit']->data_type, 'Quantitative', 'Unit data_type property value does not match expected type (Quantitative).');
-    
+
     // All 3 parameters to the method is a unit term.
     // Unit exists but not in the Trait CV the genus is configured.
     $exception_message = '';
@@ -605,8 +605,8 @@ class ValidTraitTest extends ChadoTestKernelBase {
     catch (\Exception $e) {
       $exception_message = $e->getMessage();
     }
-    
-    $this->assertMatchesRegularExpression('/CV value does not match the CV the genus was configured/', 
+
+    $this->assertMatchesRegularExpression('/CV value does not match the CV the genus was configured/',
       $exception_message, 'Combo getter failed parameter (all parameter a unit id) does not match the expected exception error message.');
   }
 }

--- a/trpcultivate_phenotypes/tests/src/Kernel/Services/Traits/ValidTraitTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Services/Traits/ValidTraitTest.php
@@ -288,7 +288,6 @@ class ValidTraitTest extends ChadoTestKernelBase {
 
     // Set genus to use by the traits service.
     $this->service_traits->setTraitGenus($this->genus);    
-    $method_id = 0;
 
     // Save the trait.
     foreach($traits as $i => $trait) {
@@ -318,7 +317,7 @@ class ValidTraitTest extends ChadoTestKernelBase {
       $this->assertEquals($method_name, $m[0]->name, 'Trait method not found (by trait name).');
 
       // Units - UnitABC and AnotherUnit.
-      $method_id = $method_id = $m[0]->cvterm_id;
+      $method_id = $m[0]->cvterm_id;
       $u = $this->service_traits->getMethodUnit($method_id);
 
       foreach($u as $unit) {

--- a/trpcultivate_phenotypes/tests/src/Kernel/Services/Traits/ValidTraitTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Services/Traits/ValidTraitTest.php
@@ -327,7 +327,6 @@ class ValidTraitTest extends ChadoTestKernelBase {
       // This is trait C Trait
       // New method
       // New Unit
-      // Use to test when single item in the result, the array is simplified.
       [
         $keys['trait']  => 'C Trait',  // C
         $keys['method'] => 'D Method',
@@ -341,11 +340,17 @@ class ValidTraitTest extends ChadoTestKernelBase {
     // C Trait has 1 method - C Method
     // A Method has 1 unit - A Unit
     // B Method has 4 units - A, B, C, and D Unit
-    // C Method has 1 unit - C Unit
+    // C Method has 2 units - A and C Unit.
+    // D Method has 1 unit - E Unit
 
     // Construct trait asset array.
     foreach($test_combo as $i => $combo) {
       $data_type = ($i % 2 == 0) ? 'Qualitative' : 'Quantitative'; 
+      
+      // Force E Unit to be Quantitative for the test.
+      if ($combo['Unit'] == 'E Unit') {
+        $data_type = 'Quantitative';
+      }
 
       $ins_trait = [ 
         'Trait Name' => $combo['Trait Name'],
@@ -357,61 +362,212 @@ class ValidTraitTest extends ChadoTestKernelBase {
       ];
 
       // Set genus to use by the traits service.
+      // This method will return the inserted cvterm ids.
       $trait_assets = $this->service_traits->insertTrait($ins_trait);
       // Check trait assets got inserted.
       $trait_combo = $this->service_traits->getTraitMethodUnitCombo($combo['Trait Name'], $combo['Method Short Name'], $combo['Unit']);
       
       // Trait.
-      $this->assertEquals($trait_assets['trait'], $trait_combo['trait']->cvterm_id, 'Test trait was not inserted.');
+      $this->assertEquals($trait_assets['trait'], $trait_combo['trait']->cvterm_id, 
+        'Test trait '. $combo['Trait Name'] .' was not inserted.');
       // Method.
-      $this->assertEquals($trait_assets['method'], $trait_combo['method']->cvterm_id, 'Test trait was not inserted.');
+      $this->assertEquals($trait_assets['method'], $trait_combo['method']->cvterm_id, 
+        'Test ' . $combo['Method Short Name'] . ' was not inserted.');
       // Unit.
-      $this->assertEquals($trait_assets['unit'], $trait_combo['unit']->cvterm_id, 'Test trait was not inserted.');
+      $this->assertEquals($trait_assets['unit'], $trait_combo['unit']->cvterm_id, 
+        'Test unit ' . $combo['Unit'] . ' was not inserted.');
     }
     
-    // At this point all traits should be in, test the relationships, connections and all.
+    // At this point, all traits should be in, test the relationships, connections and all.
+    
+    // Test nothing got inserted more than once and re-using a trait asset meant
+    // that it just referenced existing asset and not creating another copy
+    // in the same cv the genus is configured.
+    $reuse_test = [
+      'trait' => 'A Trait',   // Re-used 5x
+      'method' => 'B Method', // Re-used 5x
+      'unit' => 'C Unit'      // Re-used 2x
+    ];
+
+    foreach($reuse_test as $asset => $name) {
+      $exception_message = '';
+      
+      try {
+        // Use string trait asset name as parameter.
+        $this->service_traits->getTraitAsset($name, $asset);
+      }
+      catch (Exception $e) {
+        // The getter will throw an exception when it detected multiple copies
+        // of the same name in the same cv the genus is configured.
+        $exception_message = $e->getMessage();
+      }
+      
+      $this->assertEmpty($exception_message, 'Test trait asset ' . $asset . ':' . $name . ' was inserted more than once.');
+    }
+    
+    // Test that any trait asset can be retrieved either by using 
+    // name or id number as parameter using getTraitAsset() method.
+
+    // Test that by using id number and the id provided is an id for a trait asset that belongs
+    // to a cv not the cv set for the genus.
+
+    // term null with id 1 not in the genus.
+    /* Does not seem to catch and would kill the tests.
+    $exception_message = '';
+    try {
+      $this->service_traits->getTraitAsset(1, 'trait');
+    }
+    catch (Exception $e) {
+      $exception_message = $e->getMessage();
+    }
+    
+    $this->assertMatchesRegularExpression('/The requested trait asset (trait|method|unit)/', $exception_message, 
+      'Trait asset id provided returned an asset not in the cv the genus was configured.');
+    */
+
     foreach($test_combo as $combo) {
-      // Retrieve the trait.
-      // By string.
-      $t = $this->service_traits->getTrait($combo['Trait Name']);
-      $trait_id = (int) $t->cvterm_id;
-      $this->assertNotEquals($trait_id, 0, 'Failed to fetch the trait (by string trait name).');
+      foreach($keys as $key => $title) {
+        // Each combo, retrieve assets - trait, method and unit.
+        
+        // By string parameter.
+        $asset = $this->service_traits->getTraitAsset($combo[ $title ], $key);
+        $asset_bystring_id = (int) $asset->cvterm_id;
+        $this->assertNotEquals($asset_bystring_id, 0, 'Failed to fetch trait asset' . $key . ' : ' . $combo[ $title ] . ' (by string name parameter).');
 
-      // By id number.
-      $t = $this->service_traits->getTrait($trait_id);
-      $trait_id = (int) $t->cvterm_id;
-      $this->assertNotEquals($trait_id, 0, 'Failed to fetch the trait (by integer trait id).');
+        // By id number parameter.
+        $asset = $this->service_traits->getTraitAsset($asset_bystring_id, $key);
+        $asset_byinteger_id = (int) $asset->cvterm_id;
+        $this->assertNotEquals($asset_byinteger_id, 0, 'Failed to fetch trait asset' . $key . ' : ' . $combo[ $title ] . ' (by integer id parameter).');
+    
+        // Either cases both should match.
+        $this->assertEquals($asset_bystring_id, $asset_byinteger_id, 
+          'Trait id returned by trait asset getter with string and integer parameters do not match.');      
+      }
     }
 
-    // Base on the test data summary, test the case.
-    // A Trait has 3 methods - A, B, C Method.
-    // By string method name.
-    $m_s = $this->service_traits->getTraitMethod('A Trait');
+    // Test get trait using trait name or trait id number as parameter
+    // to getTrait() method.
+    foreach($test_combo as $combo) {
+      $name_key = 'Trait Name';
+      
+      // By string parameter.
+      $trait = $this->service_traits->getTrait($combo[ $name_key ]);
+      $trait_id = (int) $trait->cvterm_id;
+      $this->assertNotEquals($trait->cvterm_id, 0, 'Failed to fetch trait ' .  $combo[ $name_key ] . ' (by trait name parameter).');
+      
+      // By id number parameter.
+      $trait = $this->service_traits->getTrait($trait->cvterm_id);
+      $this->assertNotEquals($trait->cvterm_id, 0, 'Failed to fetch trait ' .  $combo[ $name_key ] . ' (by trait id parameter).');
+    
+      // Either cases both should match.
+      $this->assertEquals($trait_id, (int) $trait->cvterm_id, 
+        'Trait id returned by trait getter with string and integer parameters do not match.'); 
+    }
+
+    // Test get trait method using trait name or trait id as parameter
+    // to getTraitMethod() method.
+    
+    // Based on the summary of traits assets above, test the following.
+    // 1. A Trait has 3 methods - A, B, C Method.
+    // 2. C Trait has 1 method - D Method.
+    $a_trait_methods_byname = $this->service_traits->getTraitMethod('A Trait');
+    $a_trait = $this->service_traits->getTraitAsset('A Trait', 'trait');
+    $a_trait_methods_byid   = $this->service_traits->getTraitMethod($a_trait->cvterm_id);
+
+    // Assert that in both cases, the returned set of methods was the same.
+    // Then proceed to assert that methods returned are the expected methods.
+    $this->assertEquals($a_trait_methods_byname, $a_trait_methods_byid, 
+      'A Trait methods returned by methods getter with name and id as parameter do not match.');
+
+    // 3 methods in the set?
+    $methods_count = count($a_trait_methods_byid);
+    $this->assertEquals($methods_count, 3, 'A Trait methods returned by methods getter does not match expected count (3).'); 
+
     foreach(['A', 'B', 'C'] as $expected) {
+      $method_name = $expected . ' Method';
       $a_found = FALSE;
-      foreach($m_s as $a_m) {
-        if ($a_m->name == $expected . ' Method') {
+
+      foreach($a_trait_methods_byid as $a_m) {
+        if ($a_m->name == $method_name) {
           $a_found = TRUE;
+          break;
         }
       }
 
-      $this->assertTrue($a_found, 'A method for the test trait is missing (get by string method name).');
+      $this->assertTrue($a_found, 'The method ' . $method_name . ' was not found in the trait methods.');
     }
+    
+    // The same steps for C Trait.
+    $c_trait_methods_byname = $this->service_traits->getTraitMethod('C Trait');
+    $c_trait = $this->service_traits->getTraitAsset('C Trait', 'trait');
+    $c_trait_methods_byid   = $this->service_traits->getTraitMethod($c_trait->cvterm_id);
+    
+    $this->assertEquals($c_trait_methods_byname, $c_trait_methods_byid, 
+      'C Trait methods returned by methods getter with name and id as parameter do not match.');
+    
+    $methods_count = count($c_trait_methods_byid);
+    $this->assertEquals($methods_count, 1, 'C Trait methods returned by methods getter does not match expected count (1).'); 
+    
+    $this->assertEquals($c_trait_methods_byid[0]->name, 'D Method', 'The method D Method was not found in the trait methods.');
+    
+    // Test get unit method using method name or method id as parameter
+    // to getMethodUnit() method.
 
-    // Test by trait id.
-    $a_trait = $this->service_traits->getTrait('A Trait');
-    $a_trait_id = (int) $a_trait->cvterm_id;
-    $m_i = $this->service_traits->getTraitMethod($a_trait_id);
-    foreach(['A', 'B', 'C'] as $expected) {
+    // Based on the summary of traits assets above, test the following.
+    // B Method has 4 units - A, B, C, and D Unit
+    // D Method has 1 unit - E Unit
+
+    $b_method_units_byname = $this->service_traits->getMethodUnit('B Method');
+    $b_method = $this->service_traits->getTraitAsset('B Method', 'method');
+    $b_method_units_byid   = $this->service_traits->getMethodUnit($b_method->cvterm_id);
+
+    $this->assertEquals($b_method_units_byname, $b_method_units_byid, 
+      'B Method units returned by units getter with name and id as parameter do not match.');
+    
+    $units_count = count($b_method_units_byid);
+    $this->assertEquals($units_count, 4, 'B Method units returned by units getter does not match expected count (4).');
+
+    foreach(['A', 'B', 'C', 'D'] as $expected) {
+      $unit_name = $expected . ' Unit';
       $a_found = FALSE;
-      foreach($m_i as $a_m) {
-        if ($a_m->name == $expected . ' Method') {
+
+      foreach($b_method_units_byid as $a_u) {
+        if ($a_u->name == $unit_name) {
           $a_found = TRUE;
+          break;
         }
       }
 
-      $this->assertTrue($a_found, 'A method for the test trait is missing (get by integer method id).');
+      $this->assertTrue($a_found, 'The method unit ' . $unit_name . ' was not found in the method units.');
     }
+
+    // The same steps for D Method.
+    $d_method_units_byname = $this->service_traits->getMethodUnit('D Method');
+    $d_method = $this->service_traits->getTraitAsset('D Method', 'method');
+    $d_method_units_byid   = $this->service_traits->getMethodUnit($d_method->cvterm_id);
+
+    $this->assertEquals($d_method_units_byname, $d_method_units_byid, 
+      'D Method units returned by units getter with name and id as parameter do not match.');
+
+    $units_count = count($d_method_units_byid);
+    $this->assertEquals($units_count, 1, 'D Method units returned by units getter does not match expected count (1).');
+
+    $this->assertEquals($d_method_units_byid[0]->name, 'E Unit', 'The unit E Unit was not found in the method units.');
+
+    // Test get unit data type method using unit name or unit id as parameter
+    // to getMethodUnitDataType() method.
+    // From the trait asset insert test, E Unit was set to Qualitative data type.
+    $e_unit_type_byname = $this->service_traits->getMethodUnitDataType('E Unit');
+    $e_unit = $this->service_traits->getTraitAsset('E Unit', 'unit');
+    $e_unit_type_byid   = $this->service_traits->getMethodUnitDataType($e_unit->cvterm_id);
+
+    // Assert that in both cases, the returned data types were the same.
+    $this->assertEquals($e_unit_type_byname, $e_unit_type_byid, 
+      'E Unit data type returned by unit type getter with name and id as parameter do not match.');
+    
+    // Is it Quantitative?
+    $this->assertEquals($e_unit_type_byid, 'Quantitative', 
+      'E Unit data type returned by unit type getter does not match expected data type (Quantitative).');
   }
 
   /**
@@ -514,5 +670,8 @@ class ValidTraitTest extends ChadoTestKernelBase {
     $this->assertEquals($combo['trait']->name, $trait['trait'], 'Trait name does not match expected trait name.');
     $this->assertEquals($combo['method']->name, $trait['method'], 'Trait name does not match expected method name.');
     $this->assertEquals($combo['unit']->name, $trait['unit'], 'Trait name does not match expected unit name.');
+
+    // Check that the unit has extra property data type.
+    $this->assertEquals($combo['unit']->data_type, 'Quantitative', 'Unit data_type property value does not match expected type (Quantitative).');
   }
 }


### PR DESCRIPTION
**Issue #78 **

## Motivation
Given the trait name, method short name and unit name. allow trait service to pull record for each item.

<!-- This can usually be copied from the issue. Please do not just say, go see issue but instead copy the relevant details here. -->

## What does this PR do?
*Please describe each things this PR does. For example, a PR may 1) solve a specific bug, 2) create an auomated test to ensure it doesn't return.*

1. Fetch the record for trait, method and unit by the trait name, method name and unit name (alternatively, by trait id, method id and unit id).

## Testing
### Automated Testing
*Please describe each automated test this PR creates and provide a list of the assertions it makes using casual language.*
*Do not just say things like "asserts the array is not empty" but rather say "Ensures that the return value of method X with these parameters is not an empty array".*

Includes a unit test to test:
1. Any of the parameters is set to an empty string.
2. Any of the parametesrs is set to 0.
3. A non-existent trait
4. A non-existent method
5. A non-existent unit
6. All parameters of the same type (string - name)
7. All parameters of the same type (integer - id number)
8. A mix of string and integer.

### Manual Testing
*Describe in detail how someone should manually test this functionality.*
*Make sure to include whether they need to build a docker from scratch, create any records, etc.*
Add and configure a genus in your clone and in a PHP console or devel/php:
```
$service = \Drupal::service('trpcultivate_phenotypes.traits');
$service->setTraitGenus('Lens');

// Create trait, method and unit.
$trait = 'Your Trait Name';
$method = 'Your Method';
$unit = 'cm';

$combo = [
  'Trait Name' => $trait,
  'Trait Description' => 'Trait Description',
  'Method Short Name' => $method,    
  'Collection Method' => 'Pull the plant from the ground and measure', 
  'Unit' => $unit,
  'Type' => 'Quantitative'
];

$ins = $service->insertTrait($combo);
$my_combo = $service->getTraitMethodUnitCombo($trait, $method, $unit);
print_r($my_combo);

// print_r($ins);
// The insert trait method will return the inserted id number keyed by trait, method 
// and unit and can be used to test the combo method parameters type (fetch by id).
// Make sure to comment out the insert line to re-test using id numbers.

```
All 3 method parameters could take a string (name) or integer (id) values. 
