### PR TITLE
Updates to docker/workflows based on PR tripal/tripal#1951 and base#23.

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -21,7 +21,8 @@
         "DEVSENSE.composer-php-vscode",
         "mblode.twig-language-2",
         "redhat.vscode-yaml",
-        "ms-azuretools.vscode-docker"
+        "ms-azuretools.vscode-docker",
+        "github.vscode-github-actions"
       ],
       "settings": {
         // This turns off basic PHP suggestions provided by Visual Studio Code (in lieu of Intelephense's).

--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -22,7 +22,8 @@
         "mblode.twig-language-2",
         "redhat.vscode-yaml",
         "ms-azuretools.vscode-docker",
-        "github.vscode-github-actions"
+        "github.vscode-github-actions",
+        "GitHub.vscode-pull-request-github"
       ],
       "settings": {
         // This turns off basic PHP suggestions provided by Visual Studio Code (in lieu of Intelephense's).

--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,0 +1,126 @@
+{
+  "name": "TripalDocker",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "args": {
+      "drupalversion": "10.3.x-dev",
+      "phpversion": "8.3",
+      "postgresqlversion": "16"
+    }
+  },
+  "workspaceMount": "source=${localWorkspaceFolder},target=/var/www/drupal/web/modules/contrib/TripalCultivate-Phenotypes,type=bind",
+  "workspaceFolder": "/var/www/drupal/web/modules/contrib/TripalCultivate-Phenotypes",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "neilbrayfield.php-docblocker",
+        "bmewburn.vscode-intelephense-client",
+        "recca0120.vscode-phpunit",
+        "swordev.phpstan",
+        "andrewdavidblum.drupal-smart-snippets",
+        "DEVSENSE.composer-php-vscode",
+        "mblode.twig-language-2",
+        "redhat.vscode-yaml",
+        "ms-azuretools.vscode-docker"
+      ],
+      "settings": {
+        // This turns off basic PHP suggestions provided by Visual Studio Code (in lieu of Intelephense's).
+        "php.suggest.basic": false,
+        /* Coding Standards */
+        "css.validate": true,
+        "diffEditor.ignoreTrimWhitespace": false,
+        "editor.tabSize": 2,
+        "editor.autoIndent": "full",
+        "editor.insertSpaces": true,
+        "editor.formatOnPaste": true,
+        "editor.formatOnSave": false,
+        "editor.renderWhitespace": "boundary",
+        "editor.wordWrapColumn": 80,
+        "editor.wordWrap": "on",
+        "editor.detectIndentation": true,
+        "editor.rulers": [
+          80
+        ],
+        "files.trimTrailingWhitespace": true,
+        "files.insertFinalNewline": true,
+        "files.trimFinalNewlines": true,
+        "html.format.enable": true,
+        "html.format.wrapLineLength": 80,
+        /* Chosing which language a file is; Drupal-focused */
+        "files.associations": {
+          "*.inc": "php",
+          "*.module": "php",
+          "*.install": "php",
+          "*.theme": "php",
+          "*.profile": "php",
+          "*.tpl.php": "php",
+          "*.test": "php",
+          "*.php": "php",
+          "*.info": "ini",
+          "*.html": "twig"
+        },
+        "emmet.includeLanguages": {
+          "twig": "html"
+        },
+        /* Performance Related. Exludes from indexing */
+        /*files.exclude and files.watcherExclude settings via https://github.com/microsoft/vscode/issues/11963#issuecomment-317830768 */
+        "files.exclude": {
+          "**/.git": true,
+          "**/.svn": true,
+          "**/.hg": true,
+          "**/CVS": true,
+          "**/.DS_Store": true,
+          "**/tmp": true,
+          "**/node_modules": true,
+          "**/bower_components": true,
+          "**/dist": true
+        },
+        "files.watcherExclude": {
+          "**/.git/objects/**": true,
+          "**/.git/subtree-cache/**": true,
+          "**/node_modules/**": true,
+          "**/tmp/**": true,
+          "**/bower_components/**": true,
+          "**/dist/**": true
+        },
+        /* PHP Linting */
+        "php.validate.enable": true,
+        "php.validate.executablePath": "/usr/local/bin/php",
+        "php.validate.run": "onType",
+        "[php]": {
+          "editor.defaultFormatter": "bmewburn.vscode-intelephense-client"
+        },
+        /* PHP DocBlocker */
+        "php-docblocker.gap": true,
+        "php-docblocker.useShortNames": true,
+        /* PHP Intelephense */
+        // Intelephense and Drupal >8 only. This should be set to the path to web/index.php.
+        "intelephense.environment.documentRoot": "/var/www/drupal/web/index.php",
+        // Intelephense only: For Drupal compliant braces formatting use:
+        "intelephense.format.braces": "k&r",
+        // Indicate where to find additional classes.
+        "intelephense.environment.includePaths": [
+          "/var/www/drupal/web/core/",
+          "/var/www/drupal/vendor/",
+          "/var/www/drupal/web/modules/"
+        ],
+        "intelephense.diagnostics.enable": false,
+        /* PHPUnit Test Explorer */
+        "phpunit.phpunit": "/var/www/drupal/vendor/bin/phpunit",
+        /* Drupal Smart Snippets */
+        // Use this to prioritize Drupal Smart Snippets in the UI.
+        "editor.snippetSuggestions": "top",
+        /* Composer */
+        "composer.bin": "/usr/local/bin/composer",
+        "tws.trimOnSave": true,
+        "tws.highlightTrailingWhiteSpace": true
+      }
+    }
+  },
+  "forwardPorts": [
+    80,
+    5432,
+    9003
+  ],
+  "postCreateCommand": "init.sh"
+}

--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -3,9 +3,9 @@
   "build": {
     "dockerfile": "Dockerfile",
     "args": {
-      "drupalversion": "10.3.x-dev",
+      "drupalversion": "10.4.x-dev",
       "phpversion": "8.3",
-      "postgresqlversion": "16"
+      "pgsqlversion": "16"
     }
   },
   "workspaceMount": "source=${localWorkspaceFolder},target=/var/www/drupal/web/modules/contrib/TripalCultivate-Phenotypes,type=bind",

--- a/.github/workflows/ALL-PHPUnit.yml
+++ b/.github/workflows/ALL-PHPUnit.yml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/checkout@v4
       # Here we pull the development tripaldocker image for this combo in our matrix
       - name: Run Automated testing
-        uses: tripal/test-tripal-action@v1.5
+        uses: tripal/test-tripal-action@v1.6
         with:
           directory-name: $PKG_NAME
           modules: $MODULES

--- a/.github/workflows/ALL-PHPUnit.yml
+++ b/.github/workflows/ALL-PHPUnit.yml
@@ -19,6 +19,7 @@ env:
 
 jobs:
   run-tests:
+    name: "Drupal ${{ matrix.drupal-version }} - PHP ${{ matrix.php-version }} - PostgreSQL ${{ matrix.pgsql-version }}"
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/ALL-PHPUnit.yml
+++ b/.github/workflows/ALL-PHPUnit.yml
@@ -1,6 +1,17 @@
 
 name: PHPUnit Full Test Suite
