### PR TITLE
G4.100 split row into columns

### DIFF
--- a/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
+++ b/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
@@ -508,8 +508,9 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
         // ********************************************************************
         // Skip empty lines
         else if (!empty(trim($line))) {
-          // Split line into an array
-          $data_row = str_getcsv($line, "\t");
+          // Split line into an array using the delimter defined by this importer
+          // in the configure values method above.
+          $data_row = $this->splitRowIntoColumns($line);
 
           // Call each validator on this row of the file
           foreach($validators['data-row'] as $validator_name => $validator) {

--- a/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
+++ b/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
@@ -508,9 +508,8 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
         // ********************************************************************
         // Skip empty lines
         else if (!empty(trim($line))) {
-          // Pass the line (string) and row validator handles separating values
-          // into an array based on the delimiter defined by this importer instance.
-          $data_row = $this->splitRowIntoColumns($line);
+          // Split line into an array
+          $data_row = str_getcsv($line, "\t");
 
           // Call each validator on this row of the file
           foreach($validators['data-row'] as $validator_name => $validator) {

--- a/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
+++ b/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
@@ -510,7 +510,7 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
         else if (!empty(trim($line))) {
           // Pass the line (string) and row validator handles separating values
           // into an array based on the delimiter defined by this importer instance.
-          $data_row = $line;
+          $data_row = $this->splitRowIntoColumns($line);
 
           // Call each validator on this row of the file
           foreach($validators['data-row'] as $validator_name => $validator) {

--- a/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
+++ b/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
@@ -12,7 +12,7 @@ use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\file\Entity\File;
 use Drupal\Core\Url;
-
+use Drupal\trpcultivate_phenotypes\TripalCultivateValidator\TripalCultivatePhenotypesValidatorBase;
 use Drupal\trpcultivate_phenotypes\Service\TripalCultivatePhenotypesTraitsService;
 
 /**
@@ -202,6 +202,7 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
     
     // This importer expects data in tab-separated values.
     // Delimiter: tabulator key - \t
+    // @TODO: use the delimiter setter.
     $context['delimiter'] = "\t";
 
     $instance->context = $context;
@@ -312,7 +313,7 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
       '#title' => 'Genus',
       '#description' => t('The genus of the germplasm being phenotyped with the supplied traits.
         Traits in this system are specific to the genus in order to ensure they are specific enough to accurately describe the phenotypes.
-        In order for genus to be availabe here is must be first configured in the Analyzed Phenotypes configuration.'),
+        In order for genus to be available here is must be first configured in the Analyzed Phenotypes configuration.'),
       '#empty_option' => '- Select -',
       '#options' => $active_genus,
       '#default_value' => $default_genus,
@@ -348,7 +349,7 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
 
     $file_id = $form_values['file_upload'];
 
-    // Use a variable to keep track of if one input type had recieved errors
+    // Use a variable to keep track of if one input type had received errors
     // and only continue to the next if no errors.
     $failed_validator = FALSE;
 
@@ -508,9 +509,9 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
         // ********************************************************************
         // Skip empty lines
         else if (!empty(trim($line))) {
-          // Split line into an array using the delimter defined by this importer
+          // Split line into an array using the delimiter defined by this importer
           // in the configure values method above.
-          $data_row = str_getcsv($line, "\t");
+          $data_row = TripalCultivatePhenotypesValidatorBase::splitRowIntoColumns($line);
 
           // Call each validator on this row of the file
           foreach($validators['data-row'] as $validator_name => $validator) {

--- a/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
+++ b/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
@@ -199,6 +199,10 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
       $header_index['Unit'],
       $header_index['Type']
     ];
+
+    // Delimiter for tab-separated values: \t
+    $context['delimiter'] = "\t";
+
     $instance->context = $context;
     $validators['data-row']['empty_cell'] = $instance;
 
@@ -503,8 +507,8 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
         // ********************************************************************
         // Skip empty lines
         else if (!empty(trim($line))) {
-          // Split line into an array
-          $data_row = str_getcsv($line, "\t");
+          $data_row = $line;
+
           // Call each validator on this row of the file
           foreach($validators['data-row'] as $validator_name => $validator) {
             $result = $validator->validateRow($data_row);

--- a/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
+++ b/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
@@ -480,8 +480,11 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
         // Header Row Validation
         // ********************************************************************
         if ($line_no == 1) {
+          // Split line into an array using the delimiter defined by this importer
+          // in the configure values method above.
+          $header_row = TripalCultivatePhenotypesValidatorBase::splitRowIntoColumns($line, $file_mime_type);
           foreach ($validators['header-row'] as $key => $validator) {
-            // @TODO: Update to use the validateRow() method
+            // @TODO: Update to use the validateRow() method and use the split $header_row above.
             $result = $validator->validate();
             $validation[$key] = $result;
             // Check for old style...

--- a/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
+++ b/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
@@ -199,8 +199,9 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
       $header_index['Unit'],
       $header_index['Type']
     ];
-
-    // Delimiter for tab-separated values: \t
+    
+    // This importer expects data in tab-separated values.
+    // Delimiter: tabulator key - \t
     $context['delimiter'] = "\t";
 
     $instance->context = $context;
@@ -507,6 +508,8 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
         // ********************************************************************
         // Skip empty lines
         else if (!empty(trim($line))) {
+          // Pass the line (string) and row validator handles separating values
+          // into an array based on the delimiter defined by this importer instance.
           $data_row = $line;
 
           // Call each validator on this row of the file

--- a/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
+++ b/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
@@ -199,12 +199,6 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
       $header_index['Unit'],
       $header_index['Type']
     ];
-    
-    // This importer expects data in tab-separated values.
-    // Delimiter: tabulator key - \t
-    // @TODO: use the delimiter setter.
-    $context['delimiter'] = "\t";
-
     $instance->context = $context;
     $validators['data-row']['empty_cell'] = $instance;
 
@@ -470,6 +464,8 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
       // Open and read file in this uri.
       $file_uri = $file->getFileUri();
       $handle = fopen($file_uri, 'r');
+      // Get the mime type which is used to split the row.
+      $file_mime_type = $file->getMimeType();
 
       // Line counter.
       $line_no = 0;
@@ -511,7 +507,7 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
         else if (!empty(trim($line))) {
           // Split line into an array using the delimiter defined by this importer
           // in the configure values method above.
-          $data_row = TripalCultivatePhenotypesValidatorBase::splitRowIntoColumns($line);
+          $data_row = TripalCultivatePhenotypesValidatorBase::splitRowIntoColumns($line, $file_mime_type);
 
           // Call each validator on this row of the file
           foreach($validators['data-row'] as $validator_name => $validator) {

--- a/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
+++ b/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
@@ -313,7 +313,7 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
       '#title' => 'Genus',
       '#description' => t('The genus of the germplasm being phenotyped with the supplied traits.
         Traits in this system are specific to the genus in order to ensure they are specific enough to accurately describe the phenotypes.
-        In order for genus to be available here is must be first configured in the Analyzed Phenotypes configuration.'),
+        In order for genus to be available here, it must be first configured in the Analyzed Phenotypes configuration.'),
       '#empty_option' => '- Select -',
       '#options' => $active_genus,
       '#default_value' => $default_genus,

--- a/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
+++ b/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
@@ -510,7 +510,7 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
         else if (!empty(trim($line))) {
           // Split line into an array using the delimter defined by this importer
           // in the configure values method above.
-          $data_row = $this->splitRowIntoColumns($line);
+          $data_row = str_getcsv($line, "\t");
 
           // Call each validator on this row of the file
           foreach($validators['data-row'] as $validator_name => $validator) {

--- a/trpcultivate_phenotypes/src/Plugin/Validators/DuplicateTraits.php
+++ b/trpcultivate_phenotypes/src/Plugin/Validators/DuplicateTraits.php
@@ -82,9 +82,10 @@ class DuplicateTraits extends TripalCultivatePhenotypesValidatorBase implements 
    * Validate the values within the cells of this row.
    *
    * @param array $row_values
-   *   The contents of the file's row where each value within a cell is
-   *   stored as an array element
-   *
+   *   A single line or row extracted from the data file 
+   *   containing data entries, values or column headers, with each value 
+   *   delimited by a character specified by the importer class. 
+   *    
    * @return array
    *   An associative array with the following keys:
    *   - title: string, section or title of the validation as it appears in the result window.
@@ -92,6 +93,8 @@ class DuplicateTraits extends TripalCultivatePhenotypesValidatorBase implements 
    *   - details: details about the offending field/value.
    */
   public function validateRow($row_values) {
+    // Split row values into an array.
+    $row_values = $this->splitRowIntoColumns($row_values);
 
     // Set our context which was configured for this validator
     $context = $this->context;

--- a/trpcultivate_phenotypes/src/Plugin/Validators/DuplicateTraits.php
+++ b/trpcultivate_phenotypes/src/Plugin/Validators/DuplicateTraits.php
@@ -82,9 +82,8 @@ class DuplicateTraits extends TripalCultivatePhenotypesValidatorBase implements 
    * Validate the values within the cells of this row.
    *
    * @param array $row_values
-   *   A single line or row extracted from the data file 
-   *   containing data entries, values or column headers, with each value 
-   *   delimited by a character specified by the importer class. 
+   *   The contents of the file's row where each value within a cell is
+   *   stored as an array element.
    *    
    * @return array
    *   An associative array with the following keys:
@@ -93,8 +92,6 @@ class DuplicateTraits extends TripalCultivatePhenotypesValidatorBase implements 
    *   - details: details about the offending field/value.
    */
   public function validateRow($row_values) {
-    // Split row values into an array.
-    $row_values = $this->splitRowIntoColumns($row_values);
 
     // Set our context which was configured for this validator
     $context = $this->context;

--- a/trpcultivate_phenotypes/src/Plugin/Validators/DuplicateTraits.php
+++ b/trpcultivate_phenotypes/src/Plugin/Validators/DuplicateTraits.php
@@ -84,7 +84,7 @@ class DuplicateTraits extends TripalCultivatePhenotypesValidatorBase implements 
    * @param array $row_values
    *   The contents of the file's row where each value within a cell is
    *   stored as an array element.
-   *    
+   *
    * @return array
    *   An associative array with the following keys:
    *   - title: string, section or title of the validation as it appears in the result window.

--- a/trpcultivate_phenotypes/src/Plugin/Validators/DuplicateTraits.php
+++ b/trpcultivate_phenotypes/src/Plugin/Validators/DuplicateTraits.php
@@ -37,7 +37,7 @@ class DuplicateTraits extends TripalCultivatePhenotypesValidatorBase implements 
    *     - 'Method Short Name': int, the index of the method name column in $row_values
    *     - 'Unit': int, the index of the unit column in $row_values
    */
-  public $context = [];
+  public array $context = [];
 
   /**
    * A nested array of already validated values forming the unique trait name +

--- a/trpcultivate_phenotypes/src/Plugin/Validators/EmptyCell.php
+++ b/trpcultivate_phenotypes/src/Plugin/Validators/EmptyCell.php
@@ -31,7 +31,7 @@ class EmptyCell extends TripalCultivatePhenotypesValidatorBase implements Contai
    *   This validator requires the following keys:
    *   - indices => an array of indices corresponding to the cells in $row_values to act on
    */
-  public $context = [];
+  public array $context = [];
 
   /**
    * Constructor.

--- a/trpcultivate_phenotypes/src/Plugin/Validators/EmptyCell.php
+++ b/trpcultivate_phenotypes/src/Plugin/Validators/EmptyCell.php
@@ -55,9 +55,8 @@ class EmptyCell extends TripalCultivatePhenotypesValidatorBase implements Contai
    * Validate the values within the cells of this row.
    *
    * @param array $row_values
-   *   A single line or row extracted from the data file 
-   *   containing data entries, values or column headers, with each value 
-   *   delimited by a character specified by the importer class. 
+   *   The contents of the file's row where each value within a cell is
+   *   stored as an array element.
    *
    * @return array
    *   An associative array with the following keys.
@@ -66,8 +65,6 @@ class EmptyCell extends TripalCultivatePhenotypesValidatorBase implements Contai
    *   - details: details about the offending field/value.
    */
   public function validateRow($row_values) {
-    // Split row values into an array.
-    $row_values = $this->splitRowIntoColumns($row_values);
 
     // Set our context which was configured for this validator
     $context = $this->context;

--- a/trpcultivate_phenotypes/src/Plugin/Validators/EmptyCell.php
+++ b/trpcultivate_phenotypes/src/Plugin/Validators/EmptyCell.php
@@ -55,8 +55,9 @@ class EmptyCell extends TripalCultivatePhenotypesValidatorBase implements Contai
    * Validate the values within the cells of this row.
    *
    * @param array $row_values
-   *   The contents of the file's row where each value within a cell is
-   *   stored as an array element
+   *   A single line or row extracted from the data file 
+   *   containing data entries, values or column headers, with each value 
+   *   delimited by a character specified by the importer class. 
    *
    * @return array
    *   An associative array with the following keys.
@@ -65,6 +66,8 @@ class EmptyCell extends TripalCultivatePhenotypesValidatorBase implements Contai
    *   - details: details about the offending field/value.
    */
   public function validateRow($row_values) {
+    // Split row values into an array.
+    $row_values = $this->splitRowIntoColumns($row_values);
 
     // Set our context which was configured for this validator
     $context = $this->context;

--- a/trpcultivate_phenotypes/src/Plugin/Validators/ValueInList.php
+++ b/trpcultivate_phenotypes/src/Plugin/Validators/ValueInList.php
@@ -58,8 +58,9 @@ class ValueInList extends TripalCultivatePhenotypesValidatorBase implements Cont
    * Validate the values within the cells of this row.
    *
    * @param array $row_values
-   *   The contents of the file's row where each value within a cell is
-   *   stored as an array element
+   *   A single line or row extracted from the data file 
+   *   containing data entries, values or column headers, with each value 
+   *   delimited by a character specified by the importer class. 
    *
    * @return array
    *   An associative array with the following keys.
@@ -68,6 +69,8 @@ class ValueInList extends TripalCultivatePhenotypesValidatorBase implements Cont
    *   - details: details about the offending field/value.
    */
   public function validateRow($row_values) {
+    // Split row values into an array.
+    $row_values = $this->splitRowIntoColumns($row_values);
 
     // Set our context which was configured for this validator
     $context = $this->context;

--- a/trpcultivate_phenotypes/src/Plugin/Validators/ValueInList.php
+++ b/trpcultivate_phenotypes/src/Plugin/Validators/ValueInList.php
@@ -58,9 +58,8 @@ class ValueInList extends TripalCultivatePhenotypesValidatorBase implements Cont
    * Validate the values within the cells of this row.
    *
    * @param array $row_values
-   *   A single line or row extracted from the data file 
-   *   containing data entries, values or column headers, with each value 
-   *   delimited by a character specified by the importer class. 
+   *   The contents of the file's row where each value within a cell is
+   *   stored as an array element.
    *
    * @return array
    *   An associative array with the following keys.
@@ -69,8 +68,6 @@ class ValueInList extends TripalCultivatePhenotypesValidatorBase implements Cont
    *   - details: details about the offending field/value.
    */
   public function validateRow($row_values) {
-    // Split row values into an array.
-    $row_values = $this->splitRowIntoColumns($row_values);
 
     // Set our context which was configured for this validator
     $context = $this->context;

--- a/trpcultivate_phenotypes/src/Plugin/Validators/ValueInList.php
+++ b/trpcultivate_phenotypes/src/Plugin/Validators/ValueInList.php
@@ -34,7 +34,7 @@ class ValueInList extends TripalCultivatePhenotypesValidatorBase implements Cont
    *   - valid_values => an array of values that are allowed within the cell(s) located
    *     at the indices specified in $context['indices']
    */
-  public $context = [];
+  public array $context = [];
 
   /**
    * Constructor.

--- a/trpcultivate_phenotypes/src/TripalCultivateValidator/TripalCultivatePhenotypesValidatorBase.php
+++ b/trpcultivate_phenotypes/src/TripalCultivateValidator/TripalCultivatePhenotypesValidatorBase.php
@@ -74,7 +74,7 @@ abstract class TripalCultivatePhenotypesValidatorBase extends PluginBase impleme
   /**
    * {@inheritdoc}
    */
-  public function validateRow(string $row_values) {
+  public function validateRow(array $row_values) {
     $plugin_name = $this->getValidatorName();
     throw new \Exception("Method validateRow() from base class called for $plugin_name. If this plugin wants to support this type of validation then they need to override it.");
   }

--- a/trpcultivate_phenotypes/src/TripalCultivateValidator/TripalCultivatePhenotypesValidatorBase.php
+++ b/trpcultivate_phenotypes/src/TripalCultivateValidator/TripalCultivatePhenotypesValidatorBase.php
@@ -231,9 +231,11 @@ abstract class TripalCultivatePhenotypesValidatorBase extends PluginBase impleme
    *   An array containing the values extracted from the line after splitting it based
    *   on a delimiter value.
    */
-  public function splitRowIntoColumns(string $row) {
+  public static function splitRowIntoColumns(string $row) {
     // Delimiter:
-    $delimiter = $this->context['delimiter'] ?? ''; 
+
+    // @TODO: use the delimiter getter.
+    $delimiter = "\t";
     if (empty($delimiter)) {
       throw new \Exception('No delimiter provided.');
     }

--- a/trpcultivate_phenotypes/src/TripalCultivateValidator/TripalCultivatePhenotypesValidatorBase.php
+++ b/trpcultivate_phenotypes/src/TripalCultivateValidator/TripalCultivatePhenotypesValidatorBase.php
@@ -5,6 +5,7 @@ namespace Drupal\trpcultivate_phenotypes\TripalCultivateValidator;
 use Drupal\Component\Plugin\PluginBase;
 
 abstract class TripalCultivatePhenotypesValidatorBase extends PluginBase implements TripalCultivatePhenotypesValidatorInterface {
+
   /**
    *   An associative array containing the needed context, which is dependant
    *   on the validator. For example, row level validators are passed the raw
@@ -15,7 +16,7 @@ abstract class TripalCultivatePhenotypesValidatorBase extends PluginBase impleme
    *   - delimiter => the delimiter to be passed to explode in order to break
    *     the raw row string into an array of columns.
    */
-  public $context = [];
+  public array $context = [];
 
   /**
    * Get validator plugin validator_name definition annotation value.
@@ -223,10 +224,10 @@ abstract class TripalCultivatePhenotypesValidatorBase extends PluginBase impleme
 
   /**
    * Split or explode a data file line/row values into an array using a delimiter.
-   * 
+   *
    * @param string $row
    *   A line in the data file.
-   * 
+   *
    * @return array
    *   An array containing the values extracted from the line after splitting it based
    *   on a delimiter value.
@@ -239,22 +240,22 @@ abstract class TripalCultivatePhenotypesValidatorBase extends PluginBase impleme
     if (empty($delimiter)) {
       throw new \Exception('No delimiter provided.');
     }
-    
+
     // Split the values.
     $values = explode($delimiter, $row);
 
     if (count($values) == 1 && $values[0] === $row) {
       // The delimiter failed to split the row and returned the original row.
-      throw new \Exception('The data row or line provided could not be split using the delimiter (' . $delimiter . ').');  
+      throw new \Exception('The data row or line provided could not be split using the delimiter (' . $delimiter . ').');
     }
 
     // Sanitize values.
     foreach($values as &$value) {
       if ($value) {
-        $value = trim(str_replace(['"','\''], '', $value)); 
+        $value = trim(str_replace(['"','\''], '', $value));
       }
     }
-    
+
     return $values;
   }
 }

--- a/trpcultivate_phenotypes/src/TripalCultivateValidator/TripalCultivatePhenotypesValidatorBase.php
+++ b/trpcultivate_phenotypes/src/TripalCultivateValidator/TripalCultivatePhenotypesValidatorBase.php
@@ -282,9 +282,10 @@ abstract class TripalCultivatePhenotypesValidatorBase extends PluginBase impleme
       }
 
       // Now lets choose the one with the most columns --shrugs-- not ideal
-      // but I'm not sure there is a better option.
+      // but I'm not sure there is a better option. asort() is from smallest
+      // to largest preserving the keys so we want to choose the last element.
       asort($counts);
-      $winning_delimiter = array_​key_​first($counts);
+      $winning_delimiter = array_key_last($counts);
       $columns = $results[ $winning_delimiter ];
       $delimiter = $winning_delimiter;
     }
@@ -292,7 +293,7 @@ abstract class TripalCultivatePhenotypesValidatorBase extends PluginBase impleme
     // Now lets double check that we got some values...
     if (count($columns) == 1 && $columns[0] === $row) {
       // The delimiter failed to split the row and returned the original row.
-      throw new \Exception('The data row or line provided could not be split using the delimiter (' . $delimiter . ').');
+      throw new \Exception('The data row or line provided could not be split into columns. The supported delimiter(s) are "' . implode('", "', $supported_delimiters) . '".');
     }
 
     // Sanitize values.

--- a/trpcultivate_phenotypes/src/TripalCultivateValidator/TripalCultivatePhenotypesValidatorBase.php
+++ b/trpcultivate_phenotypes/src/TripalCultivateValidator/TripalCultivatePhenotypesValidatorBase.php
@@ -5,6 +5,17 @@ namespace Drupal\trpcultivate_phenotypes\TripalCultivateValidator;
 use Drupal\Component\Plugin\PluginBase;
 
 abstract class TripalCultivatePhenotypesValidatorBase extends PluginBase implements TripalCultivatePhenotypesValidatorInterface {
+  /**
+   *   An associative array containing the needed context, which is dependant
+   *   on the validator. For example, row level validators are passed the raw
+   *   row from the file and thus need the importer to indicate how it should
+   *   be split.
+   *
+   *   Row level validators require the following key(s):
+   *   - delimiter => the delimiter to be passed to explode in order to break
+   *     the raw row string into an array of columns.
+   */
+  public $context = [];
 
   /**
    * Get validator plugin validator_name definition annotation value.
@@ -63,7 +74,7 @@ abstract class TripalCultivatePhenotypesValidatorBase extends PluginBase impleme
   /**
    * {@inheritdoc}
    */
-  public function validateRow(array $row_values) {
+  public function validateRow(string $row_values) {
     $plugin_name = $this->getValidatorName();
     throw new \Exception("Method validateRow() from base class called for $plugin_name. If this plugin wants to support this type of validation then they need to override it.");
   }
@@ -213,10 +224,9 @@ abstract class TripalCultivatePhenotypesValidatorBase extends PluginBase impleme
    *   on a delimiter value.
    */
   public function splitRowIntoColumns(string $row) {
-    // @TODO: use value set in $context.delimiter property.
-    $delimiter = '';
-    
-    if ($delimiter) {
+    // Delimiter:
+    $delimiter = $this->context['delimiter'] ?? ''; 
+    if (empty($delimiter)) {
       throw new \Exception(t('No delimiter provided.'));
     }
     

--- a/trpcultivate_phenotypes/src/TripalCultivateValidator/TripalCultivatePhenotypesValidatorBase.php
+++ b/trpcultivate_phenotypes/src/TripalCultivateValidator/TripalCultivatePhenotypesValidatorBase.php
@@ -258,7 +258,7 @@ abstract class TripalCultivatePhenotypesValidatorBase extends PluginBase impleme
     $delimiter = NULL;
     // If there is only one supported delimiter then we can simply split the row!
     if (sizeof($supported_delimiters) === 1) {
-      $delimiter = array_pop($supported_delimiters);
+      $delimiter = end($supported_delimiters);
       $columns = str_getcsv($row, $delimiter);
     }
     // Otherwise we will have to try to determine which one is "right"?!?

--- a/trpcultivate_phenotypes/src/TripalCultivateValidator/TripalCultivatePhenotypesValidatorBase.php
+++ b/trpcultivate_phenotypes/src/TripalCultivateValidator/TripalCultivatePhenotypesValidatorBase.php
@@ -227,7 +227,7 @@ abstract class TripalCultivatePhenotypesValidatorBase extends PluginBase impleme
     // Delimiter:
     $delimiter = $this->context['delimiter'] ?? ''; 
     if (empty($delimiter)) {
-      throw new \Exception(t('No delimiter provided.'));
+      throw new \Exception('No delimiter provided.');
     }
     
     // Split the values.
@@ -235,7 +235,7 @@ abstract class TripalCultivatePhenotypesValidatorBase extends PluginBase impleme
 
     if (count($values) == 1 && $values[0] === $row) {
       // The delimiter failed to split the row and returned the original row.
-      throw new \Exception(t('The data row or line provided could not be split using the delimiter.'));  
+      throw new \Exception('The data row or line provided could not be split using the delimiter (' . $delimiter . ').');  
     }
 
     // Sanitize values.

--- a/trpcultivate_phenotypes/src/TripalCultivateValidator/TripalCultivatePhenotypesValidatorBase.php
+++ b/trpcultivate_phenotypes/src/TripalCultivateValidator/TripalCultivatePhenotypesValidatorBase.php
@@ -201,4 +201,40 @@ abstract class TripalCultivatePhenotypesValidatorBase extends PluginBase impleme
 
     return $allownew;
   }
+
+  /**
+   * Split or explode a data file line/row values into an array using a delimiter.
+   * 
+   * @param string $row
+   *   A line in the data file.
+   * 
+   * @return array
+   *   An array containing the values extracted from the line after splitting it based
+   *   on a delimiter value.
+   */
+  public function splitRowIntoColumns(string $row) {
+    // @TODO: use value set in $context.delimiter property.
+    $delimiter = '';
+    
+    if ($delimiter) {
+      throw new \Exception(t('No delimiter provided.'));
+    }
+    
+    // Split the values.
+    $values = explode($delimiter, $row);
+
+    if (count($values) == 1 && $values[0] === $row) {
+      // The delimiter failed to split the row and returned the original row.
+      throw new \Exception(t('The data row or line provided could not be split using the delimiter.'));  
+    }
+
+    // Sanitize values.
+    foreach($values as &$value) {
+      if ($value) {
+        $value = trim(str_replace(['"','\''], '', $value)); 
+      }
+    }
+    
+    return $values;
+  }
 }

--- a/trpcultivate_phenotypes/src/TripalCultivateValidator/TripalCultivatePhenotypesValidatorBase.php
+++ b/trpcultivate_phenotypes/src/TripalCultivateValidator/TripalCultivatePhenotypesValidatorBase.php
@@ -81,6 +81,14 @@ abstract class TripalCultivatePhenotypesValidatorBase extends PluginBase impleme
 
   /**
    * {@inheritdoc}
+   */
+  public function validateRawRow(string $raw_row) {
+    $plugin_name = $this->getValidatorName();
+    throw new \Exception("Method validateRawRow() from base class called for $plugin_name. If this plugin wants to support this type of validation then they need to override it.");
+  }
+
+  /**
+   * {@inheritdoc}
    * @deprecated Remove in issue #91
    */
   public function validate() {

--- a/trpcultivate_phenotypes/src/TripalCultivateValidator/TripalCultivatePhenotypesValidatorBase.php
+++ b/trpcultivate_phenotypes/src/TripalCultivateValidator/TripalCultivatePhenotypesValidatorBase.php
@@ -170,7 +170,7 @@ abstract class TripalCultivatePhenotypesValidatorBase extends PluginBase impleme
    *   The validator plugin scope annotation definition value.
    */
   public function getValidatorScope() {
-    return $this->pluginDefinition['validator_scope'];
+    return (array_key_exists('validator_scope', $this->pluginDefinition)) ? $this->pluginDefinition['validator_scope'] : NULL;
   }
 
   /**

--- a/trpcultivate_phenotypes/src/TripalCultivateValidator/TripalCultivatePhenotypesValidatorBase.php
+++ b/trpcultivate_phenotypes/src/TripalCultivateValidator/TripalCultivatePhenotypesValidatorBase.php
@@ -265,6 +265,7 @@ abstract class TripalCultivatePhenotypesValidatorBase extends PluginBase impleme
     // in the FileType trait.
     $supported_delimiters = $mime_to_delimiter_mapping[ $mime_type ];
 
+    $delimiter = NULL;
     // If there is only one supported delimiter then we can simply split the row!
     if (sizeof($supported_delimiters) === 1) {
       $delimiter = array_pop($supported_delimiters);
@@ -285,6 +286,7 @@ abstract class TripalCultivatePhenotypesValidatorBase extends PluginBase impleme
       asort($counts);
       $winning_delimiter = array_​key_​first($counts);
       $columns = $results[ $winning_delimiter ];
+      $delimiter = $winning_delimiter;
     }
 
     // Now lets double check that we got some values...

--- a/trpcultivate_phenotypes/src/TripalCultivateValidator/TripalCultivatePhenotypesValidatorInterface.php
+++ b/trpcultivate_phenotypes/src/TripalCultivateValidator/TripalCultivatePhenotypesValidatorInterface.php
@@ -128,6 +128,12 @@ interface TripalCultivatePhenotypesValidatorInterface extends PluginInspectionIn
    * If you are validating the content of the columns then you should use
    * validateRow() instead.
    *
+   * NOTE: Currently this method assumes it will not be passed empty lines or
+   * comment lines... to the point it will throw an exception if it is. We should
+   * rethink this at a later point. Example: Many file formats have comments. These
+   * are not data rows and will not split properly BUT we may want to validate them
+   * in other ways and at a mimimum we may not want to say they are an error ;-p
+   *
    * @param string $raw_row
    *  A single line or row extracted from the data file
    *  containing data entries, values or column headers, with each value

--- a/trpcultivate_phenotypes/src/TripalCultivateValidator/TripalCultivatePhenotypesValidatorInterface.php
+++ b/trpcultivate_phenotypes/src/TripalCultivateValidator/TripalCultivatePhenotypesValidatorInterface.php
@@ -122,6 +122,31 @@ interface TripalCultivatePhenotypesValidatorInterface extends PluginInspectionIn
   public function validateRow(array $row_values);
 
   /**
+   * Validates rows within the data file submitted to an importer.
+   *
+   * @param string $raw_row
+   *  A single line or row extracted from the data file 
+   *  containing data entries, values or column headers, with each value 
+   *  delimited by a character specified by the importer class.
+   *
+   * @return array
+   *  An array of information about the validity of the data passed in.
+   *  The supported keys are:
+   *  - 'case': a developer code describing the case triggered
+   *      (i.e. no record in chado matching project name). If the data is
+   *      is valid then this is not required but could be 'data verified'.
+   *  - 'valid': a boolean indicating the data is valid (TRUE) or not (FALSE)
+   *  - 'failedIems': an array of the items that failed validation. For example,
+   *      if this validator validates that a number of indicies are not emptya then
+   *      this will be an array of indices that were empty. Another example is
+   *      that if this validator checks that a number of indices have values in
+   *      a specific list, then this array would use the index as the key and
+   *      the value the column actually had that was not in the list for each
+   *      failed column.
+   */
+  public function validateRawRow(string $raw_row);
+
+  /**
    * Given an array of values (that represents a single row in an input file),
    * check that the list in $indices is within the range of keys in $row_values.
    *

--- a/trpcultivate_phenotypes/src/TripalCultivateValidator/TripalCultivatePhenotypesValidatorInterface.php
+++ b/trpcultivate_phenotypes/src/TripalCultivateValidator/TripalCultivatePhenotypesValidatorInterface.php
@@ -95,9 +95,10 @@ interface TripalCultivatePhenotypesValidatorInterface extends PluginInspectionIn
   /**
    * Validates rows within the data file submitted to an importer.
    *
-   * @param array $row_values
-   *  An array of values from a single row/line in the file where each element
-   *  is a single column.
+   * @param string $row_values
+   *   A single line or row extracted from the data file 
+   *   containing data entries, values or column headers, with each value 
+   *   delimited by a character specified by the importer class. 
    *
    * @return array
    *  An array of information about the validity of the data passed in.
@@ -119,7 +120,7 @@ interface TripalCultivatePhenotypesValidatorInterface extends PluginInspectionIn
    *  - details: string describing the failure to users with failed items embedded.
    *  - status: one of 'pass' or 'fail'
    */
-  public function validateRow(array $row_values);
+  public function validateRow(string $row_values);
 
   /**
    * Given an array of values (that represents a single row in an input file),

--- a/trpcultivate_phenotypes/src/TripalCultivateValidator/TripalCultivatePhenotypesValidatorInterface.php
+++ b/trpcultivate_phenotypes/src/TripalCultivateValidator/TripalCultivatePhenotypesValidatorInterface.php
@@ -95,10 +95,9 @@ interface TripalCultivatePhenotypesValidatorInterface extends PluginInspectionIn
   /**
    * Validates rows within the data file submitted to an importer.
    *
-   * @param string $row_values
-   *   A single line or row extracted from the data file 
-   *   containing data entries, values or column headers, with each value 
-   *   delimited by a character specified by the importer class. 
+   * @param array $row_values
+   *  An array of values from a single row/line in the file where each element
+   *  is a single column.
    *
    * @return array
    *  An array of information about the validity of the data passed in.
@@ -120,7 +119,7 @@ interface TripalCultivatePhenotypesValidatorInterface extends PluginInspectionIn
    *  - details: string describing the failure to users with failed items embedded.
    *  - status: one of 'pass' or 'fail'
    */
-  public function validateRow(string $row_values);
+  public function validateRow(array $row_values);
 
   /**
    * Given an array of values (that represents a single row in an input file),

--- a/trpcultivate_phenotypes/src/TripalCultivateValidator/TripalCultivatePhenotypesValidatorInterface.php
+++ b/trpcultivate_phenotypes/src/TripalCultivateValidator/TripalCultivatePhenotypesValidatorInterface.php
@@ -124,9 +124,13 @@ interface TripalCultivatePhenotypesValidatorInterface extends PluginInspectionIn
   /**
    * Validates rows within the data file submitted to an importer.
    *
+   * Note: This should only be used when validating the format of the row.
+   * If you are validating the content of the columns then you should use
+   * validateRow() instead.
+   *
    * @param string $raw_row
-   *  A single line or row extracted from the data file 
-   *  containing data entries, values or column headers, with each value 
+   *  A single line or row extracted from the data file
+   *  containing data entries, values or column headers, with each value
    *  delimited by a character specified by the importer class.
    *
    * @return array

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorBaseTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorBaseTest.php
@@ -367,17 +367,14 @@ class ValidatorBaseTest extends ChadoTestKernelBase {
 
     // Delimiter is not present in the line and could not split the line.
     // This case will return the original line.
-    // @TODO: Use delimiter setter.
-    /*
-
-    $delimiter = '<the_delimiter>';
-    $str_line = implode('<not_the_delimiter>', $raw_line);
+    $delimiter = '<not_the_delimiter>';
+    $str_line = implode($delimiter, $raw_line);
 
     $exception_caught = FALSE;
     $exception_message = '';
 
     try {
-      $instance->splitRowIntoColumns($str_line);
+      $instance->splitRowIntoColumns($str_line, $expected_mime_type);
     }
     catch (\Exception $e) {
       $exception_caught = TRUE;
@@ -385,10 +382,8 @@ class ValidatorBaseTest extends ChadoTestKernelBase {
     }
 
     $this->assertTrue($exception_caught, 'Failed to catch exception when splitRowIntoColumns() could not split line using the delimiter.');
-    $this->assertStringContainsString('The data row or line provided could not be split using the delimiter (' . $delimiter . ')', $exception_message,
+    $this->assertStringContainsString('could not be split using the delimiter (' . $expected_delimiter . ')', $exception_message,
       'Expected exception message does not match message when splitRowIntoColumns() could not split line using the delimiter.');
-
-    */
 
     // Test that the sanitized line is the same as the split values.
     $delimiter = $expected_delimiter;

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorBaseTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorBaseTest.php
@@ -273,10 +273,6 @@ class ValidatorBaseTest extends ChadoTestKernelBase {
     );
 
     // Tests Base Class validateRow().
-    // Set the delimiter.
-    $context['delimiter'] = $this->delimiter;
-    $instance->context = $context;
-
     $exception_caught = NULL;
     $exception_message = NULL;
     try {

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorBaseTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorBaseTest.php
@@ -345,10 +345,10 @@ class ValidatorBaseTest extends ChadoTestKernelBase {
 
     // Create a data row.
     // This line captures data values with single/double quotes and leading/trailing spaces.
-    $line = $line_copy = ['Value A', 'Value "B"', 'Value \'C\'', 'Value D ', ' Value E', ' Value F ', ' Value G           '];
+    $good_line = $raw_line = ['Value A', 'Value "B"', 'Value \'C\'', 'Value D ', ' Value E', ' Value F ', ' Value G           '];
     // Sanitize the values so that the expected split values would be:
     // Value A, Value B, Value C, Value D, Value E, Value F and Value G.
-    foreach($line as &$l) {
+    foreach($good_line as &$l) {
       $l = trim(str_replace(['"','\''], '', $l)); 
     }
 
@@ -356,12 +356,12 @@ class ValidatorBaseTest extends ChadoTestKernelBase {
     
     // Test:
     // 1. Failed to specify a delimiter.
-    // 2. Test that delimiter is could not split the line.
+    // 2. Test that delimiter could not split the line.
     // 3. Line values and split values match. 
     // 4. Some other delimiter.
     
     // Failed to define a delimiter
-    $str_line = implode('~', $line_copy);
+    $str_line = implode('~', $raw_line);
 
     $exception_caught = FALSE;
     $exception_message = '';
@@ -382,7 +382,7 @@ class ValidatorBaseTest extends ChadoTestKernelBase {
     // Delimiter is not present in the line and could not split the line.
     // This case will return the original line.
     $instance->context['delimiter'] = '<the_delimiter>';  
-    $str_line = implode('<not_the_delimiter>', $line_copy);
+    $str_line = implode('<not_the_delimiter>', $raw_line);
     
     $exception_caught = FALSE;
     $exception_message = '';
@@ -396,22 +396,22 @@ class ValidatorBaseTest extends ChadoTestKernelBase {
     }
 
     $this->assertTrue($exception_caught, 'Failed to catch exception when splitRowIntoColumns() could not split line using the delimiter.');
-    $this->assertStringContainsString('The data row or line provided could not be split using the delimiter', $exception_message, 
+    $this->assertStringContainsString('The data row or line provided could not be split using the delimiter (' . $instance->context['delimiter'] . ')', $exception_message, 
       'Expected exception message does not match message when splitRowIntoColumns() could not split line using the delimiter.');
    
       
     // Test that the sanitized line is the same as the split values.
     // Test delimiter for tsv: tab.
     $instance->context['delimiter'] = $this->delimiter;
-    $str_line = implode($instance->context['delimiter'], $line_copy);
+    $str_line = implode($instance->context['delimiter'], $raw_line);
     $values = $instance->splitRowIntoColumns($str_line);
-    $this->assertEquals($line, $values, 'Line values does not match expected split values.');
+    $this->assertEquals($good_line, $values, 'Line values does not match expected split values.');
   
      
     // Test delimiter for csv: comma character.
     $instance->context['delimiter'] = ',';
-    $str_line = implode($instance->context['delimiter'], $line_copy);
+    $str_line = implode($instance->context['delimiter'], $raw_line);
     $values = $instance->splitRowIntoColumns($str_line);
-    $this->assertEquals($line, $values, 'Line values does not match expected split values.');
+    $this->assertEquals($good_line, $values, 'Line values does not match expected split values.');
   }
 }

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorBaseTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorBaseTest.php
@@ -157,6 +157,11 @@ class ValidatorBaseTest extends ChadoTestKernelBase {
     $returned_allownew = $instance->getConfigAllowNew();
     $this->assertEquals($expected_allownew, $returned_allownew,
       "We did not get the status for Allowing New configuration that we expected through the $validator_id validator.");
+
+    // check that the validator scope is not returned when it is not set.
+    // @deprecated Remove in issue #91
+    $scope = $instance->getValidatorScope();
+    $this->assertNull($scope, "The validator scope is not set for the $validator_id therefore no scope should be returned.");
   }
 
   /**
@@ -206,7 +211,8 @@ class ValidatorBaseTest extends ChadoTestKernelBase {
   }
 
   /**
-   * Test the validate methods: validateMetadata(), validateFile(), validateRow(), validate().
+   * Test the validate methods: validateMetadata(), validateFile(),
+   * validateRawRow(), validateRow(), validate().
    *
    * NOTE: These should all thrown an exception in the base class.
    */
@@ -265,6 +271,27 @@ class ValidatorBaseTest extends ChadoTestKernelBase {
       'Method validateFile() from base class',
       $exception_message,
       "We did not get the exception message we expected when calling BasicallyBase::validateFile()"
+    );
+
+    // Tests Base Class validateRawRow().
+    $exception_caught = NULL;
+    $exception_message = NULL;
+    try {
+      $row_values = ['col1', 'col2', 'col3', 'col4', 'col5'];
+      $row_string = implode("\t", $row_values);
+      $instance->validateRawRow($row_string);
+    } catch (\Exception $e) {
+      $exception_caught = TRUE;
+      $exception_message = $e->getMessage();
+    }
+    $this->assertTrue(
+      $exception_caught,
+      "We expect to have an exception thrown when calling BasicallyBase::validateRawRow() since it should use the base class version."
+    );
+    $this->assertStringContainsString(
+      'Method validateRawRow() from base class',
+      $exception_message,
+      "We did not get the exception message we expected when calling BasicallyBase::validateRawRow()"
     );
 
     // Tests Base Class validateRow().

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorBaseTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorBaseTest.php
@@ -342,6 +342,8 @@ class ValidatorBaseTest extends ChadoTestKernelBase {
     // 4. Some other delimiter.
     
     // Failed to define a delimiter
+    // @TODO: Use delimiter setter.
+    /*
     $str_line = implode('~', $raw_line);
 
     $exception_caught = FALSE;
@@ -358,7 +360,7 @@ class ValidatorBaseTest extends ChadoTestKernelBase {
     $this->assertTrue($exception_caught, 'Failed to catch exception when no delimiter defined in splitRowIntoColumns().');
     $this->assertStringContainsString('No delimiter provided', $exception_message, 
       'Expected exception message does not match message when no delimiter defined in splitRowIntoColumns().');
-    
+    */
     
     // Delimiter is not present in the line and could not split the line.
     // This case will return the original line.
@@ -391,7 +393,8 @@ class ValidatorBaseTest extends ChadoTestKernelBase {
     $str_line = implode($instance->context['delimiter'], $raw_line);
     $values = $instance->splitRowIntoColumns($str_line);
     $this->assertEquals($good_line, $values, 'Line values does not match expected split values.');
-  
+    
+    // @TODO: Use delimiter setter.
     /* 
     // Test delimiter for csv: comma character.
     $instance->context['delimiter'] = ',';

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorBaseTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorBaseTest.php
@@ -362,6 +362,9 @@ class ValidatorBaseTest extends ChadoTestKernelBase {
     
     // Delimiter is not present in the line and could not split the line.
     // This case will return the original line.
+    // @TODO: Use delimiter setter.
+    /*
+
     $instance->context['delimiter'] = '<the_delimiter>';  
     $str_line = implode('<not_the_delimiter>', $raw_line);
     
@@ -380,6 +383,7 @@ class ValidatorBaseTest extends ChadoTestKernelBase {
     $this->assertStringContainsString('The data row or line provided could not be split using the delimiter (' . $instance->context['delimiter'] . ')', $exception_message, 
       'Expected exception message does not match message when splitRowIntoColumns() could not split line using the delimiter.');
    
+    */  
       
     // Test that the sanitized line is the same as the split values.
     // Test delimiter for tsv: tab.
@@ -388,11 +392,12 @@ class ValidatorBaseTest extends ChadoTestKernelBase {
     $values = $instance->splitRowIntoColumns($str_line);
     $this->assertEquals($good_line, $values, 'Line values does not match expected split values.');
   
-     
+    /* 
     // Test delimiter for csv: comma character.
     $instance->context['delimiter'] = ',';
     $str_line = implode($instance->context['delimiter'], $raw_line);
     $values = $instance->splitRowIntoColumns($str_line);
     $this->assertEquals($good_line, $values, 'Line values does not match expected split values.');
+    */
   }
 }

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorBaseTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorBaseTest.php
@@ -329,7 +329,7 @@ class ValidatorBaseTest extends ChadoTestKernelBase {
   /**
    * Test line or row split method.
    */
-  public function testLineSplit() {
+  public function testSplitRowIntoColumns() {
     $configuration = [];
     $validator_id = 'fake_basically_base';
     $plugin_definition = [

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorBaseTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorBaseTest.php
@@ -330,77 +330,70 @@ class ValidatorBaseTest extends ChadoTestKernelBase {
     // Sanitize the values so that the expected split values would be:
     // Value A, Value B, Value C, Value D, Value E, Value F and Value G.
     foreach($good_line as &$l) {
-      $l = trim(str_replace(['"','\''], '', $l)); 
+      $l = trim(str_replace(['"','\''], '', $l));
     }
 
+    // @todo test all supported mime-types.
+    $expected_mime_type = 'text/tab-separated-values';
+    $expected_delimiter = "\t";
+
     // At this point line is sanitized and sparkling*
-    
+
     // Test:
     // 1. Failed to specify a delimiter.
     // 2. Test that delimiter could not split the line.
-    // 3. Line values and split values match. 
+    // 3. Line values and split values match.
     // 4. Some other delimiter.
-    
-    // Failed to define a delimiter
-    // @TODO: Use delimiter setter.
-    /*
-    $str_line = implode('~', $raw_line);
+
+    // Unsupported mime type and thus unknown delimiter.
+    $delimiter = '~';
+    $str_line = implode($delimiter, $raw_line);
 
     $exception_caught = FALSE;
     $exception_message = '';
 
     try {
-      $instance->splitRowIntoColumns($str_line);
-    } 
+      $instance->splitRowIntoColumns($str_line, 'text/uncertain');
+    }
     catch (\Exception $e) {
       $exception_caught = TRUE;
       $exception_message = $e->getMessage();
     }
 
     $this->assertTrue($exception_caught, 'Failed to catch exception when no delimiter defined in splitRowIntoColumns().');
-    $this->assertStringContainsString('No delimiter provided', $exception_message, 
-      'Expected exception message does not match message when no delimiter defined in splitRowIntoColumns().');
-    */
-    
+    $this->assertStringContainsString(
+      'mime type "text/uncertain" passed into splitRowIntoColumns() is not supported', $exception_message,
+      'We did not get the expected message when an unknown mime type is passed into splitRowIntoColumns().');
+
     // Delimiter is not present in the line and could not split the line.
     // This case will return the original line.
     // @TODO: Use delimiter setter.
     /*
 
-    $instance->context['delimiter'] = '<the_delimiter>';  
+    $delimiter = '<the_delimiter>';
     $str_line = implode('<not_the_delimiter>', $raw_line);
-    
+
     $exception_caught = FALSE;
     $exception_message = '';
 
     try {
       $instance->splitRowIntoColumns($str_line);
-    } 
+    }
     catch (\Exception $e) {
       $exception_caught = TRUE;
       $exception_message = $e->getMessage();
     }
 
     $this->assertTrue($exception_caught, 'Failed to catch exception when splitRowIntoColumns() could not split line using the delimiter.');
-    $this->assertStringContainsString('The data row or line provided could not be split using the delimiter (' . $instance->context['delimiter'] . ')', $exception_message, 
+    $this->assertStringContainsString('The data row or line provided could not be split using the delimiter (' . $delimiter . ')', $exception_message,
       'Expected exception message does not match message when splitRowIntoColumns() could not split line using the delimiter.');
-   
-    */  
-      
-    // Test that the sanitized line is the same as the split values.
-    // Test delimiter for tsv: tab.
-    $instance->context['delimiter'] = "\t";
-    $str_line = implode($instance->context['delimiter'], $raw_line);
-    $values = $instance->splitRowIntoColumns($str_line);
-    $this->assertEquals($good_line, $values, 'Line values does not match expected split values.');
-    
-    // @TODO: Use delimiter setter.
-    /* 
-    // Test delimiter for csv: comma character.
-    $instance->context['delimiter'] = ',';
-    $str_line = implode($instance->context['delimiter'], $raw_line);
-    $values = $instance->splitRowIntoColumns($str_line);
-    $this->assertEquals($good_line, $values, 'Line values does not match expected split values.');
+
     */
+
+    // Test that the sanitized line is the same as the split values.
+    $delimiter = $expected_delimiter;
+    $str_line = implode($delimiter, $raw_line);
+    $values = $instance->splitRowIntoColumns($str_line, $expected_mime_type);
+    $this->assertEquals($good_line, $values, 'Line values does not match expected split values.');
   }
 }

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorBaseTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorBaseTest.php
@@ -37,6 +37,11 @@ class ValidatorBaseTest extends ChadoTestKernelBase {
   private $config;
 
   /**
+   * Delimiter for TSV file format.
+   */
+  private $delimiter = "\t";
+
+  /**
    * Modules to enable.
    */
   protected static $modules = [
@@ -88,10 +93,15 @@ class ValidatorBaseTest extends ChadoTestKernelBase {
       'Qualitative'
     ];
 
+    $file_row = implode($this->delimiter, $file_row);
+
     // ERROR CASES
 
     // Provide an empty array of indices
     $context['indices'] = [];
+    // Set the delimiter.
+    $context['delimiter'] = $this->delimiter;
+
     $instance->context = $context;
     $exception_caught = FALSE;
     try {
@@ -273,6 +283,10 @@ class ValidatorBaseTest extends ChadoTestKernelBase {
     );
 
     // Tests Base Class validateRow().
+    // Set the delimiter.
+    $context['delimiter'] = $this->delimiter;
+    $instance->context = $context;
+
     $exception_caught = NULL;
     $exception_message = NULL;
     try {
@@ -346,7 +360,7 @@ class ValidatorBaseTest extends ChadoTestKernelBase {
     // 3. Line values and split values match. 
     // 4. Some other delimiter.
     
-    // Failed to defnie a delimiter
+    // Failed to define a delimiter
     $str_line = implode('~', $line_copy);
 
     $exception_caught = FALSE;
@@ -388,7 +402,7 @@ class ValidatorBaseTest extends ChadoTestKernelBase {
       
     // Test that the sanitized line is the same as the split values.
     // Test delimiter for tsv: tab.
-    $instance->context['delimiter'] = '\t';
+    $instance->context['delimiter'] = $this->delimiter;
     $str_line = implode($instance->context['delimiter'], $line_copy);
     $values = $instance->splitRowIntoColumns($str_line);
     $this->assertEquals($line, $values, 'Line values does not match expected split values.');

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorBaseTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorBaseTest.php
@@ -308,9 +308,36 @@ class ValidatorBaseTest extends ChadoTestKernelBase {
   }
 
   /**
-   * Test line or row split method.
+   * DATA PROVIDER: tests the split row by providing mime type to delimiter options.
    */
-  public function testSplitRowIntoColumns() {
+  public function provideMimeTypeDelimiters() {
+    $sets = [];
+
+    $sets[] = [
+      'text/tab-separated-values',
+      "\t",
+    ];
+
+    $sets[] = [
+      'text/csv',
+      ','
+    ];
+
+    $sets[] = [
+      'text/plain',
+      ','
+    ];
+
+    return $sets;
+  }
+
+  /**
+   * Test line or row split method.
+   *
+   * @dataProvider provideMimeTypeDelimiters
+   */
+  public function testSplitRowIntoColumns(string $expected_mime_type, string $expected_delimiter) {
+
     $configuration = [];
     $validator_id = 'fake_basically_base';
     $plugin_definition = [
@@ -332,10 +359,6 @@ class ValidatorBaseTest extends ChadoTestKernelBase {
     foreach($good_line as &$l) {
       $l = trim(str_replace(['"','\''], '', $l));
     }
-
-    // @todo test all supported mime-types.
-    $expected_mime_type = 'text/tab-separated-values';
-    $expected_delimiter = "\t";
 
     // At this point line is sanitized and sparkling*
 
@@ -382,7 +405,8 @@ class ValidatorBaseTest extends ChadoTestKernelBase {
     }
 
     $this->assertTrue($exception_caught, 'Failed to catch exception when splitRowIntoColumns() could not split line using the delimiter.');
-    $this->assertStringContainsString('could not be split using the delimiter (' . $expected_delimiter . ')', $exception_message,
+    $this->assertStringContainsString(
+      'line provided could not be split into columns', $exception_message,
       'Expected exception message does not match message when splitRowIntoColumns() could not split line using the delimiter.');
 
     // Test that the sanitized line is the same as the split values.

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorBaseTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorBaseTest.php
@@ -37,11 +37,6 @@ class ValidatorBaseTest extends ChadoTestKernelBase {
   private $config;
 
   /**
-   * Delimiter for TSV file format.
-   */
-  private $delimiter = "\t";
-
-  /**
    * Modules to enable.
    */
   protected static $modules = [
@@ -93,15 +88,10 @@ class ValidatorBaseTest extends ChadoTestKernelBase {
       'Qualitative'
     ];
 
-    $file_row = implode($this->delimiter, $file_row);
-
     // ERROR CASES
 
     // Provide an empty array of indices
     $context['indices'] = [];
-    // Set the delimiter.
-    $context['delimiter'] = $this->delimiter;
-
     $instance->context = $context;
     $exception_caught = FALSE;
     try {
@@ -290,7 +280,7 @@ class ValidatorBaseTest extends ChadoTestKernelBase {
     $exception_caught = NULL;
     $exception_message = NULL;
     try {
-      $row_values = implode("\t", ['col1', 'col2', 'col3', 'col4', 'col5']);
+      $row_values = ['col1', 'col2', 'col3', 'col4', 'col5'];
       $instance->validateRow($row_values);
     } catch (\Exception $e) {
       $exception_caught = TRUE;
@@ -402,7 +392,7 @@ class ValidatorBaseTest extends ChadoTestKernelBase {
       
     // Test that the sanitized line is the same as the split values.
     // Test delimiter for tsv: tab.
-    $instance->context['delimiter'] = $this->delimiter;
+    $instance->context['delimiter'] = "\t";
     $str_line = implode($instance->context['delimiter'], $raw_line);
     $values = $instance->splitRowIntoColumns($str_line);
     $this->assertEquals($good_line, $values, 'Line values does not match expected split values.');

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorFileRowScopeTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorFileRowScopeTest.php
@@ -38,6 +38,11 @@ class ValidatorFileRowScopeTest extends ChadoTestKernelBase {
   private $config;
 
   /**
+   * Delimiter for TSV file format.
+   */
+  private $delimiter = "\t";
+
+  /**
    * Modules to enable.
    */
   protected static $modules = [
@@ -92,8 +97,11 @@ class ValidatorFileRowScopeTest extends ChadoTestKernelBase {
     // Case #1: Check for a valid value in a single column
     $expected_status = 'pass';
     $context['indices'] = [ 5 ];
+    // Set the delimiter.
+    $context['delimiter'] = $this->delimiter;
     $context['valid_values'] = [ 'Qualitative', 'Quantitative' ];
     $instance->context = $context;
+    $file_row = implode($this->delimiter, $file_row);
     $validation_status = $instance->validateRow($file_row);
     $this->assertEquals($expected_status, $validation_status['status'], "Value in list validation was expected to pass when provided a cell with a valid value in the list.");
     $this->assertStringContainsString('Value at index 5 was one of:', $validation_status['details'], "Value in list validation details did not report that index 5 contained a valid value.");
@@ -158,7 +166,10 @@ class ValidatorFileRowScopeTest extends ChadoTestKernelBase {
     // Case #1: Provide a list of indices for cells that are not empty
     $expected_status = 'pass';
     $context['indices'] = [ 0, 2, 4 ];
+    // Set the delimiter.
+    $context['delimiter'] = $this->delimiter;
     $instance->context = $context;
+    $file_row = implode($this->delimiter, $file_row);
     $validation_status = $instance->validateRow($file_row);
     $this->assertEquals($expected_status, $validation_status['status'], "Empty cell validation was expected to pass when provided only non-empty cells to check.");
 

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorFileRowScopeTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorFileRowScopeTest.php
@@ -38,11 +38,6 @@ class ValidatorFileRowScopeTest extends ChadoTestKernelBase {
   private $config;
 
   /**
-   * Delimiter for TSV file format.
-   */
-  private $delimiter = "\t";
-
-  /**
    * Modules to enable.
    */
   protected static $modules = [
@@ -97,11 +92,8 @@ class ValidatorFileRowScopeTest extends ChadoTestKernelBase {
     // Case #1: Check for a valid value in a single column
     $expected_status = 'pass';
     $context['indices'] = [ 5 ];
-    // Set the delimiter.
-    $context['delimiter'] = $this->delimiter;
     $context['valid_values'] = [ 'Qualitative', 'Quantitative' ];
     $instance->context = $context;
-    $file_row = implode($this->delimiter, $file_row);
     $validation_status = $instance->validateRow($file_row);
     $this->assertEquals($expected_status, $validation_status['status'], "Value in list validation was expected to pass when provided a cell with a valid value in the list.");
     $this->assertStringContainsString('Value at index 5 was one of:', $validation_status['details'], "Value in list validation details did not report that index 5 contained a valid value.");
@@ -166,10 +158,7 @@ class ValidatorFileRowScopeTest extends ChadoTestKernelBase {
     // Case #1: Provide a list of indices for cells that are not empty
     $expected_status = 'pass';
     $context['indices'] = [ 0, 2, 4 ];
-    // Set the delimiter.
-    $context['delimiter'] = $this->delimiter;
     $instance->context = $context;
-    $file_row = implode($this->delimiter, $file_row);
     $validation_status = $instance->validateRow($file_row);
     $this->assertEquals($expected_status, $validation_status['status'], "Empty cell validation was expected to pass when provided only non-empty cells to check.");
 

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorTraitImporterTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorTraitImporterTest.php
@@ -55,7 +55,12 @@ class ValidatorTraitImporterTest extends ChadoTestKernelBase {
    */
   protected $service_traits;
 
-    /**
+  /**
+   * Delimiter for TSV file format.
+   */
+  private $delimiter = "\t";
+
+  /**
    * Modules to enable.
    */
   protected static $modules = [
@@ -115,6 +120,9 @@ class ValidatorTraitImporterTest extends ChadoTestKernelBase {
     $validator_id = 'duplicate_traits';
     $instance = $this->plugin_manager->createInstance($validator_id);
 
+    // Set the delimiter.
+    $context['delimiter'] = $this->delimiter;
+
     // Set the genus in the $context array
     $context['genus'] = 'Tripalus';
 
@@ -127,6 +135,8 @@ class ValidatorTraitImporterTest extends ChadoTestKernelBase {
       'My unit',
       'Quantitative'
     ];
+
+    $file_row = implode($this->delimiter, $file_row);
 
     // Default case: Enter a single row of data
     $expected_status = 'pass';
@@ -166,6 +176,8 @@ class ValidatorTraitImporterTest extends ChadoTestKernelBase {
       'My unit 2'
     ];
 
+    $file_row_2 = implode($this->delimiter, $file_row_2);
+
     $expected_status = 'pass';
     $context['indices'] = [ 'Trait Name' => 0, 'Method Short Name' => 2, 'Unit' => 5 ];
     $instance->context = $context;
@@ -184,6 +196,8 @@ class ValidatorTraitImporterTest extends ChadoTestKernelBase {
       'My unit 2',
       'Qualitative'
     ];
+
+    $file_row_3 = implode($this->delimiter, $file_row_3);
 
     $expected_status = 'pass';
     $context['indices'] = [ 'Trait Name' => 0, 'Method Short Name' => 2, 'Unit' => 4 ];
@@ -205,6 +219,9 @@ class ValidatorTraitImporterTest extends ChadoTestKernelBase {
     // Create a plugin instance for this validator
     $validator_id = 'duplicate_traits';
     $instance = $this->plugin_manager->createInstance($validator_id);
+    
+    // Set the delimiter.
+    $context['delimiter'] = $this->delimiter;
 
     // Set the genus and indices in the $context array
     // For this test method, the context array only needs to be set once
@@ -226,7 +243,8 @@ class ValidatorTraitImporterTest extends ChadoTestKernelBase {
     // Create a simplified array without assigning the column headers as keys
     // for use with our validator directly
     $file_row = array_values($file_row_default);
-
+    $file_row = implode($this->delimiter, $file_row);
+    
     // Default case: Validate a single row and check against an empty database
     $expected_status = 'pass';
     $validation_status = $instance->validateRow($file_row);
@@ -256,6 +274,7 @@ class ValidatorTraitImporterTest extends ChadoTestKernelBase {
     // Now that the trait is confirmed to be in the database, our validator should
     // return a fail status when trying to validate the same trait again
     $expected_status = 'fail';
+    $file_row_1 = implode($this->delimiter, $file_row_1);
     $validation_status = $instance->validateRow($file_row_1);
     $this->assertEquals($expected_status, $validation_status['status'], "Duplicate Trait validation was expected to fail when provided a row of values for which there already exists a trait+method+unit combo in the database.");
 
@@ -272,6 +291,7 @@ class ValidatorTraitImporterTest extends ChadoTestKernelBase {
     $file_row_2 = array_values($file_row_case_2);
 
     $expected_status = 'pass';
+    $file_row_2 = implode($this->delimiter, $file_row_2);
     $validation_status = $instance->validateRow($file_row_2);
     $this->assertEquals($expected_status, $validation_status['status'], "Duplicate Trait validation was expected to pass when provided the second row of values to validate the situation where trait and method are in the database but the unit is not.");
 
@@ -294,6 +314,7 @@ class ValidatorTraitImporterTest extends ChadoTestKernelBase {
 
     $combo_ids_3 = $this->service_traits->insertTrait($file_row_case_3);
     $expected_status = 'fail';
+    $file_row_3 = implode($this->delimiter, $file_row_3);
     $validation_status = $instance->validateRow($file_row_3);
     $this->assertEquals($expected_status, $validation_status['status'], "Duplicate Trait validation was expected to fail when provided the third row of values to validate where trait + method + unit already exist in the database.");
     // Check that we are getting the right error code for a database duplicate

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorTraitImporterTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorTraitImporterTest.php
@@ -223,7 +223,7 @@ class ValidatorTraitImporterTest extends ChadoTestKernelBase {
     // Create a simplified array without assigning the column headers as keys
     // for use with our validator directly
     $file_row = array_values($file_row_default);
-    
+
     // Default case: Validate a single row and check against an empty database
     $expected_status = 'pass';
     $validation_status = $instance->validateRow($file_row);

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorTraitImporterTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorTraitImporterTest.php
@@ -56,11 +56,6 @@ class ValidatorTraitImporterTest extends ChadoTestKernelBase {
   protected $service_traits;
 
   /**
-   * Delimiter for TSV file format.
-   */
-  private $delimiter = "\t";
-
-  /**
    * Modules to enable.
    */
   protected static $modules = [
@@ -120,9 +115,6 @@ class ValidatorTraitImporterTest extends ChadoTestKernelBase {
     $validator_id = 'duplicate_traits';
     $instance = $this->plugin_manager->createInstance($validator_id);
 
-    // Set the delimiter.
-    $context['delimiter'] = $this->delimiter;
-
     // Set the genus in the $context array
     $context['genus'] = 'Tripalus';
 
@@ -135,8 +127,6 @@ class ValidatorTraitImporterTest extends ChadoTestKernelBase {
       'My unit',
       'Quantitative'
     ];
-
-    $file_row = implode($this->delimiter, $file_row);
 
     // Default case: Enter a single row of data
     $expected_status = 'pass';
@@ -176,8 +166,6 @@ class ValidatorTraitImporterTest extends ChadoTestKernelBase {
       'My unit 2'
     ];
 
-    $file_row_2 = implode($this->delimiter, $file_row_2);
-
     $expected_status = 'pass';
     $context['indices'] = [ 'Trait Name' => 0, 'Method Short Name' => 2, 'Unit' => 5 ];
     $instance->context = $context;
@@ -196,8 +184,6 @@ class ValidatorTraitImporterTest extends ChadoTestKernelBase {
       'My unit 2',
       'Qualitative'
     ];
-
-    $file_row_3 = implode($this->delimiter, $file_row_3);
 
     $expected_status = 'pass';
     $context['indices'] = [ 'Trait Name' => 0, 'Method Short Name' => 2, 'Unit' => 4 ];
@@ -219,9 +205,6 @@ class ValidatorTraitImporterTest extends ChadoTestKernelBase {
     // Create a plugin instance for this validator
     $validator_id = 'duplicate_traits';
     $instance = $this->plugin_manager->createInstance($validator_id);
-    
-    // Set the delimiter.
-    $context['delimiter'] = $this->delimiter;
 
     // Set the genus and indices in the $context array
     // For this test method, the context array only needs to be set once
@@ -243,7 +226,6 @@ class ValidatorTraitImporterTest extends ChadoTestKernelBase {
     // Create a simplified array without assigning the column headers as keys
     // for use with our validator directly
     $file_row = array_values($file_row_default);
-    $file_row = implode($this->delimiter, $file_row);
     
     // Default case: Validate a single row and check against an empty database
     $expected_status = 'pass';
@@ -274,7 +256,6 @@ class ValidatorTraitImporterTest extends ChadoTestKernelBase {
     // Now that the trait is confirmed to be in the database, our validator should
     // return a fail status when trying to validate the same trait again
     $expected_status = 'fail';
-    $file_row_1 = implode($this->delimiter, $file_row_1);
     $validation_status = $instance->validateRow($file_row_1);
     $this->assertEquals($expected_status, $validation_status['status'], "Duplicate Trait validation was expected to fail when provided a row of values for which there already exists a trait+method+unit combo in the database.");
 
@@ -291,7 +272,6 @@ class ValidatorTraitImporterTest extends ChadoTestKernelBase {
     $file_row_2 = array_values($file_row_case_2);
 
     $expected_status = 'pass';
-    $file_row_2 = implode($this->delimiter, $file_row_2);
     $validation_status = $instance->validateRow($file_row_2);
     $this->assertEquals($expected_status, $validation_status['status'], "Duplicate Trait validation was expected to pass when provided the second row of values to validate the situation where trait and method are in the database but the unit is not.");
 
@@ -314,7 +294,6 @@ class ValidatorTraitImporterTest extends ChadoTestKernelBase {
 
     $combo_ids_3 = $this->service_traits->insertTrait($file_row_case_3);
     $expected_status = 'fail';
-    $file_row_3 = implode($this->delimiter, $file_row_3);
     $validation_status = $instance->validateRow($file_row_3);
     $this->assertEquals($expected_status, $validation_status['status'], "Duplicate Trait validation was expected to fail when provided the third row of values to validate where trait + method + unit already exist in the database.");
     // Check that we are getting the right error code for a database duplicate


### PR DESCRIPTION
## Issue #100 

## Motivation

<!-- This can usually be copied from the issue. Please do not just say, go see issue but instead copy the relevant details here. -->

Create a method that will split or explode a line from the data file into columns using a delimiter chosen based on the mime type of the file.

This PR will 
1. update the importer form validate to pass a string value (the raw data row/line) to validateRawRow() in the importer
2. provide a static splitRowIntoColumns() method so the importer can split the row based on the mime type of the file.
3. ensure all automated testing checks this new approach.

## Testing

### Automated Testing
*Please describe each automated test this PR creates and provide a list of the assertions it makes using casual language.*
*Do not just say things like "asserts the array is not empty" but rather say "Ensures that the return value of method X with these parameters is not an empty array".*

ValidatorBaseTest - testSplitRowIntoColumns()
1. Test case where no delimiter
2. The method return the same line (delimiter could not split the row)
3. Test that the line was split and that each value was sanitized
4. Test basic row input
5. Do validation 1-4 for all supported mime types.

### Manual Testing
*Describe in detail how someone should manually test this functionality.*
*Make sure to include whether they need to build a docker from scratch, create any records, etc.*

In my site/devel/php of a working T4 clone, paste the code block and execute. The line array and/or the delimiter character can be altered to other value to test other set of values.

```
// LINE:
$line = ['Value A', 'Value "B"', 'Value \'C\'', 'Value D ', ' Value E', ' Value F ', ' Value G           '];

// MIME TYPE:
$mime_type = 'text/tab-separated-values';
$delimiter = "\t";

$str_line = implode($delimiter, $line);
$split_row = \Drupal\trpcultivate_phenotypes\TripalCultivateValidator\TripalCultivatePhenotypesValidatorBase::splitRowIntoColumns($str_line, $mime_type);

print_r($split_row);
```

The method includes sanitizing value from quotes (double and single) as well as leading and trailing spaces.

The code should create the array below where the extracted values are sanitized and in an array.

```

Array
(
    [0] => Value A
    [1] => Value B
    [2] => Value C
    [3] => Value D
    [4] => Value E
    [5] => Value F
    [6] => Value G
)

```