### PR TITLE
Switch tests to use chado_connection consistently.

### DIFF
--- a/trpcultivate_phenotypes/tests/src/Functional/ConfigOntologyTermsTest.php
+++ b/trpcultivate_phenotypes/tests/src/Functional/ConfigOntologyTermsTest.php
@@ -1,13 +1,8 @@
 <?php
-
-/**
- * @file
- * Functional test of Ontology and Terms configuration page.
- */
-
 namespace Drupal\Tests\trpcultivate_phenotypes\Functional;
 
 use Drupal\Component\Utility\SafeMarkup;
+use Drupal\tripal_chado\Database\ChadoConnection;
 use Drupal\Tests\tripal_chado\Functional\ChadoTestBrowserBase;
 
  /**
@@ -33,11 +28,11 @@ class ConfigOntologyTermsTest extends ChadoTestBrowserBase {
   protected $admin_user;
 
   /**
-   * Chado test schema.
+   * A Database query interface for querying Chado using Tripal DBX.
    *
-   * @var object
+   * @var ChadoConnection
    */
-  protected $chado;
+  protected ChadoConnection $chado_connection;
 
   /**
    * {@inheritdoc}
@@ -52,7 +47,7 @@ class ConfigOntologyTermsTest extends ChadoTestBrowserBase {
     // Now, we want to setup our test chado instance.
     // We can't do this before the parent as we need the container
     // and Tripal DBX initialized...
-    $this->chado = $this->getTestSchema(ChadoTestBrowserBase::PREPARE_TEST_CHADO);
+    $this->chado_connection = $this->getTestSchema(ChadoTestBrowserBase::PREPARE_TEST_CHADO);
 
     // However, by doing things in the above order, we now have all our
     // services for dependancy injection setup before the test chado was
@@ -101,7 +96,7 @@ class ConfigOntologyTermsTest extends ChadoTestBrowserBase {
       'Cicer'
     ];
 
-    $this->chado->insert('1:organism')
+    $this->chado_connection->insert('1:organism')
       ->fields(['genus', 'species', 'type_id'])
       ->values([
         'genus' => $test_insert_genus[0],
@@ -138,13 +133,13 @@ class ConfigOntologyTermsTest extends ChadoTestBrowserBase {
     $genus_ontology = $service_genusontology->defineGenusOntology();
 
     // Find cv id in the test schema to be used as test values.
-    $cvs = $this->chado->query("SELECT cv_id FROM {1:cv} LIMIT 10")
+    $cvs = $this->chado_connection->query("SELECT cv_id FROM {1:cv} LIMIT 10")
       ->fetchAllKeyed(0, 0);
 
     $test_cv_id = array_keys($cvs);
 
     // Find db id in test schema to be used as test values.
-    $dbs = $this->chado->query("SELECT db_id FROM {1:db} LIMIT 2")
+    $dbs = $this->chado_connection->query("SELECT db_id FROM {1:db} LIMIT 2")
       ->fetchAllKeyed(0, 0);
 
     $test_db_id = array_keys($dbs);
@@ -227,7 +222,7 @@ class ConfigOntologyTermsTest extends ChadoTestBrowserBase {
 
     // Find cvterms in test schema to be used as test values.
     // Terms will accept term values in cvterm name (database:accession) format.
-    $cvterms = $this->chado->query("
+    $cvterms = $this->chado_connection->query("
       SELECT ct.cvterm_id, CONCAT(ct.name, ' (', db.name, ':', dx.accession, ')')
       FROM {1:cvterm} AS ct LEFT JOIN {1:dbxref} AS dx USING(dbxref_id) LEFT JOIN {1:db} USING(db_id)
       LIMIT 13

--- a/trpcultivate_phenotypes/tests/src/Functional/InstallTest.php
+++ b/trpcultivate_phenotypes/tests/src/Functional/InstallTest.php
@@ -1,8 +1,8 @@
 <?php
-
 namespace Drupal\Tests\trpcultivate_phenotypes\Functional;
 
 use Drupal\Core\Url;
+use Drupal\tripal_chado\Database\ChadoConnection;
 use Drupal\Tests\tripal_chado\Functional\ChadoTestBrowserBase;
 
 /**
@@ -39,11 +39,18 @@ class InstallTest extends ChadoTestBrowserBase {
   protected static $help_text_excerpt = 'pports collecting all data for a specific trait (e.g. Plant Height) into a single page while still fully describing methodology and units for accurate analysis.';
 
   /**
+   * A Database query interface for querying Chado using Tripal DBX.
+   *
+   * @var ChadoConnection
+   */
+  protected ChadoConnection $chado_connection;
+
+  /**
    * {@inheritdoc}
    */
   protected function setUp() :void {
     parent::setUp();
-    $this->createTestSchema(ChadoTestBrowserBase::PREPARE_TEST_CHADO);
+    $this->chado_connection = $this->createTestSchema(ChadoTestBrowserBase::PREPARE_TEST_CHADO);
   }
 
   /**

--- a/trpcultivate_phenotypes/tests/src/Kernel/ServiceGenusOntologyTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/ServiceGenusOntologyTest.php
@@ -1,13 +1,8 @@
 <?php
-
-/**
- * @file
- * Kernel test of Genus Ontology service.
- */
-
 namespace Drupal\Tests\trpcultivate_phenotypes\Kernel;
 
 use Drupal\Tests\tripal_chado\Kernel\ChadoTestKernelBase;