-on: [push]
+on:
+  push:
+    branches-ignore:
+      - 4.x
+  # Allows us to manually trigger this workflow.
+  # This is great if there is a change made to Tripal core that we want to test our modules on ASAP.
+  workflow_dispatch:
+  # Allows us to schedule when this workflow is run.
+  # This ensures we pick up any new changes committed to Tripal Core.
+  schedule:
+    # Run at 2am every night.
+    - cron: '0 2 * * *'
 
 env:
   PKG_NAME: TripalCultivate-Phenotypes
@@ -19,17 +30,11 @@ jobs:
           - "8.3"
         pgsql-version:
           - "13"
+          - "16"
         drupal-version:
-          - "10.0.x-dev"
-          - "10.1.x-dev"
           - "10.2.x-dev"
-        exclude:
-          - php-version: "8.3"
-            pgsql-version: "13"
-            drupal-version: "10.0.x-dev"
-          - php-version: "8.3"
-            pgsql-version: "13"
-            drupal-version: "10.1.x-dev"
+          - "10.3.x-dev"
+          - "10.4.x-dev"
 
     steps:
       # Check out the repo

--- a/.github/workflows/ALL-testCoverage-codeclimate.yml
+++ b/.github/workflows/ALL-testCoverage-codeclimate.yml
@@ -5,70 +5,19 @@ on: [push, workflow_dispatch]
 env:
   PKG_NAME: TripalCultivate-Phenotypes
   MODULES: "trpcultivate_phenotypes trpcultivate_phenocollect trpcultivate_phenoshare"
-  IMAGE_TAG: baseonly-drupal${drupalversion}-php${phpversion}-pgsql${pgsqlversion}
-  SIMPLETEST_BASE_URL: "http://localhost"
-  SIMPLETEST_DB: "pgsql://drupaladmin:drupaldevelopmentonlylocal@localhost/sitedb"
-  BROWSER_OUTPUT_DIRECTORY: "/var/www/drupal/web/sites/default/files/simpletest"
 
 jobs:
-  # Job 1: 'build'
   run-tests:
-    # Runner type
     runs-on: ubuntu-latest
-    name: Test Coverage
-
     steps:
-      # Check out the repo
       - name: Checkout Repository
         uses: actions/checkout@v4
-      # Here we pull the development tripaldocker image for this combo in our matrix
-      - name: Build Image
-        run: |
-          docker build --tag=localdocker:local --build-arg drupalversion=10.3.x-dev --build-arg phpversion=8.3 ./
-      # Just spin up docker the good ol' fashion way
-      # mounting our currently checked out package inside the docker container.
-      - name: Spin up Docker locally
-        run: |
-          docker run --publish=80:80 --name=tripaldocker -tid \
-            --volume=`pwd`:/var/www/drupal/web/modules/contrib/$PKG_NAME localdocker:local
-      # Install the modules
-      - name: Install our package in Docker
-        run: |
-          docker exec tripaldocker service postgresql restart
-          docker exec tripaldocker drush en $MODULES --yes
-      # Ensure we have the variables we need.
-      - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4
-      # Prepare for code coverage.
-      - name: Prepare for Code Coverage
-        run: |
-          curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-          docker cp cc-test-reporter tripaldocker:/var/www/drupal/web/modules/contrib/$PKG_NAME
-          docker exec tripaldocker chmod a+x /var/www/drupal/web/modules/contrib/$PKG_NAME/cc-test-reporter
-          docker exec --workdir=/var/www/drupal/web/modules/contrib/$PKG_NAME tripaldocker ./cc-test-reporter before-build --debug
-      # Runs the PHPUnit tests.
-      # https://github.com/mheap/phpunit-github-actions-printer is used
-      # to report PHPUnit fails in a meaningful way to github in PRs.
-      # Stopped using mheap due to warning w/ phpunit8->9
-      - name: Run Tests for Coverage
-        env:
-          SIMPLETEST_BASE_URL: "http://localhost"
-          SIMPLETEST_DB: "pgsql://drupaladmin:drupaldevelopmentonlylocal@localhost/sitedb"
-          BROWSER_OUTPUT_DIRECTORY: "/var/www/drupal/web/sites/default/files/simpletest"
-        run: |
-          docker exec tripaldocker service postgresql restart
-          docker exec -e SIMPLETEST_BASE_URL=$SIMPLETEST_BASE_URL \
-            -e SIMPLETEST_DB=$SIMPLETEST_DB \
-            -e BROWSER_OUTPUT_DIRECTORY=$BROWSER_OUTPUT_DIRECTORY \
-            --workdir=/var/www/drupal/web/modules/contrib/$PKG_NAME \
-            tripaldocker phpunit --coverage-text \
-              --coverage-clover /var/www/drupal/web/modules/contrib/$PKG_NAME/clover.xml
-          docker exec tripaldocker ls /var/www/drupal/web/modules/contrib/$PKG_NAME
-      - name: Publish code coverage to Code Climate
-        run: |
-          docker exec --workdir=/var/www/drupal/web/modules/contrib/$PKG_NAME tripaldocker \
-            git config --global --add safe.directory /var/www/drupal/web/modules/contrib/$PKG_NAME
-          docker exec --workdir=/var/www/drupal/web/modules/contrib/$PKG_NAME \
-            tripaldocker ./cc-test-reporter after-build clover.xml \
-            --id ${{ secrets.CODECLIMATE_TEST_REPORTER_ID }} \
-            --debug -t clover -p /var/www/drupal/web/modules/contrib/$PKG_NAME
+      - name: Run Automated testing + report coverage
+        uses: tripal/test-tripal-action@v1.6
+        with:
+          directory-name: my_tripal_extension
+          modules: my_tripal_extension
+          php-version: 8.3
+          pgsql-version: 16
+          drupal-version: 10.4.x-dev
+          codeclimate-reporter-id: ${{ secrets.CODECLIMATE_TEST_REPORTER_ID }}

--- a/.github/workflows/ALL-testCoverage-codeclimate.yml
+++ b/.github/workflows/ALL-testCoverage-codeclimate.yml
@@ -1,6 +1,6 @@
 # Run some PHPUnit tests
 name: Test Coverage
-on: [push]
+on: [push, workflow_dispatch]
 
 env:
   PKG_NAME: TripalCultivate-Phenotypes
@@ -24,7 +24,7 @@ jobs:
       # Here we pull the development tripaldocker image for this combo in our matrix
       - name: Build Image
         run: |
-          docker build --tag=localdocker:local --build-arg drupalversion=10.2.x-dev --build-arg phpversion=8.3 ./
+          docker build --tag=localdocker:local --build-arg drupalversion=10.3.x-dev --build-arg phpversion=8.3 ./
       # Just spin up docker the good ol' fashion way
       # mounting our currently checked out package inside the docker container.
       - name: Spin up Docker locally

