### PR TITLE
Fixes bug in ontology configuration form

### DIFF
--- a/trpcultivate_phenotypes/src/Form/TripalCultivatePhenotypesOntologySettingsForm.php
+++ b/trpcultivate_phenotypes/src/Form/TripalCultivatePhenotypesOntologySettingsForm.php
@@ -367,6 +367,7 @@ class TripalCultivatePhenotypesOntologySettingsForm extends ConfigFormBase {
     foreach($this->config_vars['ontology'] as $genus => $vars) {
       $var_set_ctr = 0;
       $fld_names = [];
+      $trait_cv_values = [];
 
       foreach($vars as $i => $config) {
         // Crop ontology is an optional field.
@@ -377,6 +378,12 @@ class TripalCultivatePhenotypesOntologySettingsForm extends ConfigFormBase {
         $fld_names[ $i ] = $genus . '_' . $config;
         if ((int) $form_state->getValue($fld_names[$i]) > 0) {
           $var_set_ctr++;
+        }
+
+        // Get the cv values set for trait, method and unit to
+        // check if each is a unique cv id.
+        if (in_array($config, ['trait', 'method', 'unit'])) {
+          $trait_cv_values[] = (int) $form_state->getValue($fld_names[ $i ]);
         }
       }
 
@@ -389,6 +396,14 @@ class TripalCultivatePhenotypesOntologySettingsForm extends ConfigFormBase {
             $form_state->setErrorByName($field, $this->t('Error: could not save form. Required field
               (GENUS: FIELD) @fld is empty.', [ '@fld' => str_replace('_', ' ', $field) ]));
           }
+        }
+
+        // Unique cv for trait, method and unit.
+        if ($trait_cv_values && count($trait_cv_values) != count(array_unique($trait_cv_values))) {
+          // A cv was re-used in the same genus.
+          $form_state->setErrorByName($field, $this->t('Error: Controlled Vocabulary (CV) value for Trait, Method and Unit must have unique values in GENUS: @genus.',
+            ['@genus' => ucfirst($genus)]
+          ));
         }
       }
     }

--- a/trpcultivate_phenotypes/tests/src/Functional/ConfigOntologyTermsTest.php
+++ b/trpcultivate_phenotypes/tests/src/Functional/ConfigOntologyTermsTest.php
@@ -151,6 +151,32 @@ class ConfigOntologyTermsTest extends ChadoTestBrowserBase {
 
     $values_genusontology = [];
 
+    // Test setting the same cv value for trait, method and unit in the same
+    // genus will trigger an error.
+    $j = 0;
+    foreach($genus_ontology as $genus => $vars) {
+      foreach($vars as $i => $config) {
+        $fld_name = $genus . '_' . $config;
+        // Test if each genus has a trait, unit, method, db and crop ontology field.
+        $session->fieldExists($fld_name);
+
+        if ($config == 'database') {
+          $set_val = $test_db_id[ $j ];
+          $j++;
+        }
+        else {
+          // Same cv.
+          $set_val = $test_cv_id[ 0 ];
+        }
+
+        $values_genusontology[ $fld_name ] = $set_val;
+      }
+    }
+
+    // Update default values.
+    $this->submitForm($values_genusontology, 'Save configuration');
+    $session->pageTextContains('Error: Controlled Vocabulary (CV) value for Trait, Method and Unit must have unique values');
+
     $j = 0;
     foreach($genus_ontology as $genus => $vars) {
       foreach($vars as $i => $config) {


### PR DESCRIPTION
**Issue #83 **

## Motivation
This bug was identified when fixing getter methods in Traits service as describe in this review comment.
https://github.com/TripalCultivate/TripalCultivate-Phenotypes/pull/81#issuecomment-2155314262

<!-- This can usually be copied from the issue. Please do not just say, go see issue but instead copy the relevant details here. -->

## What does this PR do?
*Please describe each things this PR does. For example, a PR may 1) solve a specific bug, 2) create an auomated test to ensure it doesn't return.*

1. Add a validation to inspect the CV values provided for Trait, Method and Unit field for each Genus and ensure that each one is a unique CV value.

## Testing

### Automated Testing
*Please describe each automated test this PR creates and provide a list of the assertions it makes using casual language.*
*Do not just say things like "asserts the array is not empty" but rather say "Ensures that the return value of method X with these parameters is not an empty array".*

Includes a test where CV for trait, method and unit field was set to the same value.

### Manual Testing
*Describe in detail how someone should manually test this functionality.*
*Make sure to include whether they need to build a docker from scratch, create any records, etc.*

1. Access the Ontology and terms configuration form.
my site/admin/tripal/extension/tripal-cultivate/phenotypes/ontology
2. Set the CV for Trait, Method and Unit to the same CV value. It can be all 3 fields or any two fields.
![image](https://github.com/TripalCultivate/TripalCultivate-Phenotypes/assets/15472253/7d169c60-9783-4cbb-806e-e8ce039540bd)
3. A form error massage will trigger when all 3 fields or at least 2 fields have the same cv value.
![image](https://github.com/TripalCultivate/TripalCultivate-Phenotypes/assets/15472253/df63e09e-e4bd-4384-a4a7-8620229f5b6e)