+use Drupal\tripal_chado\Database\ChadoConnection;
 use Drupal\tripal\Services\TripalLogger;
 
 /**
@@ -33,11 +28,11 @@ class ServiceGenusOntologyTest extends ChadoTestKernelBase {
   ];
 
   /**
-   * Tripal DBX Chado Connection object
+   * A Database query interface for querying Chado using Tripal DBX.
    *
    * @var ChadoConnection
    */
-  protected $chado;
+  protected ChadoConnection $chado_connection;
 
   /**
    * Configuration
@@ -48,7 +43,7 @@ class ServiceGenusOntologyTest extends ChadoTestKernelBase {
 
   /**
    * Test genus.
-   * 
+   *
    * @var array
    */
   private $test_genus = [
@@ -61,7 +56,7 @@ class ServiceGenusOntologyTest extends ChadoTestKernelBase {
    */
   protected function setUp() :void {
     parent::setUp();
-    
+
     // Set test environment.
     \Drupal::state()->set('is_a_test_environment', TRUE);
 
@@ -69,8 +64,8 @@ class ServiceGenusOntologyTest extends ChadoTestKernelBase {
     $this->config = \Drupal::configFactory()->getEditable('trpcultivate_phenotypes.settings');
 
     // Create a test chado instance and then set it in the container for use by our service.
-    $this->chado = $this->createTestSchema(ChadoTestKernelBase::PREPARE_TEST_CHADO);
-    $this->container->set('tripal_chado.database', $this->chado);
+    $this->chado_connection = $this->createTestSchema(ChadoTestKernelBase::PREPARE_TEST_CHADO);
+    $this->container->set('tripal_chado.database', $this->chado_connection);
 
     // Create organism of type null (id: 1).
     $test_insert_genus = $this->test_genus;
@@ -81,7 +76,7 @@ class ServiceGenusOntologyTest extends ChadoTestKernelBase {
         ('$test_insert_genus[1]', 'arientinum', 1)
     ";
 
-    $this->chado->query($ins_genus);
+    $this->chado_connection->query($ins_genus);
 
     $this->service = \Drupal::service('trpcultivate_phenotypes.genus_ontology');
   }
@@ -187,7 +182,7 @@ class ServiceGenusOntologyTest extends ChadoTestKernelBase {
     // Active Genus list.
     $active_genus = $this->service->getConfiguredGenusList();
     $extra_item = array_diff($active_genus, $this->test_genus);
-    
+
     // Assert no extra item thus both arrays are the same.
     $this->assertEmpty($extra_item, 'Active genus arrays do not match.');
   }

--- a/trpcultivate_phenotypes/tests/src/Kernel/ServiceGenusProjectTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/ServiceGenusProjectTest.php
@@ -1,13 +1,8 @@
 <?php
-
-/**
- * @file
- * Kernel test of Genus Project service.
- */
-
 namespace Drupal\Tests\trpcultivate_phenotypes\Kernel;
 
 use Drupal\Tests\tripal_chado\Kernel\ChadoTestKernelBase;
+use Drupal\tripal_chado\Database\ChadoConnection;
 use Drupal\tripal\Services\TripalLogger;
 use Symfony\Component\HttpFoundation\Request;
 use Drupal\trpcultivate_phenotypes\Controller\TripalCultivatePhenotypesProjectGenusController;
@@ -20,17 +15,17 @@ use Drupal\trpcultivate_phenotypes\Controller\TripalCultivatePhenotypesProjectGe
 class ServiceGenusProjectTest extends ChadoTestKernelBase {
   /**
    * Term service.
-   * 
+   *
    * @var object
    */
   protected $service;
 
   /**
-   * Tripal DBX Chado Connection object
+   * A Database query interface for querying Chado using Tripal DBX.
    *
    * @var ChadoConnection
    */
-  protected $chado;
+  protected ChadoConnection $chado_connection;
 
   /**
    * Modules to enable.
@@ -43,11 +38,11 @@ class ServiceGenusProjectTest extends ChadoTestKernelBase {
 
   /**
    * Configuration
-   * 
+   *
    * @var config_entity
    */
   private $config;
-  
+
   /**
    * Contains inserted records.
    *
@@ -79,51 +74,51 @@ class ServiceGenusProjectTest extends ChadoTestKernelBase {
     // Install module configuration.
     $this->installConfig(['trpcultivate_phenotypes']);
     $this->config = \Drupal::configFactory()->getEditable('trpcultivate_phenotypes.settings');
-    
+
     // Set ontology.term: genus to null (id: 1).
     $this->config->set('trpcultivate.phenotypes.ontology.terms.genus', 1);
 
     // Test Chado database.
     // Create a test chado instance and then set it in the container for use by our service.
-    $this->chado = $this->createTestSchema(ChadoTestKernelBase::PREPARE_TEST_CHADO);
-    $this->container->set('tripal_chado.database', $this->chado);
+    $this->chado_connection = $this->createTestSchema(ChadoTestKernelBase::PREPARE_TEST_CHADO);
+    $this->container->set('tripal_chado.database', $this->chado_connection);
 
     // Prepare by adding test records to genus, project and projectproperty
     // to relate a genus to a project.
     $project = 'Project - ' . uniqid();
     $this->project = $project;
-    $project_id = $this->chado->insert('1:project')
+    $project_id = $this->chado_connection->insert('1:project')
       ->fields([
         'name' => $project,
-        'description' => $project . ' : Description'   
+        'description' => $project . ' : Description'
       ])
       ->execute();
 
     $this->ins['project_id'] = $project_id;
-    
+
     $genus = 'Wild Genus ' . uniqid();
-    $genus_id = $this->chado->insert('1:organism')
+    $genus_id = $this->chado_connection->insert('1:organism')
       ->fields([
         'genus' => $genus,
         'species' => 'Wild Species',
-        'type_id' => 1 
+        'type_id' => 1
       ])
       ->execute();
 
     $this->ins['genus_id'] = $genus_id;
     $this->ins['genus'] = $genus;
 
-    $prop_id = $this->chado->insert('1:projectprop')
+    $prop_id = $this->chado_connection->insert('1:projectprop')
       ->fields([
         'project_id' => $project_id,
         'type_id' => 1,
-        'value' => $genus 
+        'value' => $genus
       ])
       ->execute();
 
     $this->ins['projectprop_id'] = $prop_id;
 
-    // Create Genus Ontology configuration. 
+    // Create Genus Ontology configuration.
     // All configuration and database value to null (id: 1).
     $config_name = str_replace(' ', '_', strtolower($genus));
     $genus_ontology_config = [
@@ -139,14 +134,14 @@ class ServiceGenusProjectTest extends ChadoTestKernelBase {
     // Insert a secondary genus to be used to test when setting up a genus
     // where replace existing genus is enabled.
     $genus = 'Cultivated Genus ' . uniqid();
-    $genus_id = $this->chado->insert('1:organism')
+    $genus_id = $this->chado_connection->insert('1:organism')
       ->fields([
         'genus' => $genus,
         'species' => 'Cultivated Species',
-        'type_id' => 1 
+        'type_id' => 1
       ])
       ->execute();
-    
+
     // Configure this other genus.
     // All configuration and database value to null (id: 1).
     $config_name = str_replace(' ', '_', strtolower($genus));
@@ -181,7 +176,7 @@ class ServiceGenusProjectTest extends ChadoTestKernelBase {
 
     // Test getGenusOfProject().
     $genus_project = $this->service->getGenusOfProject($this->ins['project_id']);
-    
+
     $this->assertNotNull($genus_project, 'Genus of a project returned null: project_id - ' . $this->ins['project_id']);
     $this->assertEquals($genus_project['genus'], $this->ins['genus'], 'Genus does not match expected genus: ' . $genus_project['genus']);
 
@@ -200,7 +195,7 @@ class ServiceGenusProjectTest extends ChadoTestKernelBase {
     // No relationship yet. Create a relationship in projectprop table.
     // Create a new project.
     $project = 'New Project - ' . uniqid();
-    $project_id = $this->chado->insert('1:project')
+    $project_id = $this->chado_connection->insert('1:project')
     ->fields([
       'name' => $project,
       'description' => $project . ' : Description'
@@ -212,14 +207,14 @@ class ServiceGenusProjectTest extends ChadoTestKernelBase {
 
     $new_project_genus = $this->service->getGenusOfProject($project_id);
     $this->assertEquals($new_project_genus['genus'], $this->ins['second_genus'], 'Genus does not match expected genus: ' . $this->ins['second_genus']);
-  
+
     // Test method inserted correct record into projectprop table.
-    $projectprop = $this->chado->query("
-      SELECT * FROM {1:projectprop} 
+    $projectprop = $this->chado_connection->query("
+      SELECT * FROM {1:projectprop}
       WHERE project_id = :project_id AND type_id = :term_genus AND value = :value_genus LIMIT 1
     ", [':project_id' => $project_id, ':term_genus' => 1, ':value_genus' => $new_project_genus['genus']])
       ->fetchObject();
-    
+
     $this->assertNotNull($projectprop->projectprop_id, 'Method setGenusToProject failed to create a record in projectprop table.');
     $this->assertEquals($new_project_genus['genus'], $projectprop->value, 'Genus set value in projectprop does not match expected genus.');
     $this->assertEquals($project_id, $projectprop->project_id, 'Project id set value in projectprop does not match expected project id.');

--- a/trpcultivate_phenotypes/tests/src/Kernel/ServiceTermTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/ServiceTermTest.php
@@ -1,13 +1,8 @@
 <?php
-
-/**
- * @file
- * Kernel test of Terms service.
- */
-
 namespace Drupal\Tests\trpcultivate_phenotypes\Kernel;
 
 use Drupal\Tests\tripal_chado\Kernel\ChadoTestKernelBase;
+use Drupal\tripal_chado\Database\ChadoConnection;
 use Drupal\tripal\Services\TripalLogger;
 
  /**
@@ -41,11 +36,11 @@ class ServiceTermTest extends ChadoTestKernelBase {
   private $config;
 
   /**
-   * Tripal DBX Chado Connection object
+   * A Database query interface for querying Chado using Tripal DBX.
    *
    * @var ChadoConnection
    */
-  protected $chado_connection;
+  protected ChadoConnection $chado_connection;
 
   /**
    * {@inheritdoc}

--- a/trpcultivate_phenotypes/tests/src/Kernel/Services/Traits/ValidTraitTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Services/Traits/ValidTraitTest.php
@@ -1,14 +1,9 @@
 <?php
-
-/**
- * @file
- * Kernel test of Traits service.
- */
-
 namespace Drupal\Tests\trpcultivate_phenotypes\Kernel\Services\Traits;
 
 use Drupal\Tests\tripal_chado\Kernel\ChadoTestKernelBase;
 use Drupal\Tests\trpcultivate_phenotypes\Traits\PhenotypeImporterTestTrait;
+use Drupal\tripal_chado\Database\ChadoConnection;
 
 /**
  * Tests that a valid trait/method/unit combination can be inserted/retrieved.
@@ -26,11 +21,11 @@ class ValidTraitTest extends ChadoTestKernelBase {
   protected $service_traits;
 
   /**
-   * Tripal DBX Chado Connection object
+   * A Database query interface for querying Chado using Tripal DBX.
    *
    * @var ChadoConnection
    */
-  protected $connection;
+  protected ChadoConnection $chado_connection;
 
   /**
    * Configuration Factory
@@ -78,14 +73,14 @@ class ValidTraitTest extends ChadoTestKernelBase {
     \Drupal::state()->set('is_a_test_environment', TRUE);
 
     // Open connection to Chado
-		$this->connection = $this->getTestSchema(ChadoTestKernelBase::PREPARE_TEST_CHADO);
+		$this->chado_connection = $this->getTestSchema(ChadoTestKernelBase::PREPARE_TEST_CHADO);
 
     // Install module configuration/settings.
     $this->installConfig(['trpcultivate_phenotypes']);
 
     // Configure the module.
     $this->genus = 'Tripalus';
-    $organism_id = $this->connection->insert('1:organism')
+    $organism_id = $this->chado_connection->insert('1:organism')
     ->fields([
       'genus' => $this->genus,
       'species' => 'databasica',
@@ -149,7 +144,7 @@ class ValidTraitTest extends ChadoTestKernelBase {
 
     foreach($trait_assets as $type => $value) {
       // Retrieve the cvterm with the cvterm_di returned by the service.
-      $rec = $this->connection->query($sql, [':id' => $value])
+      $rec = $this->chado_connection->query($sql, [':id' => $value])
         ->fetchObject();
       $this->assertIsObject($rec,
         "We were unable to retrieve the $type record from chado based on the cvterm_id $value provided by the service.");
@@ -179,7 +174,7 @@ class ValidTraitTest extends ChadoTestKernelBase {
     // for the term we choose but is the same order as in AP.
     // Expected "Measured with ruler" is "Method" of "Plant Height"
     // but is currently saved as "Plant Height" is "Method" of "Measured with ruler"
-    $rec = $this->connection->query($sql, [
+    $rec = $this->chado_connection->query($sql, [
       ':s_id' => $trait_assets['trait'],
       ':t_id' => $this->terms['method_to_trait_relationship_type'],
       ':o_id' => $trait_assets['method']
@@ -192,7 +187,7 @@ class ValidTraitTest extends ChadoTestKernelBase {
     // for the term we choose but is the same order as in AP.
     // Expected "cm" is "Unit" of "Measured with Ruler"
     // but it is currently saved as "Measures with ruler" is "Unit" of "cm"
-    $rec = $this->connection->query($sql, [
+    $rec = $this->chado_connection->query($sql, [
       ':s_id' => $trait_assets['method'],
       ':t_id' => $this->terms['unit_to_method_relationship_type'],
       ':o_id' => $trait_assets['unit']
@@ -202,7 +197,7 @@ class ValidTraitTest extends ChadoTestKernelBase {
 
     // Test unit data type.
     $sql = "SELECT cvtermprop_id, value FROM {1:cvtermprop} WHERE cvterm_id = :c_id AND type_id = :t_id LIMIT 1";
-    $data_type = $this->connection->query($sql, [
+    $data_type = $this->chado_connection->query($sql, [
       ':c_id' => $trait_assets['unit'],
       ':t_id' => $this->terms['unit_type'],
       ])->fetchObject();

--- a/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterFormTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterFormTest.php
@@ -1,8 +1,8 @@
 <?php
-
 namespace Drupal\Tests\trpcultivate_phenotypes\Kernel\TripalImporter;
 
 use Drupal\Core\Url;
+use Drupal\tripal_chado\Database\ChadoConnection;
 use Drupal\Tests\tripal_chado\Kernel\ChadoTestKernelBase;
 use Drupal\Tests\user\Traits\UserCreationTrait;
 use Drupal\Tests\trpcultivate_phenotypes\Traits\PhenotypeImporterTestTrait;
@@ -24,9 +24,11 @@ class TraitImporterFormTest extends ChadoTestKernelBase {
   protected $importer;
 
   /**
-   * Chado connection
+   * A Database query interface for querying Chado using Tripal DBX.
+   *
+   * @var ChadoConnection
    */
-  protected $connection;
+  protected ChadoConnection $chado_connection;
 
   /**
    * Saves details regarding the config.
@@ -67,7 +69,7 @@ class TraitImporterFormTest extends ChadoTestKernelBase {
     \Drupal::state()->set('is_a_test_environment', TRUE);
 
 		// Open connection to Chado
-		$this->connection = $this->getTestSchema(ChadoTestKernelBase::PREPARE_TEST_CHADO);
+		$this->chado_connection = $this->getTestSchema(ChadoTestKernelBase::PREPARE_TEST_CHADO);
 
     // Ensure we can access file_managed related functionality from Drupal.
     // ... users need access to system.action config?
@@ -94,7 +96,7 @@ class TraitImporterFormTest extends ChadoTestKernelBase {
     $importer_label = 'Tripal Cultivate: Phenotypic Trait Importer';
 
     // Configure the module.
-    $organism_id = $this->connection->insert('1:organism')
+    $organism_id = $this->chado_connection->insert('1:organism')
       ->fields([
         'genus' => 'Tripalus',
         'species' => 'databasica',
@@ -172,7 +174,7 @@ class TraitImporterFormTest extends ChadoTestKernelBase {
 	  $plugin_id = 'trpcultivate-phenotypes-traits-importer';
 
     // Configure the module.
-    $organism_id = $this->connection->insert('1:organism')
+    $organism_id = $this->chado_connection->insert('1:organism')
       ->fields([
         'genus' => 'Tripalus',
         'species' => 'databasica',

--- a/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterFormValidateTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterFormValidateTest.php
@@ -1,8 +1,8 @@
 <?php
-
 namespace Drupal\Tests\trpcultivate_phenotypes\Kernel\TripalImporter;
 
 use Drupal\Core\Url;
+use Drupal\tripal_chado\Database\ChadoConnection;
 use Drupal\Tests\tripal_chado\Kernel\ChadoTestKernelBase;
 use Drupal\Tests\user\Traits\UserCreationTrait;
 use Drupal\Tests\trpcultivate_phenotypes\Traits\PhenotypeImporterTestTrait;
@@ -24,9 +24,11 @@ class TraitImporterFormValidateTest extends ChadoTestKernelBase {
   protected $importer;
 
   /**
-   * Chado connection
+   * A Database query interface for querying Chado using Tripal DBX.
+   *
+   * @var ChadoConnection
    */
-  protected $connection;
+  protected ChadoConnection $chado_connection;
 
   /**
    * Saves details regarding the config.
@@ -67,7 +69,7 @@ class TraitImporterFormValidateTest extends ChadoTestKernelBase {
     \Drupal::state()->set('is_a_test_environment', TRUE);
 
 		// Open connection to Chado
-		$this->connection = $this->getTestSchema(ChadoTestKernelBase::PREPARE_TEST_CHADO);
+		$this->chado_connection = $this->getTestSchema(ChadoTestKernelBase::PREPARE_TEST_CHADO);
 
     // Ensure we can access file_managed related functionality from Drupal.
     // ... users need access to system.action config?
@@ -188,7 +190,7 @@ class TraitImporterFormValidateTest extends ChadoTestKernelBase {
 
     // Configure the module.
     $genus = 'Tripalus';
-    $organism_id = $this->connection->insert('1:organism')
+    $organism_id = $this->chado_connection->insert('1:organism')
       ->fields([
         'genus' => $genus,
         'species' => 'databasica',

--- a/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterRunTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterRunTest.php
@@ -1,8 +1,8 @@
 <?php
-
 namespace Drupal\Tests\trpcultivate_phenotypes\Kernel\TripalImporter;
 
 use Drupal\Core\Url;
+use Drupal\tripal_chado\Database\ChadoConnection;
 use Drupal\Tests\tripal_chado\Kernel\ChadoTestKernelBase;
 use Drupal\Tests\user\Traits\UserCreationTrait;
 use Drupal\Tests\trpcultivate_phenotypes\Traits\PhenotypeImporterTestTrait;
@@ -24,9 +24,11 @@ class TraitImporterRunTest extends ChadoTestKernelBase {
   protected $importer;
 
   /**
-   * Chado connection
+   * A Database query interface for querying Chado using Tripal DBX.
+   *
+   * @var ChadoConnection
    */
-  protected $connection;
+  protected ChadoConnection $chado_connection;
 
   /**
    * Config factory
@@ -72,7 +74,7 @@ class TraitImporterRunTest extends ChadoTestKernelBase {
     \Drupal::state()->set('is_a_test_environment', TRUE);
 
 		// Open connection to Chado
-		$this->connection = $this->getTestSchema(ChadoTestKernelBase::PREPARE_TEST_CHADO);
+		$this->chado_connection = $this->getTestSchema(ChadoTestKernelBase::PREPARE_TEST_CHADO);
 
     // Ensure we can access file_managed related functionality from Drupal.
     // ... users need access to system.action config?
@@ -106,7 +108,7 @@ class TraitImporterRunTest extends ChadoTestKernelBase {
     $container->set('tripal.logger', $mock_logger);
 
     // Create our organism and configure it.
-    $organism_id = $this->connection->insert('1:organism')
+    $organism_id = $this->chado_connection->insert('1:organism')
       ->fields([
         'genus' => 'Tripalus',
         'species' => 'databasica',
@@ -123,7 +125,7 @@ class TraitImporterRunTest extends ChadoTestKernelBase {
       [],
       'trpcultivate-phenotypes-traits-importer',
       $this->definitions,
-      $this->connection
+      $this->chado_connection
     );
 
   }

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorBaseTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorBaseTest.php
@@ -1,12 +1,7 @@
 <?php
-
-/**
- * @file
- * Kernel tests for the Validator Base class
- */
-
 namespace Drupal\Tests\trpcultivate_phenotypes\Kernel\Validators;
 
+use Drupal\tripal_chado\Database\ChadoConnection;
 use Drupal\Tests\tripal_chado\Kernel\ChadoTestKernelBase;
 use Drupal\Tests\trpcultivate_phenotypes\Kernel\Validators\FakeValidators\BasicallyBase;
 
@@ -23,11 +18,11 @@ class ValidatorBaseTest extends ChadoTestKernelBase {
   protected $plugin_manager;
 
   /**
-   * Tripal DBX Chado Connection object
+   * A Database query interface for querying Chado using Tripal DBX.
    *
    * @var ChadoConnection
    */
-  protected $chado;
+  protected ChadoConnection $chado_connection;
 
   /**
    * Configuration
@@ -62,8 +57,8 @@ class ValidatorBaseTest extends ChadoTestKernelBase {
 
     // Test Chado database.
     // Create a test chado instance and then set it in the container for use by our service.
-    $this->chado = $this->createTestSchema(ChadoTestKernelBase::PREPARE_TEST_CHADO);
-    $this->container->set('tripal_chado.database', $this->chado);
+    $this->chado_connection = $this->createTestSchema(ChadoTestKernelBase::PREPARE_TEST_CHADO);
+    $this->container->set('tripal_chado.database', $this->chado_connection);
 
     // Set plugin manager service.
     $this->plugin_manager = \Drupal::service('plugin.manager.trpcultivate_validator');

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorFileRowScopeTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorFileRowScopeTest.php
@@ -1,12 +1,7 @@
 <?php
-
-/**
- * @file
- * Kernel tests for validator plugins that operate within the scope of "FILE ROW"
- */
-
 namespace Drupal\Tests\trpcultivate_phenotypes\Kernel\Validators;
 
+use Drupal\tripal_chado\Database\ChadoConnection;
 use Drupal\Tests\tripal_chado\Kernel\ChadoTestKernelBase;
 
  /**
@@ -24,11 +19,11 @@ class ValidatorFileRowScopeTest extends ChadoTestKernelBase {
   protected $plugin_manager;
 
   /**
-   * Tripal DBX Chado Connection object
+   * A Database query interface for querying Chado using Tripal DBX.
    *
    * @var ChadoConnection
    */
-  protected $chado;
+  protected ChadoConnection $chado_connection;
 
   /**
    * Configuration
@@ -63,8 +58,8 @@ class ValidatorFileRowScopeTest extends ChadoTestKernelBase {
 
     // Test Chado database.
     // Create a test chado instance and then set it in the container for use by our service.
-    $this->chado = $this->createTestSchema(ChadoTestKernelBase::PREPARE_TEST_CHADO);
-    $this->container->set('tripal_chado.database', $this->chado);
+    $this->chado_connection = $this->createTestSchema(ChadoTestKernelBase::PREPARE_TEST_CHADO);
+    $this->container->set('tripal_chado.database', $this->chado_connection);
 
     // Set plugin manager service.
     $this->plugin_manager = \Drupal::service('plugin.manager.trpcultivate_validator');

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorTraitImporterTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorTraitImporterTest.php
@@ -1,12 +1,7 @@
 <?php
-
-/**
- * @file
- * Kernel tests for validator plugins specific to validating the Trait Importer
- */
-
 namespace Drupal\Tests\trpcultivate_phenotypes\Kernel\Validators;
 
+use Drupal\tripal_chado\Database\ChadoConnection;
 use Drupal\Tests\tripal_chado\Kernel\ChadoTestKernelBase;
 use Drupal\Tests\trpcultivate_phenotypes\Traits\PhenotypeImporterTestTrait;
 
@@ -27,11 +22,11 @@ class ValidatorTraitImporterTest extends ChadoTestKernelBase {
   protected $plugin_manager;
 
   /**
-   * Tripal DBX Chado Connection object
+   * A Database query interface for querying Chado using Tripal DBX.
    *
    * @var ChadoConnection
    */
-  protected $connection;
+  protected ChadoConnection $chado_connection;
 
   /**
    * Configuration
@@ -80,15 +75,15 @@ class ValidatorTraitImporterTest extends ChadoTestKernelBase {
 
     // Test Chado database.
     // Create a test chado instance and then set it in the container for use by our service.
-    $this->connection = $this->createTestSchema(ChadoTestKernelBase::PREPARE_TEST_CHADO);
-    $this->container->set('tripal_chado.database', $this->connection);
+    $this->chado_connection = $this->createTestSchema(ChadoTestKernelBase::PREPARE_TEST_CHADO);
+    $this->container->set('tripal_chado.database', $this->chado_connection);
 
     // Set plugin manager service.
     $this->plugin_manager = \Drupal::service('plugin.manager.trpcultivate_validator');
 
     $genus = 'Tripalus';
     // Create our organism and configure it.
-    $organism_id = $this->connection->insert('1:organism')
+    $organism_id = $this->chado_connection->insert('1:organism')
       ->fields([
         'genus' => $genus,
         'species' => 'databasica',

--- a/trpcultivate_phenotypes/tests/src/Traits/PhenotypeImporterTestTrait.php
+++ b/trpcultivate_phenotypes/tests/src/Traits/PhenotypeImporterTestTrait.php
@@ -2,8 +2,16 @@
 namespace Drupal\Tests\trpcultivate_phenotypes\Traits;
 
 use Drupal\file\Entity\File;
+use Drupal\tripal_chado\Database\ChadoConnection;
 
 trait PhenotypeImporterTestTrait {
+
+  /**
+   * A Database query interface for querying Chado using Tripal DBX.
+   *
+   * @var ChadoConnection
+   */
+  protected ChadoConnection $chado_connection;
 
   /**
    * Sets the ontology configuration for a specific genus.
@@ -62,7 +70,7 @@ trait PhenotypeImporterTestTrait {
       if (empty($details[$key]['name']) AND !empty($details[$key][$id_column])) {
         $table = ($id_column == 'cv_id') ? 'cv' : 'db';
         $id = $details[$key][$id_column];
-        $name = $this->connection->select("1:$table", 'tbl')
+        $name = $this->chado_connection->select("1:$table", 'tbl')
           ->fields('tbl', ['name'])
           ->condition($id_column, $id, '=')
           ->execute()
@@ -74,7 +82,7 @@ trait PhenotypeImporterTestTrait {
       // -- no id but we have the name.
       elseif (!empty($details[$key]['name']) AND empty($details[$key][$id_column])) {
         $name = $details[$key]['name'];
-        $id = $this->connection->select("1:$table", 'tbl')
+        $id = $this->chado_connection->select("1:$table", 'tbl')
           ->fields('tbl', [$id_column])
           ->condition('name', $name, '=')
           ->execute()
@@ -89,7 +97,7 @@ trait PhenotypeImporterTestTrait {
         // set the name if it's not already.
         $details[$key]['name'] = $details[$key]['name'] ?: $genus . ' ' . $key . uniqid();
         $name = $details[$key]['name'];
-        $id = $this->connection->insert("1:$table")
+        $id = $this->chado_connection->insert("1:$table")
           ->fields([
             'name' => $name,
           ])


### PR DESCRIPTION
## Motivation

We need to use a consistent variable in tests for the chado connection in order for test traits to work well. I had started to make this change in my setters PR but then realized it would be better on it's own and make my setters PR less confusing.

So here it is.

## What does this PR do?
*Please describe each things this PR does. For example, a PR may 1) solve a specific bug, 2) create an auomated test to ensure it doesn't return.*

1. Ensure that all tests connecting to chado, have a $chado_connection variable defined consistently with full type hinting.
2. Ensure that these tests all now correctly use the variable above instead of the original `chado` or `connection` variables each one had before.
3. Add the use statement for ChadoConnection to ensure the type-hinting works properly.
4. Removes any `@file` docblocks from testing files I changed since Drupal code standards says not to include them if there is only a single class in the file.

## Testing

This PR only changes automated tests so a simple code review and confirming that the tests still pass should be sufficient.