--- a/.github/workflows/ALL-testCoverage-codeclimate.yml
+++ b/.github/workflows/ALL-testCoverage-codeclimate.yml
@@ -2,8 +2,14 @@
 name: Test Coverage
 on: [push, workflow_dispatch]
 
+env:
+  drupal_version: 10.4.x-dev
+  php_version: 8.3
+  pgsql_version: 16
+
 jobs:
-  run-tests:
+  run-coverage:
+    name: "Drupal $drupal_version - PHP $php_version - PostgreSQL $pgsql_version"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -15,7 +21,7 @@ jobs:
           modules: 'trpcultivate_phenotypes trpcultivate_phenocollect trpcultivate_phenoshare'
           build-image: TRUE
           dockerfile: 'Dockerfile'
-          php-version: 8.3
-          pgsql-version: 16
-          drupal-version: 10.4.x-dev
+          php-version: $php_version
+          pgsql-version: $pgsql_version
+          drupal-version: $drupal_version
           codeclimate-reporter-id: ${{ secrets.CODECLIMATE_TEST_REPORTER_ID }}

--- a/.github/workflows/ALL-testCoverage-codeclimate.yml
+++ b/.github/workflows/ALL-testCoverage-codeclimate.yml
@@ -2,10 +2,6 @@
 name: Test Coverage
 on: [push, workflow_dispatch]
 
-env:
-  PKG_NAME: TripalCultivate-Phenotypes
-  MODULES: "trpcultivate_phenotypes trpcultivate_phenocollect trpcultivate_phenoshare"
-
 jobs:
   run-tests:
     runs-on: ubuntu-latest
@@ -15,8 +11,8 @@ jobs:
       - name: Run Automated testing + report coverage
         uses: tripal/test-tripal-action@v1.6
         with:
-          directory-name: my_tripal_extension
-          modules: my_tripal_extension
+          directory-name: 'TripalCultivate-Phenotypes'
+          modules: 'trpcultivate_phenotypes trpcultivate_phenocollect trpcultivate_phenoshare'
           php-version: 8.3
           pgsql-version: 16
           drupal-version: 10.4.x-dev

--- a/.github/workflows/ALL-testCoverage-codeclimate.yml
+++ b/.github/workflows/ALL-testCoverage-codeclimate.yml
@@ -13,6 +13,8 @@ jobs:
         with:
           directory-name: 'TripalCultivate-Phenotypes'
           modules: 'trpcultivate_phenotypes trpcultivate_phenocollect trpcultivate_phenoshare'
+          build-image: TRUE
+          dockerfile: 'Dockerfile'
           php-version: 8.3
           pgsql-version: 16
           drupal-version: 10.4.x-dev

--- a/.github/workflows/ALL-testCoverage-codeclimate.yml
+++ b/.github/workflows/ALL-testCoverage-codeclimate.yml
@@ -2,14 +2,12 @@
 name: Test Coverage
 on: [push, workflow_dispatch]
 
-env:
-  drupal_version: 10.4.x-dev
-  php_version: 8.3
-  pgsql_version: 16
+## UPDATES
+## Update the version numbers in the job name and the action parameters
 
 jobs:
   run-coverage:
-    name: "Drupal $drupal_version - PHP $php_version - PostgreSQL $pgsql_version"
+    name: "Drupal 10.4.x-dev - PHP 8.3 - PostgreSQL 16"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -21,7 +19,7 @@ jobs:
           modules: 'trpcultivate_phenotypes trpcultivate_phenocollect trpcultivate_phenoshare'
           build-image: TRUE
           dockerfile: 'Dockerfile'
-          php-version: $php_version
-          pgsql-version: $pgsql_version
-          drupal-version: $drupal_version
+          php-version: 8.3
+          pgsql-version: 16
+          drupal-version: 10.4.x-dev
           codeclimate-reporter-id: ${{ secrets.CODECLIMATE_TEST_REPORTER_ID }}

--- a/.github/workflows/MAIN-phpunit-Grid1A.yml
+++ b/.github/workflows/MAIN-phpunit-Grid1A.yml
@@ -4,14 +4,18 @@ on:
     branches:
       - 4.x
 
-env:
-  php_version: '8.1'
-  pgsql_version: '16'
-  drupal_version: '10.2.x-dev'
+## UPDATES
+## Update the version numbers in the job name and the action parameters
+# |-------------|-----------------|-----------------|-----------------|
+# |  Drupal     |  10.2.x         |  10.3.x         |  10.4.x         |
+# |-------------|-----------------|-----------------|-----------------|
+# | **PHP 8.1** | ![Grid1A-Badge] | ![Grid2A-Badge] | ![Grid3A-Badge] |
+# | **PHP 8.2** | ![Grid1B-Badge] | ![Grid2B-Badge] | ![Grid3B-Badge] |
+# | **PHP 8.3** | ![Grid1C-Badge] | ![Grid2C-Badge] | ![Grid3C-Badge] |
 
 jobs:
   grid-1A:
-    name: "Drupal $drupal_version - PHP $php_version - PostgreSQL $pgsql_version"
+    name: "Drupal 10.2.x-dev - PHP 8.1 - PostgreSQL 16"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -23,6 +27,6 @@ jobs:
           modules: 'trpcultivate_phenotypes trpcultivate_phenocollect trpcultivate_phenoshare'
           build-image: TRUE
           dockerfile: 'Dockerfile'
-          php-version: $php_version
-          pgsql-version: $pgsql_version
-          drupal-version: $drupal_version
+          php-version: 8.1
+          pgsql-version: 16
+          drupal-version: 10.2.x-dev

--- a/.github/workflows/MAIN-phpunit-Grid1A.yml
+++ b/.github/workflows/MAIN-phpunit-Grid1A.yml
@@ -4,8 +4,14 @@ on:
     branches:
       - 4.x
 
+env:
+  php_version: '8.1'
+  pgsql_version: '16'
+  drupal_version: '10.2.x-dev'
+
 jobs:
   grid-1A:
+    name: "Drupal $drupal_version - PHP $php_version - PostgreSQL $pgsql_version"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -17,6 +23,6 @@ jobs:
           modules: 'trpcultivate_phenotypes trpcultivate_phenocollect trpcultivate_phenoshare'
           build-image: TRUE
           dockerfile: 'Dockerfile'
-          php-version: '8.1'
-          pgsql-version: '16'
-          drupal-version: '10.2.x-dev'
+          php-version: $php_version
+          pgsql-version: $pgsql_version
+          drupal-version: $drupal_version

--- a/.github/workflows/MAIN-phpunit-Grid1A.yml
+++ b/.github/workflows/MAIN-phpunit-Grid1A.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
       - name: Run Automated testing
-        uses: tripal/test-tripal-action@v1.5
+        uses: tripal/test-tripal-action@v1.6
         with:
           directory-name: 'TripalCultivate-Phenotypes'
           modules: 'trpcultivate_phenotypes trpcultivate_phenocollect trpcultivate_phenoshare'

--- a/.github/workflows/MAIN-phpunit-Grid1B.yml
+++ b/.github/workflows/MAIN-phpunit-Grid1B.yml
@@ -4,8 +4,14 @@ on:
     branches:
       - 4.x
 
+env:
+  php_version: '8.2'
+  pgsql_version: '16'
+  drupal_version: '10.2.x-dev'
+
 jobs:
   grid-1B:
+    name: "Drupal $drupal_version - PHP $php_version - PostgreSQL $pgsql_version"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -17,6 +23,6 @@ jobs:
           modules: 'trpcultivate_phenotypes trpcultivate_phenocollect trpcultivate_phenoshare'
           build-image: TRUE
           dockerfile: 'Dockerfile'
-          php-version: '8.2'
-          pgsql-version: '16'
-          drupal-version: '10.2.x-dev'
+          php-version: $php_version
+          pgsql-version: $pgsql_version
+          drupal-version: $drupal_version

--- a/.github/workflows/MAIN-phpunit-Grid1B.yml
+++ b/.github/workflows/MAIN-phpunit-Grid1B.yml
@@ -18,5 +18,5 @@ jobs:
           build-image: TRUE
           dockerfile: 'Dockerfile'
           php-version: '8.2'
-          pgsql-version: '13'
-          drupal-version: '10.0.x-dev'
+          pgsql-version: '16'
+          drupal-version: '10.2.x-dev'

--- a/.github/workflows/MAIN-phpunit-Grid1B.yml
+++ b/.github/workflows/MAIN-phpunit-Grid1B.yml
@@ -4,14 +4,18 @@ on:
     branches:
       - 4.x
 
-env:
-  php_version: '8.2'
-  pgsql_version: '16'
-  drupal_version: '10.2.x-dev'
+## UPDATES
+## Update the version numbers in the job name and the action parameters
+# |-------------|-----------------|-----------------|-----------------|
+# |  Drupal     |  10.2.x         |  10.3.x         |  10.4.x         |
+# |-------------|-----------------|-----------------|-----------------|
+# | **PHP 8.1** | ![Grid1A-Badge] | ![Grid2A-Badge] | ![Grid3A-Badge] |
+# | **PHP 8.2** | ![Grid1B-Badge] | ![Grid2B-Badge] | ![Grid3B-Badge] |
+# | **PHP 8.3** | ![Grid1C-Badge] | ![Grid2C-Badge] | ![Grid3C-Badge] |
 
 jobs:
   grid-1B:
-    name: "Drupal $drupal_version - PHP $php_version - PostgreSQL $pgsql_version"
+    name: "Drupal 10.2.x-dev - PHP 8.2 - PostgreSQL 16"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -23,6 +27,6 @@ jobs:
           modules: 'trpcultivate_phenotypes trpcultivate_phenocollect trpcultivate_phenoshare'
           build-image: TRUE
           dockerfile: 'Dockerfile'
-          php-version: $php_version
-          pgsql-version: $pgsql_version
-          drupal-version: $drupal_version
+          php-version: 8.2
+          pgsql-version: 16
+          drupal-version: 10.2.x-dev

--- a/.github/workflows/MAIN-phpunit-Grid1B.yml
+++ b/.github/workflows/MAIN-phpunit-Grid1B.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
       - name: Run Automated testing
-        uses: tripal/test-tripal-action@v1.5
+        uses: tripal/test-tripal-action@v1.6
         with:
           directory-name: 'TripalCultivate-Phenotypes'
           modules: 'trpcultivate_phenotypes trpcultivate_phenocollect trpcultivate_phenoshare'

--- a/.github/workflows/MAIN-phpunit-Grid1C.yml
+++ b/.github/workflows/MAIN-phpunit-Grid1C.yml
@@ -4,8 +4,14 @@ on:
     branches:
       - 4.x
 
+env:
+  php_version: '8.3'
+  pgsql_version: '16'
+  drupal_version: '10.2.x-dev'
+
 jobs:
-  grid-1A:
+  grid-1C:
+    name: "Drupal $drupal_version - PHP $php_version - PostgreSQL $pgsql_version"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -17,6 +23,6 @@ jobs:
           modules: 'trpcultivate_phenotypes trpcultivate_phenocollect trpcultivate_phenoshare'
           build-image: TRUE
           dockerfile: 'Dockerfile'
-          php-version: '8.3'
-          pgsql-version: '16'
-          drupal-version: '10.2.x-dev'
+          php-version: $php_version
+          pgsql-version: $pgsql_version
+          drupal-version: $drupal_version

--- a/.github/workflows/MAIN-phpunit-Grid1C.yml
+++ b/.github/workflows/MAIN-phpunit-Grid1C.yml
@@ -17,6 +17,6 @@ jobs:
           modules: 'trpcultivate_phenotypes trpcultivate_phenocollect trpcultivate_phenoshare'
           build-image: TRUE
           dockerfile: 'Dockerfile'
-          php-version: '8.1'
-          pgsql-version: '13'
+          php-version: '8.3'
+          pgsql-version: '16'
           drupal-version: '10.2.x-dev'

--- a/.github/workflows/MAIN-phpunit-Grid1C.yml
+++ b/.github/workflows/MAIN-phpunit-Grid1C.yml
@@ -4,14 +4,18 @@ on:
     branches:
       - 4.x
 
-env:
-  php_version: '8.3'
-  pgsql_version: '16'
-  drupal_version: '10.2.x-dev'
+## UPDATES
+## Update the version numbers in the job name and the action parameters
+# |-------------|-----------------|-----------------|-----------------|
+# |  Drupal     |  10.2.x         |  10.3.x         |  10.4.x         |
+# |-------------|-----------------|-----------------|-----------------|
+# | **PHP 8.1** | ![Grid1A-Badge] | ![Grid2A-Badge] | ![Grid3A-Badge] |
+# | **PHP 8.2** | ![Grid1B-Badge] | ![Grid2B-Badge] | ![Grid3B-Badge] |
+# | **PHP 8.3** | ![Grid1C-Badge] | ![Grid2C-Badge] | ![Grid3C-Badge] |
 
 jobs:
   grid-1C:
-    name: "Drupal $drupal_version - PHP $php_version - PostgreSQL $pgsql_version"
+    name: "Drupal 10.2.x-dev - PHP 8.3 - PostgreSQL 16"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -23,6 +27,6 @@ jobs:
           modules: 'trpcultivate_phenotypes trpcultivate_phenocollect trpcultivate_phenoshare'
           build-image: TRUE
           dockerfile: 'Dockerfile'
-          php-version: $php_version
-          pgsql-version: $pgsql_version
-          drupal-version: $drupal_version
+          php-version: 8.3
+          pgsql-version: 16
+          drupal-version: 10.2.x-dev

--- a/.github/workflows/MAIN-phpunit-Grid1C.yml
+++ b/.github/workflows/MAIN-phpunit-Grid1C.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
       - name: Run Automated testing
-        uses: tripal/test-tripal-action@v1.5
+        uses: tripal/test-tripal-action@v1.6
         with:
           directory-name: 'TripalCultivate-Phenotypes'
           modules: 'trpcultivate_phenotypes trpcultivate_phenocollect trpcultivate_phenoshare'

--- a/.github/workflows/MAIN-phpunit-Grid2A.yml
+++ b/.github/workflows/MAIN-phpunit-Grid2A.yml
@@ -4,8 +4,14 @@ on:
     branches:
       - 4.x
 
+env:
+  php_version: '8.1'
+  pgsql_version: '16'
+  drupal_version: '10.3.x-dev'
+
 jobs:
   grid-2A:
+    name: "Drupal $drupal_version - PHP $php_version - PostgreSQL $pgsql_version"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -17,6 +23,6 @@ jobs:
           modules: 'trpcultivate_phenotypes trpcultivate_phenocollect trpcultivate_phenoshare'
           build-image: TRUE
           dockerfile: 'Dockerfile'
-          php-version: '8.1'
-          pgsql-version: '16'
-          drupal-version: '10.3.x-dev'
+          php-version: $php_version
+          pgsql-version: $pgsql_version
+          drupal-version: $drupal_version

--- a/.github/workflows/MAIN-phpunit-Grid2A.yml
+++ b/.github/workflows/MAIN-phpunit-Grid2A.yml
@@ -4,14 +4,18 @@ on:
     branches:
       - 4.x
 
-env:
-  php_version: '8.1'
-  pgsql_version: '16'
-  drupal_version: '10.3.x-dev'
+## UPDATES
+## Update the version numbers in the job name and the action parameters
+# |-------------|-----------------|-----------------|-----------------|
+# |  Drupal     |  10.2.x         |  10.3.x         |  10.4.x         |
+# |-------------|-----------------|-----------------|-----------------|
+# | **PHP 8.1** | ![Grid1A-Badge] | ![Grid2A-Badge] | ![Grid3A-Badge] |
+# | **PHP 8.2** | ![Grid1B-Badge] | ![Grid2B-Badge] | ![Grid3B-Badge] |
+# | **PHP 8.3** | ![Grid1C-Badge] | ![Grid2C-Badge] | ![Grid3C-Badge] |
 
 jobs:
   grid-2A:
-    name: "Drupal $drupal_version - PHP $php_version - PostgreSQL $pgsql_version"
+    name: "Drupal 10.3.x-dev - PHP 8.1 - PostgreSQL 16"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -23,6 +27,6 @@ jobs:
           modules: 'trpcultivate_phenotypes trpcultivate_phenocollect trpcultivate_phenoshare'
           build-image: TRUE
           dockerfile: 'Dockerfile'
-          php-version: $php_version
-          pgsql-version: $pgsql_version
-          drupal-version: $drupal_version
+          php-version: 8.1
+          pgsql-version: 16
+          drupal-version: 10.3.x-dev

--- a/.github/workflows/MAIN-phpunit-Grid2A.yml
+++ b/.github/workflows/MAIN-phpunit-Grid2A.yml
@@ -18,5 +18,5 @@ jobs:
           build-image: TRUE
           dockerfile: 'Dockerfile'
           php-version: '8.1'
-          pgsql-version: '13'
-          drupal-version: '10.1.x-dev'
+          pgsql-version: '16'
+          drupal-version: '10.3.x-dev'

--- a/.github/workflows/MAIN-phpunit-Grid2A.yml
+++ b/.github/workflows/MAIN-phpunit-Grid2A.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
       - name: Run Automated testing
-        uses: tripal/test-tripal-action@v1.5
+        uses: tripal/test-tripal-action@v1.6
         with:
           directory-name: 'TripalCultivate-Phenotypes'
           modules: 'trpcultivate_phenotypes trpcultivate_phenocollect trpcultivate_phenoshare'

--- a/.github/workflows/MAIN-phpunit-Grid2B.yml
+++ b/.github/workflows/MAIN-phpunit-Grid2B.yml
@@ -4,8 +4,14 @@ on:
     branches:
       - 4.x
 
+env:
+  php_version: '8.2'
+  pgsql_version: '16'
+  drupal_version: '10.3.x-dev'
+
 jobs:
   grid-2B:
+    name: "Drupal $drupal_version - PHP $php_version - PostgreSQL $pgsql_version"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -17,6 +23,6 @@ jobs:
           modules: 'trpcultivate_phenotypes trpcultivate_phenocollect trpcultivate_phenoshare'
           build-image: TRUE
           dockerfile: 'Dockerfile'
-          php-version: '8.2'
-          pgsql-version: '16'
-          drupal-version: '10.3.x-dev'
+          php-version: $php_version
+          pgsql-version: $pgsql_version
+          drupal-version: $drupal_version

--- a/.github/workflows/MAIN-phpunit-Grid2B.yml
+++ b/.github/workflows/MAIN-phpunit-Grid2B.yml
@@ -4,14 +4,18 @@ on:
     branches:
       - 4.x
 
-env:
-  php_version: '8.2'
-  pgsql_version: '16'
-  drupal_version: '10.3.x-dev'
+## UPDATES
+## Update the version numbers in the job name and the action parameters
+# |-------------|-----------------|-----------------|-----------------|
+# |  Drupal     |  10.2.x         |  10.3.x         |  10.4.x         |
+# |-------------|-----------------|-----------------|-----------------|
+# | **PHP 8.1** | ![Grid1A-Badge] | ![Grid2A-Badge] | ![Grid3A-Badge] |
+# | **PHP 8.2** | ![Grid1B-Badge] | ![Grid2B-Badge] | ![Grid3B-Badge] |
+# | **PHP 8.3** | ![Grid1C-Badge] | ![Grid2C-Badge] | ![Grid3C-Badge] |
 
 jobs:
   grid-2B:
-    name: "Drupal $drupal_version - PHP $php_version - PostgreSQL $pgsql_version"
+    name: "Drupal 10.3.x-dev - PHP 8.2 - PostgreSQL 16"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -23,6 +27,6 @@ jobs:
           modules: 'trpcultivate_phenotypes trpcultivate_phenocollect trpcultivate_phenoshare'
           build-image: TRUE
           dockerfile: 'Dockerfile'
-          php-version: $php_version
-          pgsql-version: $pgsql_version
-          drupal-version: $drupal_version
+          php-version: 8.2
+          pgsql-version: 16
+          drupal-version: 10.3.x-dev

--- a/.github/workflows/MAIN-phpunit-Grid2B.yml
+++ b/.github/workflows/MAIN-phpunit-Grid2B.yml
@@ -18,5 +18,5 @@ jobs:
           build-image: TRUE
           dockerfile: 'Dockerfile'
           php-version: '8.2'
-          pgsql-version: '13'
-          drupal-version: '10.1.x-dev'
+          pgsql-version: '16'
+          drupal-version: '10.3.x-dev'

--- a/.github/workflows/MAIN-phpunit-Grid2B.yml
+++ b/.github/workflows/MAIN-phpunit-Grid2B.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
       - name: Run Automated testing
-        uses: tripal/test-tripal-action@v1.5
+        uses: tripal/test-tripal-action@v1.6
         with:
           directory-name: 'TripalCultivate-Phenotypes'
           modules: 'trpcultivate_phenotypes trpcultivate_phenocollect trpcultivate_phenoshare'

--- a/.github/workflows/MAIN-phpunit-Grid2C.yml
+++ b/.github/workflows/MAIN-phpunit-Grid2C.yml
@@ -4,14 +4,18 @@ on:
     branches:
       - 4.x
 
-env:
-  php_version: '8.3'
-  pgsql_version: '16'
-  drupal_version: '10.3.x-dev'
+## UPDATES
+## Update the version numbers in the job name and the action parameters
+# |-------------|-----------------|-----------------|-----------------|
+# |  Drupal     |  10.2.x         |  10.3.x         |  10.4.x         |
+# |-------------|-----------------|-----------------|-----------------|
+# | **PHP 8.1** | ![Grid1A-Badge] | ![Grid2A-Badge] | ![Grid3A-Badge] |
+# | **PHP 8.2** | ![Grid1B-Badge] | ![Grid2B-Badge] | ![Grid3B-Badge] |
+# | **PHP 8.3** | ![Grid1C-Badge] | ![Grid2C-Badge] | ![Grid3C-Badge] |
 
 jobs:
   grid-2C:
-    name: "Drupal $drupal_version - PHP $php_version - PostgreSQL $pgsql_version"
+    name: "Drupal 10.3.x-dev - PHP 8.3 - PostgreSQL 16"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -23,6 +27,6 @@ jobs:
           modules: 'trpcultivate_phenotypes trpcultivate_phenocollect trpcultivate_phenoshare'
           build-image: TRUE
           dockerfile: 'Dockerfile'
-          php-version: $php_version
-          pgsql-version: $pgsql_version
-          drupal-version: $drupal_version
+          php-version: 8.3
+          pgsql-version: 16
+          drupal-version: 10.3.x-dev

--- a/.github/workflows/MAIN-phpunit-Grid2C.yml
+++ b/.github/workflows/MAIN-phpunit-Grid2C.yml
@@ -4,8 +4,14 @@ on:
     branches:
       - 4.x
 
+env:
+  php_version: '8.3'
+  pgsql_version: '16'
+  drupal_version: '10.3.x-dev'
+
 jobs:
-  grid-1A:
+  grid-2C:
+    name: "Drupal $drupal_version - PHP $php_version - PostgreSQL $pgsql_version"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -17,6 +23,6 @@ jobs:
           modules: 'trpcultivate_phenotypes trpcultivate_phenocollect trpcultivate_phenoshare'
           build-image: TRUE
           dockerfile: 'Dockerfile'
-          php-version: '8.3'
-          pgsql-version: '16'
-          drupal-version: '10.3.x-dev'
+          php-version: $php_version
+          pgsql-version: $pgsql_version
+          drupal-version: $drupal_version

--- a/.github/workflows/MAIN-phpunit-Grid2C.yml
+++ b/.github/workflows/MAIN-phpunit-Grid2C.yml
@@ -17,6 +17,6 @@ jobs:
           modules: 'trpcultivate_phenotypes trpcultivate_phenocollect trpcultivate_phenoshare'
           build-image: TRUE
           dockerfile: 'Dockerfile'
-          php-version: '8.2'
-          pgsql-version: '13'
-          drupal-version: '10.2.x-dev'
+          php-version: '8.3'
+          pgsql-version: '16'
+          drupal-version: '10.3.x-dev'

--- a/.github/workflows/MAIN-phpunit-Grid2C.yml
+++ b/.github/workflows/MAIN-phpunit-Grid2C.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
       - name: Run Automated testing
-        uses: tripal/test-tripal-action@v1.5
+        uses: tripal/test-tripal-action@v1.6
         with:
           directory-name: 'TripalCultivate-Phenotypes'
           modules: 'trpcultivate_phenotypes trpcultivate_phenocollect trpcultivate_phenoshare'

--- a/.github/workflows/MAIN-phpunit-Grid3A.yml
+++ b/.github/workflows/MAIN-phpunit-Grid3A.yml
@@ -5,7 +5,7 @@ on:
       - 4.x
 
 jobs:
-  grid-1A:
+  grid-2A:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -19,4 +19,4 @@ jobs:
           dockerfile: 'Dockerfile'
           php-version: '8.1'
           pgsql-version: '16'
-          drupal-version: '10.2.x-dev'
+          drupal-version: '10.4.x-dev'

--- a/.github/workflows/MAIN-phpunit-Grid3A.yml
+++ b/.github/workflows/MAIN-phpunit-Grid3A.yml
@@ -4,8 +4,14 @@ on:
     branches:
       - 4.x
 
+env:
+  php_version: '8.1'
+  pgsql_version: '16'
+  drupal_version: '10.4.x-dev'
+
 jobs:
-  grid-2A:
+  grid-3A:
+    name: "Drupal $drupal_version - PHP $php_version - PostgreSQL $pgsql_version"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -17,6 +23,6 @@ jobs:
           modules: 'trpcultivate_phenotypes trpcultivate_phenocollect trpcultivate_phenoshare'
           build-image: TRUE
           dockerfile: 'Dockerfile'
-          php-version: '8.1'
-          pgsql-version: '16'
-          drupal-version: '10.4.x-dev'
+          php-version: $php_version
+          pgsql-version: $pgsql_version
+          drupal-version: $drupal_version

--- a/.github/workflows/MAIN-phpunit-Grid3A.yml
+++ b/.github/workflows/MAIN-phpunit-Grid3A.yml
@@ -4,14 +4,18 @@ on:
     branches:
       - 4.x
 
-env:
-  php_version: '8.1'
-  pgsql_version: '16'
-  drupal_version: '10.4.x-dev'
+## UPDATES
+## Update the version numbers in the job name and the action parameters
+# |-------------|-----------------|-----------------|-----------------|
+# |  Drupal     |  10.2.x         |  10.3.x         |  10.4.x         |
+# |-------------|-----------------|-----------------|-----------------|
+# | **PHP 8.1** | ![Grid1A-Badge] | ![Grid2A-Badge] | ![Grid3A-Badge] |
+# | **PHP 8.2** | ![Grid1B-Badge] | ![Grid2B-Badge] | ![Grid3B-Badge] |
+# | **PHP 8.3** | ![Grid1C-Badge] | ![Grid2C-Badge] | ![Grid3C-Badge] |
 
 jobs:
   grid-3A:
-    name: "Drupal $drupal_version - PHP $php_version - PostgreSQL $pgsql_version"
+    name: "Drupal 10.4.x-dev - PHP 8.1 - PostgreSQL 16"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -23,6 +27,6 @@ jobs:
           modules: 'trpcultivate_phenotypes trpcultivate_phenocollect trpcultivate_phenoshare'
           build-image: TRUE
           dockerfile: 'Dockerfile'
-          php-version: $php_version
-          pgsql-version: $pgsql_version
-          drupal-version: $drupal_version
+          php-version: 8.1
+          pgsql-version: 16
+          drupal-version: 10.4.x-dev

--- a/.github/workflows/MAIN-phpunit-Grid3A.yml
+++ b/.github/workflows/MAIN-phpunit-Grid3A.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
       - name: Run Automated testing
-        uses: tripal/test-tripal-action@v1.5
+        uses: tripal/test-tripal-action@v1.6
         with:
           directory-name: 'TripalCultivate-Phenotypes'
           modules: 'trpcultivate_phenotypes trpcultivate_phenocollect trpcultivate_phenoshare'

--- a/.github/workflows/MAIN-phpunit-Grid3B.yml
+++ b/.github/workflows/MAIN-phpunit-Grid3B.yml
@@ -5,7 +5,7 @@ on:
       - 4.x
 
 jobs:
-  grid-1A:
+  grid-2B:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -17,6 +17,6 @@ jobs:
           modules: 'trpcultivate_phenotypes trpcultivate_phenocollect trpcultivate_phenoshare'
           build-image: TRUE
           dockerfile: 'Dockerfile'
-          php-version: '8.1'
+          php-version: '8.2'
           pgsql-version: '16'
-          drupal-version: '10.2.x-dev'
+          drupal-version: '10.4.x-dev'

--- a/.github/workflows/MAIN-phpunit-Grid3B.yml
+++ b/.github/workflows/MAIN-phpunit-Grid3B.yml
@@ -4,14 +4,18 @@ on:
     branches:
       - 4.x
 
-env:
-  php_version: '8.2'
-  pgsql_version: '16'
-  drupal_version: '10.4.x-dev'
+## UPDATES
+## Update the version numbers in the job name and the action parameters
+# |-------------|-----------------|-----------------|-----------------|
+# |  Drupal     |  10.2.x         |  10.3.x         |  10.4.x         |
+# |-------------|-----------------|-----------------|-----------------|
+# | **PHP 8.1** | ![Grid1A-Badge] | ![Grid2A-Badge] | ![Grid3A-Badge] |
+# | **PHP 8.2** | ![Grid1B-Badge] | ![Grid2B-Badge] | ![Grid3B-Badge] |
+# | **PHP 8.3** | ![Grid1C-Badge] | ![Grid2C-Badge] | ![Grid3C-Badge] |
 
 jobs:
   grid-3B:
-    name: "Drupal $drupal_version - PHP $php_version - PostgreSQL $pgsql_version"
+    name: "Drupal 10.4.x-dev - PHP 8.2 - PostgreSQL 16"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -23,6 +27,6 @@ jobs:
           modules: 'trpcultivate_phenotypes trpcultivate_phenocollect trpcultivate_phenoshare'
           build-image: TRUE
           dockerfile: 'Dockerfile'
-          php-version: $php_version
-          pgsql-version: $pgsql_version
-          drupal-version: $drupal_version
+          php-version: 8.2
+          pgsql-version: 16
+          drupal-version: 10.4.x-dev

--- a/.github/workflows/MAIN-phpunit-Grid3B.yml
+++ b/.github/workflows/MAIN-phpunit-Grid3B.yml
@@ -4,8 +4,14 @@ on:
     branches:
       - 4.x
 
+env:
+  php_version: '8.2'
+  pgsql_version: '16'
+  drupal_version: '10.4.x-dev'
+
 jobs:
-  grid-2B:
+  grid-3B:
+    name: "Drupal $drupal_version - PHP $php_version - PostgreSQL $pgsql_version"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -17,6 +23,6 @@ jobs:
           modules: 'trpcultivate_phenotypes trpcultivate_phenocollect trpcultivate_phenoshare'
           build-image: TRUE
           dockerfile: 'Dockerfile'
-          php-version: '8.2'
-          pgsql-version: '16'
-          drupal-version: '10.4.x-dev'
+          php-version: $php_version
+          pgsql-version: $pgsql_version
+          drupal-version: $drupal_version

--- a/.github/workflows/MAIN-phpunit-Grid3B.yml
+++ b/.github/workflows/MAIN-phpunit-Grid3B.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
       - name: Run Automated testing
-        uses: tripal/test-tripal-action@v1.5
+        uses: tripal/test-tripal-action@v1.6
         with:
           directory-name: 'TripalCultivate-Phenotypes'
           modules: 'trpcultivate_phenotypes trpcultivate_phenocollect trpcultivate_phenoshare'

--- a/.github/workflows/MAIN-phpunit-Grid3C.yml
+++ b/.github/workflows/MAIN-phpunit-Grid3C.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
       - name: Run Automated testing
-        uses: tripal/test-tripal-action@v1.5
+        uses: tripal/test-tripal-action@v1.6
         with:
           directory-name: 'TripalCultivate-Phenotypes'
           modules: 'trpcultivate_phenotypes trpcultivate_phenocollect trpcultivate_phenoshare'

--- a/.github/workflows/MAIN-phpunit-Grid3C.yml
+++ b/.github/workflows/MAIN-phpunit-Grid3C.yml
@@ -18,5 +18,5 @@ jobs:
           build-image: TRUE
           dockerfile: 'Dockerfile'
           php-version: '8.3'
-          pgsql-version: '13'
-          drupal-version: '10.2.x-dev'
+          pgsql-version: '16'
+          drupal-version: '10.4.x-dev'

--- a/.github/workflows/MAIN-phpunit-Grid3C.yml
+++ b/.github/workflows/MAIN-phpunit-Grid3C.yml
@@ -4,14 +4,18 @@ on:
     branches:
       - 4.x
 
-env:
-  php_version: '8.3'
-  pgsql_version: '16'
-  drupal_version: '10.4.x-dev'
+## UPDATES
+## Update the version numbers in the job name and the action parameters
+# |-------------|-----------------|-----------------|-----------------|
+# |  Drupal     |  10.2.x         |  10.3.x         |  10.4.x         |
+# |-------------|-----------------|-----------------|-----------------|
+# | **PHP 8.1** | ![Grid1A-Badge] | ![Grid2A-Badge] | ![Grid3A-Badge] |
+# | **PHP 8.2** | ![Grid1B-Badge] | ![Grid2B-Badge] | ![Grid3B-Badge] |
+# | **PHP 8.3** | ![Grid1C-Badge] | ![Grid2C-Badge] | ![Grid3C-Badge] |
 
 jobs:
   grid-3C:
-    name: "Drupal $drupal_version - PHP $php_version - PostgreSQL $pgsql_version"
+    name: "Drupal 10.4.x-dev - PHP 8.3 - PostgreSQL 16"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -23,6 +27,6 @@ jobs:
           modules: 'trpcultivate_phenotypes trpcultivate_phenocollect trpcultivate_phenoshare'
           build-image: TRUE
           dockerfile: 'Dockerfile'
-          php-version: $php_version
-          pgsql-version: $pgsql_version
-          drupal-version: $drupal_version
+          php-version: 8.3
+          pgsql-version: 16
+          drupal-version: 10.4.x-dev

--- a/.github/workflows/MAIN-phpunit-Grid3C.yml
+++ b/.github/workflows/MAIN-phpunit-Grid3C.yml
@@ -4,8 +4,14 @@ on:
     branches:
       - 4.x
 
+env:
+  php_version: '8.3'
+  pgsql_version: '16'
+  drupal_version: '10.4.x-dev'
+
 jobs:
-  grid-1A:
+  grid-3C:
+    name: "Drupal $drupal_version - PHP $php_version - PostgreSQL $pgsql_version"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -17,6 +23,6 @@ jobs:
           modules: 'trpcultivate_phenotypes trpcultivate_phenocollect trpcultivate_phenoshare'
           build-image: TRUE
           dockerfile: 'Dockerfile'
-          php-version: '8.3'
-          pgsql-version: '16'
-          drupal-version: '10.4.x-dev'
+          php-version: $php_version
+          pgsql-version: $pgsql_version
+          drupal-version: $drupal_version

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG drupalversion='10.2.x-dev'
+ARG drupalversion='10.3.x-dev'
 ARG phpversion='8.3'
 ARG pgsqlversion='16'
 FROM knowpulse/tripalcultivate:baseonly-drupal${drupalversion}-php${phpversion}-pgsql${pgsqlversion}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-ARG drupalversion='10.3.x-dev'
-ARG phpversion='8.3'
-ARG pgsqlversion='16'
+ARG drupalversion=10.3.x-dev
+ARG phpversion=8.3
+ARG pgsqlversion=16
 FROM knowpulse/tripalcultivate:baseonly-drupal${drupalversion}-php${phpversion}-pgsql${pgsqlversion}
 
 COPY . /var/www/drupal/web/modules/contrib/TripalCultivate-Phenotypes

--- a/README.md
+++ b/README.md
@@ -62,11 +62,11 @@ maintainability issues and test coverage.
 
 The following compatibility is proven via automated testing workflows.
 
-|  Drupal     |  10.0.x         |  10.1.x         |  10.2.x         |
+|  Drupal     |  10.2.x         |  10.3.x         |  10.4.x         |
 |-------------|-----------------|-----------------|-----------------|
-| **PHP 8.1** | ![Grid1A-Badge] | ![Grid1B-Badge] | ![Grid1C-Badge] |
-| **PHP 8.2** | ![Grid2A-Badge] | ![Grid2B-Badge] | ![Grid2C-Badge] |
-| **PHP 8.3** |                 |                 | ![Grid3C-Badge] |
+| **PHP 8.1** | ![Grid1A-Badge] | ![Grid2A-Badge] | ![Grid3A-Badge] |
+| **PHP 8.2** | ![Grid1B-Badge] | ![Grid2B-Badge] | ![Grid3B-Badge] |
+| **PHP 8.3** | ![Grid1C-Badge] | ![Grid2C-Badge] | ![Grid3C-Badge] |
 
 [our CodeClimate project page]: https://github.com/TripalCultivate/TripalCultivate-Phenotypes
 [MaintainabilityBadge]: https://api.codeclimate.com/v1/badges/03fa542e0d95dedb97e8/maintainability
@@ -80,4 +80,6 @@ The following compatibility is proven via automated testing workflows.
 [Grid2B-Badge]: https://github.com/TripalCultivate/TripalCultivate-Phenotypes/actions/workflows/MAIN-phpunit-Grid2B.yml/badge.svg
 [Grid2C-Badge]: https://github.com/TripalCultivate/TripalCultivate-Phenotypes/actions/workflows/MAIN-phpunit-Grid2C.yml/badge.svg
 
+[Grid3A-Badge]: https://github.com/TripalCultivate/TripalCultivate-Phenotypes/actions/workflows/MAIN-phpunit-Grid3A.yml/badge.svg
+[Grid3B-Badge]: https://github.com/TripalCultivate/TripalCultivate-Phenotypes/actions/workflows/MAIN-phpunit-Grid3B.yml/badge.svg
 [Grid3C-Badge]: https://github.com/TripalCultivate/TripalCultivate-Phenotypes/actions/workflows/MAIN-phpunit-Grid3C.yml/badge.svg

--- a/trpcultivate_phenocollect/tests/src/Functional/InstallTest.php
+++ b/trpcultivate_phenocollect/tests/src/Functional/InstallTest.php
@@ -72,10 +72,7 @@ class InstallTest extends ChadoTestBrowserBase {
     $some_extected_text = self::$help_text_excerpt;
 
     // Ensure we have an admin user.
-    $permissions = ['access administration pages', 'administer modules'];
-    if (strncmp(\Drupal::VERSION, '10.2', 4) === 0) {
-      $permissions[] = 'access help pages';
-    }
+    $permissions = ['access administration pages','administer modules', 'access help pages'];
     $user = $this->drupalCreateUser($permissions);
     $this->drupalLogin($user);
 

--- a/trpcultivate_phenoshare/tests/src/Functional/InstallTest.php
+++ b/trpcultivate_phenoshare/tests/src/Functional/InstallTest.php
@@ -72,10 +72,7 @@ class InstallTest extends ChadoTestBrowserBase {
     $some_extected_text = self::$help_text_excerpt;
 
     // Ensure we have an admin user.
-    $permissions = ['access administration pages', 'administer modules'];
-    if (strncmp(\Drupal::VERSION, '10.2', 4) === 0) {
-      $permissions[] = 'access help pages';
-    }
+    $permissions = ['access administration pages','administer modules', 'access help pages'];
     $user = $this->drupalCreateUser($permissions);
     $this->drupalLogin($user);
 

--- a/trpcultivate_phenotypes/tests/src/Functional/InstallTest.php
+++ b/trpcultivate_phenotypes/tests/src/Functional/InstallTest.php
@@ -86,10 +86,7 @@ class InstallTest extends ChadoTestBrowserBase {
     $some_extected_text = self::$help_text_excerpt;
 
     // Ensure we have an admin user.
-    $permissions = ['access administration pages', 'administer modules'];
-    if (strncmp(\Drupal::VERSION, '10.2', 4) === 0) {
-      $permissions[] = 'access help pages';
-    }
+    $permissions = ['access administration pages', 'administer modules', 'access help pages'];
     $user = $this->drupalCreateUser($permissions);
     $this->drupalLogin($user);
 


### PR DESCRIPTION
**Issue #103**

This PR adds the following:

1. Supports the new TripalDocker version as of PR https://github.com/tripal/tripal/pull/1951 which merges all PHP versions into a single Dockerfile and ensures the Docker handles keeping up PostgreSQL via Supervisord this means we no longer need to run `service postgresql restart` on a fresh TripalDocker container and also meant the test-tripal-action needs to confirm postgresql is done starting before running tests.
2. Supports reporting Test Code Coverage to CodeClimate Quality using the test-tripal-action to make these workflows easier to maintain.
3. Updates the versions of Drupal/PHP/PostgreSQL being tested, the version grid in the readme and makes the workflows easier to keep track of with better job names and comments.
4. Adds support for devcontainers in this repo including extensions to manage automated tests and workflow results in VSCode.

Testing:

This PR really just makes changes to automated testing workflows so as long as they pass here on github it should be fine. That said, you can also try out the devcontainer locally using the instructions here: https://github.com/tripal/tripal_doc/pull/92.