### PR TITLE
g4.85 Update Validators: EmptyCell, ValueInList and DuplicateTraits

### DIFF
--- a/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
+++ b/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
@@ -523,7 +523,8 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
             // Then new style.
             elseif (array_key_exists('valid', $result) && $result['valid'] === FALSE) {
               $failed_validator = TRUE;
-              //array_push($failures['data-row'][$validator_name]['failed_rows'], $line_no);
+              //$failures['data-row'][$validator_name][$line_no] = $result;
+              array_push($failures['data-row'][$validator_name]['failed_rows'], $line_no);
             }
           }
         }
@@ -534,9 +535,14 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
         foreach($failures['data-row'] as $validator_name => $validator_messages) {
           if (!empty($validator_messages['failed_rows'])) {
             $validation[$validator_name] = [
+              // Old return values
               'title' => $validator_messages['fail_title'],
               'status' => 'fail',
-              'details' => $validator_messages['fail_details'] . implode(', ', $validator_messages['failed_rows'])
+              'details' => $validator_messages['fail_details'] . implode(', ', $validator_messages['failed_rows']),
+              // New return values
+              'case' => $validator_messages['fail_details'],
+              'valid' => FALSE,
+              'failedItems' => $validator_messages['failed_rows']
             ];
           }
         }

--- a/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
+++ b/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
@@ -193,13 +193,13 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
     // Data Row Level
     // - All data row cells in columns 0,2,4 are not empty
     $instance = $manager->createInstance('empty_cell');
-    $context['indices'] = [
+    $indices = [
       $header_index['Trait Name'],
       $header_index['Method Short Name'],
       $header_index['Unit'],
       $header_index['Type']
     ];
-    $instance->context = $context;
+    $instance->setIndices($indices);
     $validators['data-row']['empty_cell'] = $instance;
 
     // - The column 'Type' is one of "Qualitative" and "Quantitative"

--- a/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
+++ b/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
@@ -204,14 +204,11 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
 
     // - The column 'Type' is one of "Qualitative" and "Quantitative"
     $instance = $manager->createInstance('value_in_list');
-    $context['indices'] = [
-      $header_index['Type']
-    ];
-    $context['valid_values'] = [
+    $instance->setIndices([$header_index['Type']]);
+    $instance->setValidValues([
       'Quantitative',
       'Qualitative'
-    ];
-    $instance->context = $context;
+    ]);
     $validators['data-row']['valid_data_type'] = $instance;
 
     // - The combination of Trait Name, Method Short Name and Unit is unique

--- a/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
+++ b/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
@@ -558,9 +558,9 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
           $message = $failures[$validator_name]['case'];
           $messages[$validator_name] = [
             'status' => 'fail',
-            'details' => $message
+            'details' => $message,
+            'raw_results' => $failures[$validator_name],
           ];
-          $messages['raw_results'] = $failures[$validator_name];
         }
         // @todo: Remove this if block when old validators GENUS, FILE, and
         // HEADERS are removed.
@@ -568,9 +568,9 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
           $message = $failures[$validator_name]['details'];
           $messages[$validator_name] = [
             'status' => 'fail',
-            'details' => $message
+            'details' => $message,
+            'raw_results' => $failures[$validator_name],
           ];
-          $messages['raw_results'] = $failures[$validator_name];
         }
         // @todo: Check if this is a validator that keeps track of line numbers.
         // @assumption: Only data-row validators enter this else
@@ -593,9 +593,9 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
           $message = $failures[$validator_name][$first_failed_row]['case'] . ' at row #: ' . $first_failed_row;
           $messages[$validator_name] = [
             'status' => 'fail',
-            'details' => $message
+            'details' => $message,
+            'raw_results' => $failures[$validator_name],
           ];
-          $messages['raw_results'] = $failures[$validator_name];
         }
       }
     }

--- a/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
+++ b/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
@@ -213,15 +213,15 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
 
     // - The combination of Trait Name, Method Short Name and Unit is unique
     $instance = $manager->createInstance('duplicate_traits');
+    // Set the logger since this validator uses a setter (setConfiguredGenus)
+    // which may log messages
+    $instance->setLogger($this->logger);
     $instance->setConfiguredGenus($genus);
     $instance->setIndices([
       'Trait Name' => $header_index['Trait Name'],
       'Method Short Name' => $header_index['Method Short Name'],
       'Unit' => $header_index['Unit']
     ]);
-    // Set the logger since this validator uses a setter (setConfiguredGenus)
-    // which may log messages
-    $instance->setLogger($this->logger);
     $validators['data-row']['duplicate_traits'] = $instance;
 
     //$this->validatorObjects = $validators;

--- a/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
+++ b/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
@@ -168,7 +168,7 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
     // - All header row cells are not empty.
     // @TODO: Uncomment the following code when the Headers validator has been
     //        updated and no longer uses the validate() method.
-    // $instance = $manager->createInstance('empty_header_cell');
+    // $instance = $manager->createInstance('empty_cell');
     // $context['indices'] = [
     //   $header_index['Trait Name'],
     //   $header_index['Trait Description'],
@@ -478,9 +478,9 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
    *   by the unique name assigned to each validator-input type combination
    *
    * @return array
-   *   An array of all the final return values for all of the validators used by
-   *   this importer, keyed by a string that is associated with a line in the
-   *   validate UI. Specifically:
+   *   An array of feedback to provide to the user which summarizes the validation results 
+   *   reported by the validators in the formValidate (i.e. $failures). This array is keyed 
+   *   by a string that is associated with a line in the validate UI. Specifically,
    *   - 'validation_line': A string associated with a line that will be
    *     displayed to the user in the validate UI
    *     - 'title': A user-focussed message describing the validation that took
@@ -493,7 +493,9 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
    *       contents of $failures['validator_name'].
    */
   public function processValidationMessages($failures) {
-    // Array to hold all validation results for each validator. Everything is
+    // Array to hold all the user feedback. Currently this includes an entry for each 
+    // validator. However, in future designs we may combine more then one validator into a
+    // single line in the validate UI and, thus, a single entry in this array. Everything is
     // set to status of 'todo' to start and will only change to one of 'pass' or
     // 'fail' if the $failures[] array is defined for that validator, indicating
     // that validation did take place.

--- a/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
+++ b/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
@@ -230,32 +230,6 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
   }
 
   /**
-   * Service setter method:
-   * Set genus ontology configuration service.
-   *
-   * @param $service
-   *   Service as created/injected through create method.
-   */
-  public function setServiceGenusOntology($service) {
-    if ($service) {
-      $this->service_genusontology = $service;
-    }
-  }
-
-  /**
-   * Service setter method:
-   * Set traits service.
-   *
-   * @param $service
-   *   Service as created/injected through create method.
-   */
-  public function setServiceTraits($service) {
-    if ($service) {
-      $this->service_traits = $service;
-    }
-  }
-
-  /**
    * {@inheritDoc}
    */
   public function form($form, &$form_state) {
@@ -323,10 +297,6 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
     return $form;
   }
 
-
-  ///
-
-
   /**
    * {@inheritdoc}
    */
@@ -342,17 +312,19 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
 
     $file_id = $form_values['file_upload'];
 
-    // Use a variable to keep track of if one input type had received errors
-    // and only continue to the next if no errors.
+    // A FLAG to keep track if any validator fails.
+    // We will only continue to the next input-type if all validators of the
+    // current input-type pass.
     $failed_validator = FALSE;
 
     // Keep track of failed items.
-    // We expect the first key to be a unique id of the validator instance
-    // which is not just the validator id as there can be multiple instances
-    // of one validator. Then within that we expect line number
+    // We expect the first key to be a unique name of the validator instance
+    // (as declared by the configureValidators() method) as there can be multiple
+    // instances of one validator. For file-row input-type validators, this will
+    // be further keyed by line number.
     $failures = [];
 
-    // Configure the validators
+    // Configure the validators.
     $validators = $this->configureValidators($form_values);
 
     // ************************************************************************
@@ -360,7 +332,7 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
     // ************************************************************************
     foreach ($validators['metadata'] as $validator_name => $validator) {
       // Set failures for this validator name to an empty array to signal that
-      // this validator has been run
+      // this validator has been run.
       $failures[$validator_name] = [];
       // @TODO: Update to use the validateMetadata() method
       $result = $validator->validate();
@@ -377,7 +349,7 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
     }
 
     // Check if any previous validators failed before moving on to the next
-    // input type validation
+    // input-type validation.
     if ($failed_validator === FALSE) {
       // **********************************************************************
       // File Validation
@@ -403,14 +375,16 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
     }
 
     // Check if any previous validators failed before moving on to the next
-    // input type validation
+    // input-type validation.
     if ($failed_validator === FALSE) {
 
       // Open the file so we can iterate through the rows
       $file = File::load($file_id);
+
       // Open and read file in this uri.
       $file_uri = $file->getFileUri();
       $handle = fopen($file_uri, 'r');
+
       // Get the mime type which is used to split the row.
       $file_mime_type = $file->getMimeType();
 
@@ -427,14 +401,14 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
         // Header Row Validation
         // ********************************************************************
         if ($line_no == 1) {
-          // Split line into an array using the delimiter defined by this importer
-          // in the configure values method above.
+          // Split line into an array of values.
           $header_row = TripalCultivatePhenotypesValidatorBase::splitRowIntoColumns($line, $file_mime_type);
           foreach ($validators['header-row'] as $validator_name => $validator) {
-            // Set failures for this validator name to an empty array to signal that
-            // this validator has been run
+            // Set failures for this validator name to an empty array to signal
+            // that this validator has been run
             $failures[$validator_name] = [];
-            // @TODO: Update to use the validateRow() method and use the split $header_row above.
+            // @TODO: Update to use the validateRow() method and use the split
+            // $header_row above.
             $result = $validator->validate();
 
             // Check for old style...
@@ -448,7 +422,8 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
               $failures[$validator_name] = $result;
             }
           }
-          // If a header validator failed, skip validation of the data rows
+          // If any header-row validators failed, skip validation of the data
+          // rows.
           if ($failed_validator === TRUE) {
             break;
           }
@@ -458,19 +433,20 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
         // Data Row Validation
         // ********************************************************************
         else if ($line_no > 1) {
-          // Split line into an array using the delimiter defined by this importer
-          // in the configure values method above.
+          // Split line into an array using the delimiter defined by this
+          // importer in the configure values method above.
           $data_row = TripalCultivatePhenotypesValidatorBase::splitRowIntoColumns($line, $file_mime_type);
 
-          // Call each validator on this row of the file
+          // Call each validator on this row of the file.
           foreach($validators['data-row'] as $validator_name => $validator) {
-            // Set failures for this validator name to an empty array to signal that
-            // this validator has been run, ONLY if it doesn't already exist.
+            // Set failures for this validator name to an empty array to signal
+            // that this validator has been run, ONLY if it doesn't already exist
+            // (ie. this validator may have already failed on a previous row).
             if(!array_key_exists($validator_name, $failures)) {
               $failures[$validator_name] = [];
             }
             $result = $validator->validateRow($data_row);
-            // Check if validation failed
+            // Check if validation failed.
             if (array_key_exists('valid', $result) && $result['valid'] === FALSE) {
               $failed_validator = TRUE;
               $failures[$validator_name][$line_no] = $result;
@@ -481,16 +457,14 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
     }
     $validation_feedback = $this->processValidationMessages($failures);
 
-    // Save all validation results in Drupal storage to be used by
-    // validation window to create summary report.
+    // Save all validation results in Drupal storage to create a summary report.
     $storage = $form_state->getStorage();
     $storage[ $this->validation_result ] = $validation_feedback;
     $form_state->setStorage($storage);
 
     if ($failed_validator === TRUE) {
-      // There are issues in the submission and are detailed in the validation result window.
-      // Prevent this form from submitting and reload form with all the validation errors
-      // in the storage system.
+      // Prevent this form from submitting and reload form with all the
+      // validation failures in the storage system.
       $form_state->setRebuild(TRUE);
     }
   }
@@ -507,37 +481,42 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
    *   An array of all the final return values for all of the validators used by
    *   this importer, keyed by a string that is associated with a line in the
    *   validate UI. Specifically:
-   *   - 'validation_line': A string assocaited with a line that will be
+   *   - 'validation_line': A string associated with a line that will be
    *     displayed to the user in the validate UI
    *     - 'title': A user-focussed message describing the validation that took
    *       place.
    *     - 'details': A user-focussed message describing the failure that
    *       occurred and any relevant details to help the user fix it.
-   *     - 'status': One of 'pass' or 'fail'.
+   *     - 'status': One of: 'todo', 'pass', 'fail'.
    *     - 'raw_results': A nested array keyed by validator name, which contains
    *       the raw return values when validation failed. Essentially, the
    *       contents of $failures['validator_name'].
    */
   public function processValidationMessages($failures) {
-    // Array to hold all validation result for each validator.
-    // @todo: Remove the keys 'title', 'status' and 'details' once the old
-    // return style is fully deprecated.
+    // Array to hold all validation results for each validator. Everything is
+    // set to status of 'todo' to start and will only change to one of 'pass' or
+    // 'fail' if the $failures[] array is defined for that validator, indicating
+    // that validation did take place.
     $messages = [
+      // ----------------------------- METADATA --------------------------------
       'GENUS' => [
         'title' => 'Genus exists and/or matches the project/experiment',
         'status' => 'todo',
         'details' => ''
       ],
+      // ------------------------------- FILE ----------------------------------
       'FILE' => [
         'title' => 'File is a valid tsv or txt',
         'status' => 'todo',
         'details' => ''
       ],
+      // ---------------------------- HEADER ROW -------------------------------
       'HEADERS' => [
         'title' => 'File has all of the column headers expected',
         'status' => 'todo',
         'details' => ''
       ],
+      // ----------------------------- DATA ROW --------------------------------
       'empty_cell' => [
         'title' => 'Required cells contain a value',
         'status' => 'todo',
@@ -559,6 +538,8 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
       // Check if this validator exists in the failures array, which indicates
       // that it was run.
       if (array_key_exists($validator_name, $failures)) {
+
+        // ----------------------------- PASS ----------------------------------
         // Check if $failures[$validator_name] is empty, which indicates there
         // are no errors to report for this validator.
         if (count($failures[$validator_name]) === 0 ) {
@@ -566,38 +547,55 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
             'status' => 'pass',
           ];
         }
+
+        // ----------------------------- FAIL ----------------------------------
         // Check if $failures[$validator_name] contains one of the results
         // keys, indicating that this is not a row-level validator and therefore
         // doesn't keep track of line numbers.
         else if (array_key_exists('case', $failures[$validator_name])) {
-          // @todo: Update this to not use the 'case' string by default and to
-          // incorporate the 'failed_details'
+          // @todo: Update the message to not use the 'case' string by default
+          // and to incorporate the 'failed_details'.
           $message = $failures[$validator_name]['case'];
           $messages[$validator_name] = [
             'status' => 'fail',
             'details' => $message
           ];
+          $messages['raw_results'] = $failures[$validator_name];
         }
-        // @todo: Remove this if when old validators GENUS, FILE, and HEADERS are
-        // removed
+        // @todo: Remove this if block when old validators GENUS, FILE, and
+        // HEADERS are removed.
         else if (array_key_exists('details', $failures[$validator_name])){
           $message = $failures[$validator_name]['details'];
           $messages[$validator_name] = [
             'status' => 'fail',
             'details' => $message
           ];
+          $messages['raw_results'] = $failures[$validator_name];
         }
-        // Lastly, assume this is a validator that keeps track of line numbers.
+        // @todo: Check if this is a validator that keeps track of line numbers.
+        // @assumption: Only data-row validators enter this else
+        // block since BOTH:
+        //   a) $failures[$validator_name] is not empty
+        //   b) $failures[$validator_name]['case'] is not set
+        // It would be better to validate that we have line numbers (integers)
+        // then leave the else {} for anything outside of these options to throw
+        // an exception for the developer. Reminder that:
+        // $failures[$validator_name]['valid'] and
+        // $failures[$validator_name]['failures']
+        // also are valid but this scenario should have already been caught by
+        // the previous if block.
         else {
           // @todo: Update this current approach to not report only the first
-          // failure, but instead collect all the cases and faileditems and
+          // failure, but instead collect all the cases and failedItems and
           // formulate one concise, helpful feedback message.
+          // foreach ($failures[$validator_name] as $line_no => $validator_results) {
           $first_failed_row = array_key_first($failures[$validator_name]);
           $message = $failures[$validator_name][$first_failed_row]['case'] . ' at row #: ' . $first_failed_row;
           $messages[$validator_name] = [
             'status' => 'fail',
             'details' => $message
           ];
+          $messages['raw_results'] = $failures[$validator_name];
         }
       }
     }
@@ -704,5 +702,35 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
     ];
 
     return \Drupal::service('renderer')->renderPlain($build);
+  }
+
+  /**
+   * Service setter method:
+   * Set genus ontology configuration service.
+   *
+   * @param $service
+   *   Service as created/injected through create method.
+   *
+   * @return void
+   */
+  public function setServiceGenusOntology($service) {
+    if ($service) {
+      $this->service_genusontology = $service;
+    }
+  }
+
+  /**
+   * Service setter method:
+   * Set traits service.
+   *
+   * @param $service
+   *   Service as created/injected through create method.
+   *
+   * @return void
+   */
+  public function setServiceTraits($service) {
+    if ($service) {
+      $this->service_traits = $service;
+    }
   }
 }

--- a/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
+++ b/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
@@ -213,13 +213,12 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
 
     // - The combination of Trait Name, Method Short Name and Unit is unique
     $instance = $manager->createInstance('duplicate_traits');
-    $context['genus'] = $genus;
-    $context['indices'] = [
+    $instance->setConfiguredGenus($genus);
+    $instance->setIndices([
       'Trait Name' => $header_index['Trait Name'],
       'Method Short Name' => $header_index['Method Short Name'],
       'Unit' => $header_index['Unit']
-    ];
-    $instance->context = $context;
+    ]);
     $validators['data-row']['duplicate_traits'] = $instance;
 
     //$this->validatorObjects = $validators;

--- a/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
+++ b/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
@@ -541,7 +541,7 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
         foreach($validators['data-row'] as $validator_name => $validator) {
           if (array_key_exists($validator_name, $failures['data-row'])) {
             $first_failed_row = array_key_first($failures['data-row'][$validator_name]);
-            $message = $failures['data-row'][$validator_name][$first_failed_row]['case'] . 'at row #: ' . $first_failed_row;
+            $message = $failures['data-row'][$validator_name][$first_failed_row]['case'] . ' at row #: ' . $first_failed_row;
             $validation[$validator_name] = [
               'case' => $message,
               'valid' => FALSE,

--- a/trpcultivate_phenotypes/src/Plugin/Validators/DuplicateTraits.php
+++ b/trpcultivate_phenotypes/src/Plugin/Validators/DuplicateTraits.php
@@ -171,11 +171,9 @@ class DuplicateTraits extends TripalCultivatePhenotypesValidatorBase implements 
     }
 
     // Check if our trait combo exists at the database level
-    // First make sure to get our genus and then set it in our Traits Service
-    // before we can grab our trait combo
-    $genus = $this->getConfiguredGenus();
-    $this->service_PhenoTraits->setTraitGenus($genus);
-    // Grab our traits service
+    // NOTE: The trait service was configured to use this genus by
+    // the GenusConfigured trait when the genus was set.
+    // Grab our trait combo.
     $trait_combo = $this->service_PhenoTraits->getTraitMethodUnitCombo($trait, $method, $unit);
     if (!empty($trait_combo)) {
       // Duplicate found

--- a/trpcultivate_phenotypes/src/Plugin/Validators/DuplicateTraits.php
+++ b/trpcultivate_phenotypes/src/Plugin/Validators/DuplicateTraits.php
@@ -190,7 +190,7 @@ class DuplicateTraits extends TripalCultivatePhenotypesValidatorBase implements 
       if ($duplicate_in_db) {
         // This row is a duplicate of another row AND in the database
         $validator_status = [
-          'case' => 'A duplicate trait was found within both the input file and the database.',
+          'case' => 'A duplicate trait was found within both the input file and the database',
           'valid' => FALSE,
           'failedItems' => [
             'combo_provided' => [
@@ -203,7 +203,7 @@ class DuplicateTraits extends TripalCultivatePhenotypesValidatorBase implements 
       }
       else {
         $validator_status = [
-          'case' => 'A duplicate trait was found within the input file.',
+          'case' => 'A duplicate trait was found within the input file',
           'valid' => FALSE,
           'failedItems' => [
             'combo_provided' => [
@@ -217,7 +217,7 @@ class DuplicateTraits extends TripalCultivatePhenotypesValidatorBase implements 
     }
     else if ($duplicate_in_db) {
       $validator_status = [
-        'case' => 'A duplicate trait was found in the database.',
+        'case' => 'A duplicate trait was found in the database',
         'valid' => FALSE,
         'failedItems' => [
           'combo_provided' => [
@@ -231,7 +231,7 @@ class DuplicateTraits extends TripalCultivatePhenotypesValidatorBase implements 
     // If not seen before in the file or in the database, then set the validation to pass
     else {
       $validator_status = [
-        'case' => 'Confirmed that the current trait being validated is unique.',
+        'case' => 'Confirmed that the current trait being validated is unique',
         'valid' => TRUE,
         'failed_items' => []
       ];

--- a/trpcultivate_phenotypes/src/Plugin/Validators/DuplicateTraits.php
+++ b/trpcultivate_phenotypes/src/Plugin/Validators/DuplicateTraits.php
@@ -112,7 +112,7 @@ class DuplicateTraits extends TripalCultivatePhenotypesValidatorBase implements 
    * @return array
    *   An associative array with the following keys.
    *   - case: a developer focused string describing the case checked.
-   *   - valid: either TRUE or FALSE depending on if the genus value is valid or not.
+   *   - valid: TRUE if the trait is unique and FALSE if it already exists.
    *   - failedItems: an array of "items" that failed with the following keys, to
    *     be used in the message to the user. This is an empty array if the data row input was valid.
    *     - combo_provided: The combo of trait, method, and unit provided in the file.

--- a/trpcultivate_phenotypes/src/Plugin/Validators/DuplicateTraits.php
+++ b/trpcultivate_phenotypes/src/Plugin/Validators/DuplicateTraits.php
@@ -121,6 +121,13 @@ class DuplicateTraits extends TripalCultivatePhenotypesValidatorBase implements 
    *       - Trait Name: The trait name provided in the file
    *       - Method Short Name: The method name provided in the file
    *       - Unit: The unit provided in the file
+   *
+   * @throws \Exception
+   *  - If the $indices array grabbed by getIndices() is missing any of the
+   *    following keys (ie. these were not set by setIndices() in the importer):
+   *    - 'Trait Name'
+   *    - 'Method Short Name'
+   *    - 'Unit'
    */
   public function validateRow($row_values) {
 

--- a/trpcultivate_phenotypes/src/Plugin/Validators/DuplicateTraits.php
+++ b/trpcultivate_phenotypes/src/Plugin/Validators/DuplicateTraits.php
@@ -233,7 +233,7 @@ class DuplicateTraits extends TripalCultivatePhenotypesValidatorBase implements 
       $validator_status = [
         'case' => 'Confirmed that the current trait being validated is unique',
         'valid' => TRUE,
-        'failed_items' => []
+        'failedItems' => []
       ];
     }
     return $validator_status;

--- a/trpcultivate_phenotypes/src/Plugin/Validators/DuplicateTraits.php
+++ b/trpcultivate_phenotypes/src/Plugin/Validators/DuplicateTraits.php
@@ -22,7 +22,7 @@ use Drupal\trpcultivate_phenotypes\Service\TripalCultivatePhenotypesTraitsServic
  * @TripalCultivatePhenotypesValidator(
  *   id = "duplicate_traits",
  *   validator_name = @Translation("Duplicate Traits Validator"),
- *   validator_scope = "FILE ROW",
+ *   input_types = {"data-row"},
  * )
  */
 class DuplicateTraits extends TripalCultivatePhenotypesValidatorBase implements ContainerFactoryPluginInterface {

--- a/trpcultivate_phenotypes/src/Plugin/Validators/EmptyCell.php
+++ b/trpcultivate_phenotypes/src/Plugin/Validators/EmptyCell.php
@@ -26,7 +26,7 @@ class EmptyCell extends TripalCultivatePhenotypesValidatorBase implements Contai
   /**
    * This validator requires the following traits:
    * - ColumnIndices: Gets an array of indices corresponding to the cells in
-   *   $row_values to act on.
+   *     $row_values to act on.
    */
   use ColumnIndices;
 

--- a/trpcultivate_phenotypes/src/Plugin/Validators/EmptyCell.php
+++ b/trpcultivate_phenotypes/src/Plugin/Validators/EmptyCell.php
@@ -8,6 +8,7 @@
 namespace Drupal\trpcultivate_phenotypes\Plugin\Validators;
 
 use Drupal\trpcultivate_phenotypes\TripalCultivateValidator\TripalCultivatePhenotypesValidatorBase;
+use Drupal\trpcultivate_phenotypes\TripalCultivateValidator\ValidatorTraits\ColumnIndices;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -23,15 +24,11 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class EmptyCell extends TripalCultivatePhenotypesValidatorBase implements ContainerFactoryPluginInterface {
 
   /**
-   *   An associative array containing the needed context, which is dependant
-   *   on the validator. For example, instead of validating each cell by default,
-   *   a validator may need a list of indices which correspond to the columns in
-   *   the row for which the validator should act on.
-   *
-   *   This validator requires the following keys:
-   *   - indices => an array of indices corresponding to the cells in $row_values to act on
+   * This validator requires the following traits:
+   * - ColumnIndices: Gets an array of indices corresponding to the cells in
+   *   $row_values to act on.
    */
-  public array $context = [];
+  use ColumnIndices;
 
   /**
    * Constructor.
@@ -66,12 +63,12 @@ class EmptyCell extends TripalCultivatePhenotypesValidatorBase implements Contai
    */
   public function validateRow($row_values) {
 
-    // Set our context which was configured for this validator
-    $context = $this->context;
+    // Grab our indices
+    $indices = $this->getIndices();
 
     // Check the indices provided are valid in the context of the row.
     // Will throw an exception if there's a problem
-    $this->checkIndices($row_values, $context['indices']);
+    $this->checkIndices($row_values, $indices);
 
     $empty = FALSE;
     $failed_indices = [];
@@ -79,7 +76,7 @@ class EmptyCell extends TripalCultivatePhenotypesValidatorBase implements Contai
     foreach($row_values as $index => $cell) {
       // Only validate the values in which their index is also within our
       // context array of indices
-      if (in_array($index, $context['indices'])) {
+      if (in_array($index, $indices)) {
         // First trim the contents of our cell in case we have whitespace
         $cell = trim($cell);
         // Check if our content is empty and report an error if it is

--- a/trpcultivate_phenotypes/src/Plugin/Validators/EmptyCell.php
+++ b/trpcultivate_phenotypes/src/Plugin/Validators/EmptyCell.php
@@ -100,7 +100,7 @@ class EmptyCell extends TripalCultivatePhenotypesValidatorBase implements Contai
     } else {
       $validator_status = [
         'case' => 'No empty values found in required column(s)',
-        'valid' => 'pass',
+        'valid' => TRUE,
         'failedItems' => []
       ];
     }

--- a/trpcultivate_phenotypes/src/Plugin/Validators/EmptyCell.php
+++ b/trpcultivate_phenotypes/src/Plugin/Validators/EmptyCell.php
@@ -91,7 +91,7 @@ class EmptyCell extends TripalCultivatePhenotypesValidatorBase implements Contai
     // Check if empty values were found that should not be empty
     if ($empty) {
       $validator_status = [
-        'case' => 'Empty value found in required column(s).',
+        'case' => 'Empty value found in required column(s)',
         'valid' => FALSE,
         'failedItems' => [
           'empty_indices' => $failed_indices
@@ -99,7 +99,7 @@ class EmptyCell extends TripalCultivatePhenotypesValidatorBase implements Contai
       ];
     } else {
       $validator_status = [
-        'case' => 'No empty values found in required column(s).',
+        'case' => 'No empty values found in required column(s)',
         'valid' => 'pass',
         'failedItems' => []
       ];

--- a/trpcultivate_phenotypes/src/Plugin/Validators/EmptyCell.php
+++ b/trpcultivate_phenotypes/src/Plugin/Validators/EmptyCell.php
@@ -58,7 +58,7 @@ class EmptyCell extends TripalCultivatePhenotypesValidatorBase implements Contai
    * @return array
    *   An associative array with the following keys.
    *   - case: a developer focused string describing the case checked.
-   *   - valid: either TRUE or FALSE depending on if the genus value is valid or not.
+   *   - valid: FALSE if any of the cells being checked are empty and TRUE otherwise.
    *   - failedItems: an array of "items" that failed with the following keys, to
    *     be used in the message to the user. This is an empty array if the data row input was valid.
    *     - empty_indices: A list of indices which were checked and found to be empty

--- a/trpcultivate_phenotypes/src/Plugin/Validators/EmptyCell.php
+++ b/trpcultivate_phenotypes/src/Plugin/Validators/EmptyCell.php
@@ -24,7 +24,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class EmptyCell extends TripalCultivatePhenotypesValidatorBase implements ContainerFactoryPluginInterface {
 
   /**
-   * This validator requires the following traits:
+   * This validator requires the following validator traits:
    * - ColumnIndices: Gets an array of indices corresponding to the cells in
    *     $row_values to act on.
    */

--- a/trpcultivate_phenotypes/src/Plugin/Validators/EmptyCell.php
+++ b/trpcultivate_phenotypes/src/Plugin/Validators/EmptyCell.php
@@ -57,9 +57,11 @@ class EmptyCell extends TripalCultivatePhenotypesValidatorBase implements Contai
    *
    * @return array
    *   An associative array with the following keys.
-   *   - title: string, section or title of the validation as it appears in the result window.
-   *   - status: string, pass if it passed the validation check/test, fail string otherwise and todo string if validation was not applied.
-   *   - details: details about the offending field/value.
+   *   - case: a developer focused string describing the case checked.
+   *   - valid: either TRUE or FALSE depending on if the genus value is valid or not.
+   *   - failedItems: an array of "items" that failed with the following keys, to
+   *     be used in the message to the user. This is an empty array if the data row input was valid.
+   *     - empty_indices: A list of indices which were checked and found to be empty
    */
   public function validateRow($row_values) {
 
@@ -88,17 +90,18 @@ class EmptyCell extends TripalCultivatePhenotypesValidatorBase implements Contai
     }
     // Check if empty values were found that should not be empty
     if ($empty) {
-      $failed_list = implode(', ', $failed_indices);
       $validator_status = [
-        'title' => 'Empty value found in required column(s)',
-        'status' => 'fail',
-        'details' => 'Empty values at index: ' . $failed_list
+        'case' => 'Empty value found in required column(s).',
+        'valid' => FALSE,
+        'failedItems' => [
+          'empty_indices' => $failed_indices
+        ]
       ];
     } else {
       $validator_status = [
-        'title' => 'No empty values found in required column(s)',
-        'status' => 'pass',
-        'details' => ''
+        'case' => 'No empty values found in required column(s).',
+        'valid' => 'pass',
+        'failedItems' => []
       ];
     }
     return $validator_status;

--- a/trpcultivate_phenotypes/src/Plugin/Validators/EmptyCell.php
+++ b/trpcultivate_phenotypes/src/Plugin/Validators/EmptyCell.php
@@ -18,7 +18,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * @TripalCultivatePhenotypesValidator(
  *   id = "empty_cell",
  *   validator_name = @Translation("Empty Cell Validator"),
- *   validator_scope = "FILE ROW",
+ *   input_types = {"header-row", "data-row"},
  * )
  */
 class EmptyCell extends TripalCultivatePhenotypesValidatorBase implements ContainerFactoryPluginInterface {

--- a/trpcultivate_phenotypes/src/Plugin/Validators/ValueInList.php
+++ b/trpcultivate_phenotypes/src/Plugin/Validators/ValueInList.php
@@ -71,12 +71,12 @@ class ValueInList extends TripalCultivatePhenotypesValidatorBase implements Cont
     // Grab our indices
     $indices = $this->getIndices();
 
-    // Grab our valid values
-    $valid_values = $this->getValidValues();
-
     // Check the indices provided are valid in the context of the row.
     // Will throw an exception if there's a problem
     $this->checkIndices($row_values, $indices);
+
+    // Grab our valid values
+    $valid_values = $this->getValidValues();
 
     $valid = TRUE;
     $failed_indices = [];

--- a/trpcultivate_phenotypes/src/Plugin/Validators/ValueInList.php
+++ b/trpcultivate_phenotypes/src/Plugin/Validators/ValueInList.php
@@ -62,7 +62,8 @@ class ValueInList extends TripalCultivatePhenotypesValidatorBase implements Cont
    * @return array
    *   An associative array with the following keys.
    *   - case: a developer focused string describing the case checked.
-   *   - valid: either TRUE or FALSE depending on if the genus value is valid or not.
+   *   - valid: FALSE if any of the cells being checked contain a value not in the 
+   *     configured list of approved values and TRUE otherwise.
    *   - failedItems: an array of "items" that failed, to be used in the message
    *     to the user. This is an empty array if the data row input was valid.
    *     The array contains key => value pairs that map to the index => cell value(s)

--- a/trpcultivate_phenotypes/src/Plugin/Validators/ValueInList.php
+++ b/trpcultivate_phenotypes/src/Plugin/Validators/ValueInList.php
@@ -19,8 +19,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * @TripalCultivatePhenotypesValidator(
  *   id = "value_in_list",
  *   validator_name = @Translation("Value In List Validator"),
- *   validator_scope = "FILE ROW",
- *   input_types = {"header-row", "data-row"}
+ *   input_types = {"header-row", "data-row"},
  * )
  */
 class ValueInList extends TripalCultivatePhenotypesValidatorBase implements ContainerFactoryPluginInterface {

--- a/trpcultivate_phenotypes/src/TripalCultivateValidator/TripalCultivatePhenotypesValidatorBase.php
+++ b/trpcultivate_phenotypes/src/TripalCultivateValidator/TripalCultivatePhenotypesValidatorBase.php
@@ -200,7 +200,7 @@ abstract class TripalCultivatePhenotypesValidatorBase extends PluginBase impleme
     // Report if the indices array is empty
     if (!$indices) {
       throw new \Exception(
-        t('An empty indices array was provided.')
+        'An empty indices array was provided.'
       );
     }
 
@@ -210,7 +210,7 @@ abstract class TripalCultivatePhenotypesValidatorBase extends PluginBase impleme
     $num_indices = count($indices);
     if($num_indices > $num_values) {
       throw new \Exception(
-        t('Too many indices were provided (@indices) compared to the number of cells in the provided row (@values)', ['@indices' => $num_indices, '@values' => $num_values])
+        'Too many indices were provided ('. $num_indices .') compared to the number of cells in the provided row (' . $num_values .').'
       );
     }
 
@@ -220,7 +220,7 @@ abstract class TripalCultivatePhenotypesValidatorBase extends PluginBase impleme
     if($result) {
       $invalid_indices = implode(', ', $result);
       throw new \Exception(
-        t('One or more of the indices provided (@invalid) is not valid when compared to the indices of the provided row', ['@invalid' => $invalid_indices])
+        'One or more of the indices provided (' . $invalid_indices . ') is not valid when compared to the indices of the provided row.'
       );
     }
   }
@@ -265,7 +265,7 @@ abstract class TripalCultivatePhenotypesValidatorBase extends PluginBase impleme
    *   on a delimiter value.
    */
   public static function splitRowIntoColumns(string $row, string $mime_type) {
-    
+
     $mime_to_delimiter_mapping = self::$mime_to_delimiter_mapping;
 
     // Ensure that the mime type is in our delimiter mapping...

--- a/trpcultivate_phenotypes/src/TripalCultivateValidator/ValidatorTraits/GenusConfigured.php
+++ b/trpcultivate_phenotypes/src/TripalCultivateValidator/ValidatorTraits/GenusConfigured.php
@@ -47,8 +47,9 @@ trait GenusConfigured {
    * @return void
    *
    * @throws \Exception
-   *  - If the genus does not match at least one record in the chado.organism table.
-   *  - If the genus is not configured to work with this module.
+   *  - If the PhenoGenusOntology service is not accessible
+   *  - If the PhenoTraits service is not accessible
+   *  - If an instance of ChadoConnection is not accessible
    */
   public function setConfiguredGenus(string $genus) {
 

--- a/trpcultivate_phenotypes/src/TripalCultivateValidator/ValidatorTraits/GenusConfigured.php
+++ b/trpcultivate_phenotypes/src/TripalCultivateValidator/ValidatorTraits/GenusConfigured.php
@@ -58,17 +58,21 @@ trait GenusConfigured {
       ->condition('o.genus', $genus);
     $exists = $query->execute()->fetchObject();
     if (!is_object($exists)) {
-      throw new \Exception("The genus '$genus' does not exist in chado and GenusConfigured Trait requires it both exist and be configured to work with phenotypes. The validators using this trait should not be called if previous validators checking for a configured genus fail.");
+
+      // @TODO: This is a user provided value, should be logged message
+      //        and checked by a validator.
+
+      //throw new \Exception("The genus '$genus' does not exist in chado and GenusConfigured Trait requires it both exist and be configured to work with phenotypes. The validators using this trait should not be called if previous validators checking for a configured genus fail.");
     }
 
     // Check that the genus is configured + get that configuration while we are at it.
     $configuration_values = $this->service_PhenoGenusOntology->getGenusOntologyConfigValues($genus);
     if (!is_array($configuration_values) OR empty($configuration_values)) {
-      
+
       // @TODO: This is a user provided value, should be logged message
       //        and checked by a validator.
-      
-      throw new \Exception("The genus '$genus' is not configured and GenusConfigured Trait requires it both exist and be configured to work with phenotypes. The validators using this trait should not be called if previous validators checking for a configured genus fail.");
+
+      //throw new \Exception("The genus '$genus' is not configured and GenusConfigured Trait requires it both exist and be configured to work with phenotypes. The validators using this trait should not be called if previous validators checking for a configured genus fail.");
     }
 
     // Now we finally get to set things up for the validator!

--- a/trpcultivate_phenotypes/src/TripalCultivateValidator/ValidatorTraits/GenusConfigured.php
+++ b/trpcultivate_phenotypes/src/TripalCultivateValidator/ValidatorTraits/GenusConfigured.php
@@ -4,6 +4,7 @@ namespace Drupal\trpcultivate_phenotypes\TripalCultivateValidator\ValidatorTrait
 
 use Drupal\tripal_chado\Database\ChadoConnection;
 use Drupal\trpcultivate_phenotypes\Service\TripalCultivatePhenotypesGenusOntologyService;
+use Drupal\trpcultivate_phenotypes\Service\TripalCultivatePhenotypesTraitsService;
 
 /**
  * Provides setters focused on configuring a validator to use a specific genus
@@ -21,6 +22,13 @@ trait GenusConfigured {
    * @var TripalCultivatePhenotypesGenusOntologyService
    */
   protected TripalCultivatePhenotypesGenusOntologyService $service_PhenoGenusOntology;
+
+  /**
+   * Traits Service
+   *
+   * @var TripalCultivatePhenotypesTraitsService
+   */
+  protected TripalCultivatePhenotypesTraitsService $service_PhenoTraits;
 
   /**
    * A Database query interface for querying Chado using Tripal DBX.
@@ -47,6 +55,9 @@ trait GenusConfigured {
     // Check we have the services we need.
     if (!isset($this->service_PhenoGenusOntology)) {
       throw new \Exception('The GenusConfigured Trait needs the Genus ontology (trpcultivate_phenotypes.genus_ontology) service injected via the create() and set to $this->service_PhenoGenusOntology in the constructor.');
+    }
+    if (!isset($this->service_PhenoTraits)) {
+      throw new \Exception('The GenusConfigured Trait needs the Trait (trpcultivate_phenotypes.traits) service injected via the create() and set to $this->service_PhenoTraits in the constructor.');
     }
     if (!isset($this->chado_connection)) {
       throw new \Exception('The GenusConfigured Trait needs an instance of ChadoConnection (tripal_chado.database) injected via the create() and set to $this->chado_connection.');
@@ -84,6 +95,9 @@ trait GenusConfigured {
 
       // Set the configured genus
       $this->context['genus']['name'] = $genus;
+
+      // Configure the trait service to use this genus.
+      $this->service_PhenoTraits->setTraitGenus($genus);
     }
   }
 

--- a/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterFormTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterFormTest.php
@@ -83,6 +83,19 @@ class TraitImporterFormTest extends ChadoTestKernelBase {
     // Create and log-in a user.
     $this->setUpCurrentUser();
 
+    // We need to mock the logger to test the progress reporting.
+    $container = \Drupal::getContainer();
+    $mock_logger = $this->getMockBuilder(\Drupal\tripal\Services\TripalLogger::class)
+      ->onlyMethods(['error'])
+      ->getMock();
+    $mock_logger->method('error')
+    ->willReturnCallback(function ($message, $context, $options) {
+      // @todo: Revisit print out of log messages, but perhaps setting an option
+      // for log messages to not print to the UI?
+      //print str_replace(array_keys($context), $context, $message);
+      return NULL;
+    });
+    $container->set('tripal.logger', $mock_logger);
   }
 
   /**

--- a/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterFormValidateTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterFormValidateTest.php
@@ -172,7 +172,7 @@ class TraitImporterFormValidateTest extends ChadoTestKernelBase {
         'empty_cell' => ['valid' => TRUE],
         'valid_data_type' => ['valid' => TRUE],
         'duplicate_traits' => [
-          'case' => 'A duplicate trait was found within the input file.',
+          'case' => 'A duplicate trait was found within the input file',
           'valid' => FALSE,
           'failedItems' => [
             'combo_provided' => [

--- a/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterFormValidateTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterFormValidateTest.php
@@ -131,14 +131,12 @@ class TraitImporterFormValidateTest extends ChadoTestKernelBase {
         'FILE' => ['status' => 'pass'],
         'HEADERS' => ['status' => 'pass'],
         'empty_cell' => [
-          'case' => 'Empty value found in required column(s)',
-          'valid' => FALSE,
-          'failedItems' => [
-            'empty_indices' => [ 2 ]
-          ]
+          'title' => 'Empty value found in required column(s)',
+          'status' => 'fail',
+          'details' => ''
         ],
-        'valid_data_type' => ['valid' => TRUE],
-        'duplicate_traits' => ['valid' => TRUE]
+        'valid_data_type' => ['status' => 'pass'],
+        'duplicate_traits' => ['status' => 'pass']
       ]
     ];
 
@@ -150,15 +148,13 @@ class TraitImporterFormValidateTest extends ChadoTestKernelBase {
         'GENUS' => ['status' => 'pass'],
         'FILE' => ['status' => 'pass'],
         'HEADERS' => ['status' => 'pass'],
-        'empty_cell' => ['valid' => TRUE],
+        'empty_cell' => ['status' => 'pass'],
         'valid_data_type' => [
-          'case' => 'Invalid value(s) in required column(s)',
-          'valid' => FALSE,
-          'failedItems' => [
-            5 => 'incorrect'
-          ]
+          'title' => 'Invalid value(s) in required column(s)',
+          'status' => 'fail',
+          'details' => ''
         ],
-        'duplicate_traits' => ['valid' => TRUE]
+        'duplicate_traits' => ['status' => 'pass']
       ]
     ];
 
@@ -169,18 +165,12 @@ class TraitImporterFormValidateTest extends ChadoTestKernelBase {
         'GENUS' => ['status' => 'pass'],
         'FILE' => ['status' => 'pass'],
         'HEADERS' => ['status' => 'pass'],
-        'empty_cell' => ['valid' => TRUE],
-        'valid_data_type' => ['valid' => TRUE],
+        'empty_cell' => ['status' => 'pass'],
+        'valid_data_type' => ['status' => 'pass'],
         'duplicate_traits' => [
-          'case' => 'A duplicate trait was found within the input file',
-          'valid' => FALSE,
-          'failedItems' => [
-            'combo_provided' => [
-              'Trait Name' => 'trait1',
-              'Method Short Name' => 'method1',
-              'Unit' => 'unit1'
-            ]
-          ]
+          'title' => 'A duplicate trait was found within the input file',
+          'status' => 'fail',
+          'details' => ''
         ]
       ]
     ];

--- a/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterFormValidateTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterFormValidateTest.php
@@ -93,8 +93,10 @@ class TraitImporterFormValidateTest extends ChadoTestKernelBase {
    * -- the filename of the test file used for this scenario (test files are
    *    located in: tests/src/Fixtures/TraitImporterFiles/)
    * -- an array indicating the expected validation results
-   *    - Each key is the unique name of a validator instance that was instant-
-   *      iated by the configureValidators() method in the Traits Importer class
+   *    - Each key is the unique name of a feedback line provided to the validator UI 
+   *      by the processValidationMessages(). Currently there is a feedback line for 
+   *      each unique validator instance that was instantiated by the 
+   *      configureValidators() method in the Traits Importer class
    *      - 'status': [REQUIRED] One of 'pass', 'todo', or 'fail'
    *      - 'title': [REQUIRED if 'status' = 'fail'] A string that matches the
    *        title set in processValidationMessages() method in the Trait Importer

--- a/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterFormValidateTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterFormValidateTest.php
@@ -131,7 +131,7 @@ class TraitImporterFormValidateTest extends ChadoTestKernelBase {
         'FILE' => ['status' => 'pass'],
         'HEADERS' => ['status' => 'pass'],
         'empty_cell' => [
-          'case' => 'Empty value found in required column(s).',
+          'case' => 'Empty value found in required column(s)',
           'valid' => FALSE,
           'failedItems' => [
             'empty_indices' => [ 2 ]

--- a/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterFormValidateTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterFormValidateTest.php
@@ -131,8 +131,11 @@ class TraitImporterFormValidateTest extends ChadoTestKernelBase {
         'FILE' => ['status' => 'pass'],
         'HEADERS' => ['status' => 'pass'],
         'empty_cell' => [
-          'status' => 'fail',
-          'details' => 'One or more required columns was empty at row #: 3'
+          'case' => 'Empty value found in required column(s).',
+          'valid' => FALSE,
+          'failedItems' => [
+            'empty_indices' => [ 2 ]
+          ]
         ],
         'valid_data_type' => ['status' => 'pass'],
         'duplicate_traits' => ['valid' => TRUE]
@@ -147,7 +150,7 @@ class TraitImporterFormValidateTest extends ChadoTestKernelBase {
         'GENUS' => ['status' => 'pass'],
         'FILE' => ['status' => 'pass'],
         'HEADERS' => ['status' => 'pass'],
-        'empty_cell' => ['status' => 'pass'],
+        'empty_cell' => ['valid' => TRUE],
         'valid_data_type' => [
           'status' => 'fail',
           'details' => 'Column "type" violates required values at row #: 2'
@@ -163,7 +166,7 @@ class TraitImporterFormValidateTest extends ChadoTestKernelBase {
         'GENUS' => ['status' => 'pass'],
         'FILE' => ['status' => 'pass'],
         'HEADERS' => ['status' => 'pass'],
-        'empty_cell' => ['status' => 'pass'],
+        'empty_cell' => ['valid' => TRUE],
         'valid_data_type' => ['status' => 'pass'],
         'duplicate_traits' => [
           'case' => 'A duplicate trait was found within the input file.',

--- a/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterFormValidateTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterFormValidateTest.php
@@ -113,6 +113,7 @@ class TraitImporterFormValidateTest extends ChadoTestKernelBase {
         'GENUS' => ['status' => 'pass'],
         'FILE' => ['status' => 'pass'],
         'HEADERS' => [
+          'title' => 'File has all of the column headers expected',
           'status' => 'fail',
           'details' => 'Trait Description is/are missing in the file',
         ],
@@ -131,9 +132,9 @@ class TraitImporterFormValidateTest extends ChadoTestKernelBase {
         'FILE' => ['status' => 'pass'],
         'HEADERS' => ['status' => 'pass'],
         'empty_cell' => [
-          'title' => 'Empty value found in required column(s)',
+          'title' => 'Required cells contain a value',
           'status' => 'fail',
-          'details' => ''
+          'details' => 'Empty value found in required column(s) at row #: 3'
         ],
         'valid_data_type' => ['status' => 'pass'],
         'duplicate_traits' => ['status' => 'pass']
@@ -150,9 +151,9 @@ class TraitImporterFormValidateTest extends ChadoTestKernelBase {
         'HEADERS' => ['status' => 'pass'],
         'empty_cell' => ['status' => 'pass'],
         'valid_data_type' => [
-          'title' => 'Invalid value(s) in required column(s)',
+          'title' => 'Values in required cells are valid',
           'status' => 'fail',
-          'details' => ''
+          'details' => 'Invalid value(s) in required column(s) at row #: 2'
         ],
         'duplicate_traits' => ['status' => 'pass']
       ]
@@ -168,9 +169,9 @@ class TraitImporterFormValidateTest extends ChadoTestKernelBase {
         'empty_cell' => ['status' => 'pass'],
         'valid_data_type' => ['status' => 'pass'],
         'duplicate_traits' => [
-          'title' => 'A duplicate trait was found within the input file',
+          'title' => 'All trait-method-unit combinations are unique',
           'status' => 'fail',
-          'details' => ''
+          'details' => 'A duplicate trait was found within the input file at row #: 3'
         ]
       ]
     ];
@@ -241,33 +242,20 @@ class TraitImporterFormValidateTest extends ChadoTestKernelBase {
 
     // Now check our expectations are met.
     foreach ($expectations as $validation_plugin => $expected) {
-      // Check if this plugin has been updated to use valid instead of status,
-      // and preferrentially use that one as the key
-      // @todo: Remove this line and update the assert to ONLY check for 'valid'
-      // once all plugins have been updated
-      $status_or_valid_key = isset($expected['valid']) ? 'valid' : 'status';
-      $this->assertEquals($expected[$status_or_valid_key], $validation_element_data[$validation_plugin][$status_or_valid_key],
-        "We expected the form validation element to indicate the $validation_plugin plugin had the specified status.");
-      // Check this plugin's case message
-      // @todo: Remove the check for 'case' in $expected once all plugins' return values
-      // have been updated
-      if (array_key_exists('case', $expected)) {
-        $this->assertStringContainsString(
-          $expected['case'],
-          $validation_element_data[$validation_plugin]['case'],
-          "We expected the case message for $validation_plugin to include a specific string but it did not."
-        );
-      }
-      // @todo: Remove this entire if block once all plugins' return values have been updated
+      $this->assertEquals(
+        $expected['status'],
+        $validation_element_data[$validation_plugin]['status'],
+        "We expected the form validation element to indicate the $validation_plugin plugin had the specified status."
+      );
       if (array_key_exists('details', $expected)) {
-        $this->assertStringContainsString($expected['details'], $validation_element_data[$validation_plugin]['details'],
-          "We expected the details for $validation_plugin to include a specific string but it did not.");
-      }
-      if (array_key_exists('failedItems', $expected)) {
-        $this->assertEquals(
-          $expected['failedItems'],
-          $validation_element_data[$validation_plugin]['failedItems'],
-          "We expected the array of failed items for $validation_plugin to include all failed items but it did not."
+        $this->assertNotEmpty(
+          $expected['details'],
+          "A non-empty string was a provided with a 'details' key within the data provider - trust me, don't do that!"
+        );
+        $this->assertStringContainsString(
+          $expected['details'],
+          $validation_element_data[$validation_plugin]['details'],
+          "We expected the details for $validation_plugin to include a specific string but it did not."
         );
       }
     }

--- a/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterFormValidateTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterFormValidateTest.php
@@ -137,7 +137,7 @@ class TraitImporterFormValidateTest extends ChadoTestKernelBase {
             'empty_indices' => [ 2 ]
           ]
         ],
-        'valid_data_type' => ['status' => 'pass'],
+        'valid_data_type' => ['valid' => TRUE],
         'duplicate_traits' => ['valid' => TRUE]
       ]
     ];
@@ -152,8 +152,11 @@ class TraitImporterFormValidateTest extends ChadoTestKernelBase {
         'HEADERS' => ['status' => 'pass'],
         'empty_cell' => ['valid' => TRUE],
         'valid_data_type' => [
-          'status' => 'fail',
-          'details' => 'Column "type" violates required values at row #: 2'
+          'case' => 'Invalid value(s) in required column(s)',
+          'valid' => FALSE,
+          'failedItems' => [
+            5 => 'incorrect'
+          ]
         ],
         'duplicate_traits' => ['valid' => TRUE]
       ]
@@ -167,7 +170,7 @@ class TraitImporterFormValidateTest extends ChadoTestKernelBase {
         'FILE' => ['status' => 'pass'],
         'HEADERS' => ['status' => 'pass'],
         'empty_cell' => ['valid' => TRUE],
-        'valid_data_type' => ['status' => 'pass'],
+        'valid_data_type' => ['valid' => TRUE],
         'duplicate_traits' => [
           'case' => 'A duplicate trait was found within the input file.',
           'valid' => FALSE,

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/FakeValidators/ValidatorGenusConfigured.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/FakeValidators/ValidatorGenusConfigured.php
@@ -53,7 +53,7 @@ class ValidatorGenusConfigured extends TripalCultivatePhenotypesValidatorBase {
       $configuration,
       $plugin_id,
       $plugin_definition,
-      $container->get('tripal_chado.databse'),
+      $container->get('tripal_chado.database'),
       $container->get('trpcultivate_phenotypes.genus_ontology')
     );
   }

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/FakeValidators/ValidatorGenusConfigured.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/FakeValidators/ValidatorGenusConfigured.php
@@ -5,6 +5,7 @@ namespace Drupal\Tests\trpcultivate_phenotypes\Kernel\Validators\FakeValidators;
 use Drupal\trpcultivate_phenotypes\TripalCultivateValidator\TripalCultivatePhenotypesValidatorBase;
 use Drupal\trpcultivate_phenotypes\TripalCultivateValidator\ValidatorTraits\GenusConfigured;
 use Drupal\trpcultivate_phenotypes\Service\TripalCultivatePhenotypesGenusOntologyService;
+use Drupal\trpcultivate_phenotypes\Service\TripalCultivatePhenotypesTraitsService;
 use Drupal\tripal_chado\Database\ChadoConnection;
 
 /**
@@ -36,13 +37,21 @@ class ValidatorGenusConfigured extends TripalCultivatePhenotypesValidatorBase {
   protected ChadoConnection $chado_connection;
 
   /**
+   * Traits Service
+   *
+   * @var TripalCultivatePhenotypesTraitsService
+   */
+  protected TripalCultivatePhenotypesTraitsService $service_PhenoTraits;
+
+  /**
    * Constructor.
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, ChadoConnection $chado_connection, TripalCultivatePhenotypesGenusOntologyService $service_PhenoGenusOntology) {
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, ChadoConnection $chado_connection, TripalCultivatePhenotypesGenusOntologyService $service_PhenoGenusOntology, TripalCultivatePhenotypesTraitsService $service_PhenoTraits) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
 
     $this->chado_connection = $chado_connection;
     $this->service_PhenoGenusOntology = $service_PhenoGenusOntology;
+    $this->service_PhenoTraits = $service_PhenoTraits;
   }
 
   /**
@@ -54,7 +63,8 @@ class ValidatorGenusConfigured extends TripalCultivatePhenotypesValidatorBase {
       $plugin_id,
       $plugin_definition,
       $container->get('tripal_chado.database'),
-      $container->get('trpcultivate_phenotypes.genus_ontology')
+      $container->get('trpcultivate_phenotypes.genus_ontology'),
+      $container->get('trpcultivate_phenotypes.traits')
     );
   }
 }

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/FakeValidators/ValidatorGenusConfiguredNOServiceGenusontology.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/FakeValidators/ValidatorGenusConfiguredNOServiceGenusontology.php
@@ -5,6 +5,7 @@ namespace Drupal\Tests\trpcultivate_phenotypes\Kernel\Validators\FakeValidators;
 use Drupal\trpcultivate_phenotypes\TripalCultivateValidator\TripalCultivatePhenotypesValidatorBase;
 use Drupal\trpcultivate_phenotypes\TripalCultivateValidator\ValidatorTraits\GenusConfigured;
 use Drupal\trpcultivate_phenotypes\Service\TripalCultivatePhenotypesGenusOntologyService;
+use Drupal\trpcultivate_phenotypes\Service\TripalCultivatePhenotypesTraitsService;
 use Drupal\tripal_chado\Database\ChadoConnection;
 
 /**
@@ -12,12 +13,12 @@ use Drupal\tripal_chado\Database\ChadoConnection;
  * Used to test the base class.
  *
  * @TripalCultivatePhenotypesValidator(
- * id = "validator_requiring_configured_genus_no_service",
+ * id = "validator_configured_genus_no_service_genusontology",
  * validator_name = @Translation("Validator Using GenusConfigured Trait"),
  * input_types = {"header-row", "data-row"}
  * )
  */
-class ValidatorGenusConfiguredNOService extends TripalCultivatePhenotypesValidatorBase {
+class ValidatorGenusConfiguredNOServiceGenusontology extends TripalCultivatePhenotypesValidatorBase {
 
   use GenusConfigured;
 
@@ -36,13 +37,21 @@ class ValidatorGenusConfiguredNOService extends TripalCultivatePhenotypesValidat
   protected ChadoConnection $chado_connection;
 
   /**
+   * Traits Service
+   *
+   * @var TripalCultivatePhenotypesTraitsService
+   */
+  protected TripalCultivatePhenotypesTraitsService $service_PhenoTraits;
+
+  /**
    * Constructor.
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, ChadoConnection $chado_connection, TripalCultivatePhenotypesGenusOntologyService $service_PhenoGenusOntology) {
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, ChadoConnection $chado_connection, TripalCultivatePhenotypesGenusOntologyService $service_PhenoGenusOntology, TripalCultivatePhenotypesTraitsService $service_PhenoTraits) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
 
     $this->chado_connection = $chado_connection;
     // $this->service_PhenoGenusOntology = $service_PhenoGenusOntology;
+    $this->service_PhenoTraits = $service_PhenoTraits;
   }
 
   /**
@@ -54,7 +63,8 @@ class ValidatorGenusConfiguredNOService extends TripalCultivatePhenotypesValidat
       $plugin_id,
       $plugin_definition,
       $container->get('tripal_chado.databse'),
-      $container->get('trpcultivate_phenotypes.genus_ontology')
+      $container->get('trpcultivate_phenotypes.genus_ontology'),
+      $container->get('trpcultivate_phenotypes.traits')
     );
   }
 }

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/FakeValidators/ValidatorGenusConfiguredNOServiceTraits.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/FakeValidators/ValidatorGenusConfiguredNOServiceTraits.php
@@ -13,12 +13,12 @@ use Drupal\tripal_chado\Database\ChadoConnection;
  * Used to test the base class.
  *
  * @TripalCultivatePhenotypesValidator(
- * id = "validator_configured_genus_no_connection",
+ * id = "validator_configured_genus_no_service_trait",
  * validator_name = @Translation("Validator Using GenusConfigured Trait"),
  * input_types = {"header-row", "data-row"}
  * )
  */
-class ValidatorGenusConfiguredNOConnection extends TripalCultivatePhenotypesValidatorBase {
+class ValidatorGenusConfiguredNOServiceTraits extends TripalCultivatePhenotypesValidatorBase {
 
   use GenusConfigured;
 
@@ -49,9 +49,9 @@ class ValidatorGenusConfiguredNOConnection extends TripalCultivatePhenotypesVali
   public function __construct(array $configuration, $plugin_id, $plugin_definition, ChadoConnection $chado_connection, TripalCultivatePhenotypesGenusOntologyService $service_PhenoGenusOntology, TripalCultivatePhenotypesTraitsService $service_PhenoTraits) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
 
-    // $this->chado_connection = $chado_connection;
+    $this->chado_connection = $chado_connection;
     $this->service_PhenoGenusOntology = $service_PhenoGenusOntology;
-    $this->service_PhenoTraits = $service_PhenoTraits;
+    // $this->service_PhenoTraits = $service_PhenoTraits;
   }
 
   /**

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/README.md
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/README.md
@@ -1,0 +1,33 @@
+# Validator Tests
+
+Each validator plugin is expected to have its own test file with the following
+naming scheme:
+
+`Validator<Name of Validator>Test.php`
+
+# Validator Trait Tests
+
+Tests for Validator Traits go into the `Traits/` folder. They should be named as
+follows:
+
+`ValidatorTrait<Name of Trait>Test.php`
+
+Each Validator Trait test class also needs a Fake Validator class to instantiate
+within its setUp() method. This allows for tests to be independent of any actual
+validators. The class for a fake validator is to be placed within the
+`FakeValidators/` folder. The naming scheme is:
+
+`Validator<NameofValidatorTrait>.php`
+
+Occasionally, a validator trait may need multiple different setups to accurately
+test error cases. In this case, append a short identifier of the unique setup
+in a separate test file. For example:
+- `ValidatorGenusConfiguredNOConnection.php`
+- `ValidatorGenusConfiguredNOService.php`
+
+# Testing the ValidatorBase class
+There is already a `BasicallyBase.php` class in the `FakeValidators/` folder
+which can be utilized for testing methods in the ValidatorBase class directly,
+therefore elimimating the need to instantiate an actual validator for testing.
+
+Current tests for ValidatorBase are in: `ValidatorBaseTest.php`

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/Traits/ValidatorTraitGenusConfiguredTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/Traits/ValidatorTraitGenusConfiguredTest.php
@@ -120,7 +120,8 @@ class ValidatorTraitGenusConfiguredTest extends ChadoTestKernelBase {
       $validator_id,
       $plugin_definition,
       $this->chado_connection,
-      $this->container->get('trpcultivate_phenotypes.genus_ontology')
+      $this->container->get('trpcultivate_phenotypes.genus_ontology'),
+      $this->container->get('trpcultivate_phenotypes.traits')
     );
 
     // We need to mock the logger to test the progress reporting.

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/Traits/ValidatorTraitsMissingDependenciesTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/Traits/ValidatorTraitsMissingDependenciesTest.php
@@ -6,7 +6,8 @@ use Drupal\Tests\tripal_chado\Kernel\ChadoTestKernelBase;
 use Drupal\tripal_chado\Database\ChadoConnection;
 use Drupal\Tests\trpcultivate_phenotypes\Traits\PhenotypeImporterTestTrait;
 use Drupal\Tests\trpcultivate_phenotypes\Kernel\Validators\FakeValidators\ValidatorGenusConfiguredNOConnection;
-use Drupal\Tests\trpcultivate_phenotypes\Kernel\Validators\FakeValidators\ValidatorGenusConfiguredNOService;
+use Drupal\Tests\trpcultivate_phenotypes\Kernel\Validators\FakeValidators\ValidatorGenusConfiguredNOServiceGenusontology;
+use Drupal\Tests\trpcultivate_phenotypes\Kernel\Validators\FakeValidators\ValidatorGenusConfiguredNOServiceTraits;
 
 /**
  * Tests the GenusConfigured validator trait.
@@ -48,38 +49,97 @@ class ValidatorTraitsMissingDependenciesTest extends ChadoTestKernelBase {
   }
 
   /**
-   * Tests the GenusConfigured::setConfiguredGenus() setter
-   *       and GenusConfigured::getConfiguredGenus() getter
+   * DATA PROVIDER: provides fake validators to be tested for bad configuration.
    *
-   * @return void
+   * @return array
+   *   Returns an array of senarios where each one has a 'case', 'validator_defn',
+   *   and 'expected_message'. Specifically.
+   *     - case: a short senario description for the assert fail messages.
+   *     - validator_defn: the plugin definition to use when creating the validator.
+   *       Must include 'id', 'validator_name', 'input_types', 'class'.
+   *     - expected_message: the exception message expected when trying to set
+   *       the genus for a badly configured validator.
    */
-  public function testConfiguredGenusBadlyConfigured() {
+  public function provideBadlyConfiguredValidators() {
+    $senarios = [];
 
-    // Bad Validator: No $chado_connection.
+    $senarios['no_connection'] = [
+      'case' => 'validator without the chado connection set',
+      'validator_defn' => [
+        'id' => 'validator_configured_genus_no_connection',
+        'validator_name' => 'Validator Using GenusConfigured Trait',
+        'input_types' => ['header-row', 'data-row'],
+        'class' => '\Drupal\Tests\trpcultivate_phenotypes\Kernel\Validators\FakeValidators\ValidatorGenusConfiguredNOConnection',
+      ],
+      'expected_message' => 'GenusConfigured Trait needs an instance of ChadoConnection',
+    ];
+
+    $senarios['no_genus_ontolgy'] = [
+      'case' => 'validator without the genus ontology service set',
+      'validator_defn' => [
+        'id' => 'validator_configured_genus_no_service_genusontology',
+        'validator_name' => 'Validator Using GenusConfigured Trait',
+        'input_types' => ['header-row', 'data-row'],
+        'class' => '\Drupal\Tests\trpcultivate_phenotypes\Kernel\Validators\FakeValidators\ValidatorGenusConfiguredNOServiceGenusontology',
+      ],
+      'expected_message' => 'GenusConfigured Trait needs the Genus ontology (trpcultivate_phenotypes.genus_ontology) service',
+    ];
+
+    $senarios['no_traits'] = [
+      'case' => 'validator without the trait service set',
+      'validator_defn' => [
+        'id' => 'validator_configured_genus_no_service_trait',
+        'validator_name' => 'Validator Using GenusConfigured Trait',
+        'input_types' => ['header-row', 'data-row'],
+        'class' => '\Drupal\Tests\trpcultivate_phenotypes\Kernel\Validators\FakeValidators\ValidatorGenusConfiguredNOServiceTraits',
+      ],
+      'expected_message' => 'GenusConfigured Trait needs the Trait (trpcultivate_phenotypes.traits) service',
+    ];
+
+    return $senarios;
+  }
+
+/**
+ * Tests the GenusConfigured::setConfiguredGenus() setter
+ *       and GenusConfigured::getConfiguredGenus() getter
+ *
+ * @dataProvider provideBadlyConfiguredValidators
+ *
+ * @param string $case
+ *   A short senario description for the assert fail messages.
+ * @param array $validator_defn
+ *   The plugin definition to use when creating the validator.
+ *   Must include
+ *    - id: the fake validator id in the annotation
+ *    - validator_name: the name of the validator in the annotation
+ *    - input_types: an array of input-types this fake validator supports
+ *    - class: the name of the class this fake validator is in with full namespace.
+ * @param string $expected_message
+ *   The exception message expected when trying to set the genus for a badly
+ *   configured validator.
+ */
+  public function testConfiguredGenusBadlyConfigured($case, $validator_defn, $expected_message) {
+
     // Create a fake plugin instance for testing.
     $configuration = [];
-    $validator_id = 'validator_requiring_configured_genus_no_connection';
-    $plugin_definition = [
-      'id' => $validator_id,
-      'validator_name' => 'Validator Using GenusConfigured Trait But Missing Connection',
-      'input_types' => ['header-row', 'data-row'],
-    ];
-    $instance = new ValidatorGenusConfiguredNOConnection(
+    $validator_id = $validator_defn['id'];
+    $validator_class = $validator_defn['class'];
+    $instance = new $validator_class(
       $configuration,
-      $validator_id,
-      $plugin_definition,
+      $validator_defn['id'],
+      $validator_defn,
       $this->chado_connection,
-      $this->container->get('trpcultivate_phenotypes.genus_ontology')
+      $this->container->get('trpcultivate_phenotypes.genus_ontology'),
+      $this->container->get('trpcultivate_phenotypes.traits')
     );
     $this->assertIsObject(
       $instance,
-      "Unable to create $validator_id validator instance to test the GenusConfigured trait."
+      "Unable to create $validator_id validator instance to test the GenusConfigured trait for '$case'."
     );
 
     // Now try setting the genus when the dependencies are not met.
     // We expect an exception to be thrown before setting is even attempted
     // so the genus passed in here doesn't matter.
-    $expected_message = "GenusConfigured Trait needs an instance of ChadoConnection";
     $exception_caught = FALSE;
     $exception_message = 'NONE';
     try {
@@ -90,55 +150,12 @@ class ValidatorTraitsMissingDependenciesTest extends ChadoTestKernelBase {
     }
     $this->assertTrue(
       $exception_caught,
-      "Calling setConfiguredGenus() on a validator that has not set the chado connection should throw an exception."
+      "Calling setConfiguredGenus() on a '$case' should throw an exception."
     );
     $this->assertStringContainsString(
       $expected_message,
       $exception_message,
-      "The exception thrown does not have the message we expected for a validator without the chado connection set."
-    );
-
-    // Bad Validator: No trpcultivate_phenotypes.genus_ontology service
-    // Create a fake plugin instance for testing.
-    $configuration = [];
-    $validator_id = 'validator_requiring_configured_genus_no_service';
-    $plugin_definition = [
-      'id' => $validator_id,
-      'validator_name' => 'Validator Using GenusConfigured Trait But Missing Genus Service',
-      'input_types' => ['header-row', 'data-row'],
-    ];
-    $instance = new ValidatorGenusConfiguredNOService(
-      $configuration,
-      $validator_id,
-      $plugin_definition,
-      $this->chado_connection,
-      $this->container->get('trpcultivate_phenotypes.genus_ontology')
-    );
-    $this->assertIsObject(
-      $instance,
-      "Unable to create $validator_id validator instance to test the GenusConfigured trait."
-    );
-
-    // Now try setting the genus when the dependencies are not met.
-    // We expect an exception to be thrown before setting is even attempted
-    // so the genus passed in here doesn't matter.
-    $expected_message = "GenusConfigured Trait needs the Genus ontology";
-    $exception_caught = FALSE;
-    $exception_message = 'NONE';
-    try {
-      $instance->setConfiguredGenus('Tripalus');
-    } catch (\Exception $e) {
-      $exception_caught = TRUE;
-      $exception_message = $e->getMessage();
-    }
-    $this->assertTrue(
-      $exception_caught,
-      "Calling setConfiguredGenus() on a validator that has not set the genus ontology service should throw an exception."
-    );
-    $this->assertStringContainsString(
-      $expected_message,
-      $exception_message,
-      "The exception thrown does not have the message we expected for a validator without the genus ontology service set."
+      "The exception thrown does not have the message we expected for a '$case'."
     );
   }
 }

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorBaseTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorBaseTest.php
@@ -87,8 +87,9 @@ class ValidatorBaseTest extends ChadoTestKernelBase {
     // ERROR CASES
 
     // Provide an empty array of indices
-    $context['indices'] = [];
-    $instance->context = $context;
+    // @TODO: This throws an exception from setIndices() instead of from checkIndices()
+    /**
+    $instance->setIndices([]);
     $exception_caught = FALSE;
     try {
       $validation_status = $instance->validateRow($file_row);
@@ -98,10 +99,10 @@ class ValidatorBaseTest extends ChadoTestKernelBase {
     }
     $this->assertTrue($exception_caught, 'Did not catch exception that should have occurred due to passing in an empty array of indices.');
     $this->assertStringContainsString('An empty indices array was provided.', $e->getMessage(), "Did not get the expected exception message when providing an empty array of indices.");
+    */
 
     // Provide too many indices
-    $context['indices'] = [ 0, 1, 2, 3, 4, 5, 6, 7 ];
-    $instance->context = $context;
+    $instance->setIndices( [0, 1, 2, 3, 4, 5, 6, 7] );
     $exception_caught = FALSE;
     try {
       $validation_status = $instance->validateRow($file_row);
@@ -113,8 +114,7 @@ class ValidatorBaseTest extends ChadoTestKernelBase {
     $this->assertStringContainsString('Too many indices were provided (8) compared to the number of cells in the provided row (6)', $e->getMessage(), "Did not get the expected exception message when providing 8 indices compared to 6 values.");
 
     // Provide invalid indices
-    $context['indices'] = [ 1, -4, 77 ];
-    $instance->context = $context;
+    $instance->setIndices( [1, -4, 77] );
     $exception_caught = FALSE;
     try {
       $validation_status = $instance->validateRow($file_row);
@@ -337,7 +337,7 @@ class ValidatorBaseTest extends ChadoTestKernelBase {
 
   /**
    * DATA PROVIDER: tests the split row by providing mime type to delimiter options.
-   * 
+   *
    * @return array
    *   Each test scenario is an array with the following values.
    *
@@ -369,10 +369,10 @@ class ValidatorBaseTest extends ChadoTestKernelBase {
 
   /**
    * Data Provider: provide test data (mime types) to file delimiter getter method.
-   * 
+   *
    * @return array
    *   Each test scenario is an array with the following values.
-   * 
+   *
    *   - A string, human-readable short description of the test scenario.
    *   - A string, mime type input.
    *   - Boolean value, indicates if the scenario is expecting an exception thrown (TRUE) or not (FALSE).
@@ -421,7 +421,7 @@ class ValidatorBaseTest extends ChadoTestKernelBase {
 
   /**
    * Test line or row split method.
-   * 
+   *
    * @param $expected_mime_type
    *   Mime type input to the split row method.
    * @param $expected_delimiter
@@ -511,7 +511,7 @@ class ValidatorBaseTest extends ChadoTestKernelBase {
 
   /**
    * Test validator base file delimiter getter method.
-   * 
+   *
    * @param $scenario
    *   Human-readable text description of the test scenario.
    * @param $mime_type_input
@@ -522,15 +522,15 @@ class ValidatorBaseTest extends ChadoTestKernelBase {
    *   The exception message if the test scenario is expected to throw an exception.
    * @param $expected
    *   The returned file delimiter.
-   * 
+   *
    * @dataProvider provideMimeTypesForFileDelimiterGetter
    */
   public function testFileDelimiterGetter($scenario, $mime_type_input, $has_exception, $exception_message, $expected) {
-    
+
     $exception_caught = FALSE;
     $exception_get_message = '';
     $delimiter = FALSE;
-    
+
     try {
       $delimiter = TripalCultivatePhenotypesValidatorBase::getFileDelimiters($mime_type_input);
     }
@@ -538,7 +538,7 @@ class ValidatorBaseTest extends ChadoTestKernelBase {
       $exception_caught = TRUE;
       $exception_get_message = $e->getMessage();
     }
-    
+
     $this->assertEquals($exception_caught, $has_exception, 'An exception was expected by file delimiter getter method for scenario:' . $scenario);
     $this->assertStringContainsString(
       $exception_message,

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorBaseTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorBaseTest.php
@@ -70,9 +70,18 @@ class ValidatorBaseTest extends ChadoTestKernelBase {
    */
   public function testValidatorBaseCheckIndices() {
 
-    // Create a plugin instance for any validator that uses this function
-    $validator_id = 'value_in_list';
-    $instance = $this->plugin_manager->createInstance($validator_id);
+    $configuration = [];
+    $validator_id = 'fake_basically_base';
+    $plugin_definition = [
+      'id' => $validator_id,
+      'validator_name' => 'Basically Base Validator',
+      'input_types' => ['header-row', 'data-row'],
+    ];
+    $instance = new BasicallyBase($configuration, $validator_id, $plugin_definition);
+    $this->assertIsObject(
+      $instance,
+      "Unable to create fake_basically_base validator instance to test the base class."
+    );
 
     // Simulates a row within the Trait Importer
     $file_row = [
@@ -84,28 +93,34 @@ class ValidatorBaseTest extends ChadoTestKernelBase {
       'Qualitative'
     ];
 
-    // ERROR CASES
-
-    // Provide an empty array of indices
-    // @TODO: This throws an exception from setIndices() instead of from checkIndices()
-    /**
-    $instance->setIndices([]);
+    // Provide a valid list of indices
+    $indices = [ 0, 1, 2, 3, 4, 5 ];
     $exception_caught = FALSE;
     try {
-      $validation_status = $instance->validateRow($file_row);
+      $instance->checkIndices($file_row, $indices);
+    } catch (\Exception $e) {
+      $exception_caught = TRUE;
+    }
+    $this->assertFalse($exception_caught, 'Caught an exception from checkIndices() in spite of valid indices being provided.');
+
+    // ------------ ERROR CASES ---------------
+    // Provide an empty array of indices
+    $indices = [];
+    $exception_caught = FALSE;
+    try {
+      $instance->checkIndices($file_row, $indices);
     }
     catch ( \Exception $e ) {
       $exception_caught = TRUE;
     }
     $this->assertTrue($exception_caught, 'Did not catch exception that should have occurred due to passing in an empty array of indices.');
     $this->assertStringContainsString('An empty indices array was provided.', $e->getMessage(), "Did not get the expected exception message when providing an empty array of indices.");
-    */
 
     // Provide too many indices
-    $instance->setIndices( [0, 1, 2, 3, 4, 5, 6, 7] );
+    $indices = [0, 1, 2, 3, 4, 5, 6, 7];
     $exception_caught = FALSE;
     try {
-      $validation_status = $instance->validateRow($file_row);
+      $instance->checkIndices($file_row, $indices);
     }
     catch ( \Exception $e ) {
       $exception_caught = TRUE;
@@ -114,10 +129,10 @@ class ValidatorBaseTest extends ChadoTestKernelBase {
     $this->assertStringContainsString('Too many indices were provided (8) compared to the number of cells in the provided row (6)', $e->getMessage(), "Did not get the expected exception message when providing 8 indices compared to 6 values.");
 
     // Provide invalid indices
-    $instance->setIndices( [1, -4, 77] );
+    $indices = [1, -4, 77];
     $exception_caught = FALSE;
     try {
-      $validation_status = $instance->validateRow($file_row);
+      $instance->checkIndices($file_row, $indices);
     }
     catch ( \Exception $e ) {
       $exception_caught = TRUE;

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorDuplicateTraitsTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorDuplicateTraitsTest.php
@@ -8,14 +8,17 @@ use Drupal\trpcultivate_phenotypes\TripalCultivateValidator\TripalCultivatePheno
 use Drupal\trpcultivate_phenotypes\Service\TripalCultivatePhenotypesTraitsService;
 
 
- /**
-  * Tests Tripal Cultivate Phenotypes Validator Plugins that are specific to
-  * the Trait Importer (ie. they are not also used by other importers)
-  *
-  * @group trpcultivate_phenotypes
-  * @group validators
-  */
-class ValidatorTraitImporterTest extends ChadoTestKernelBase {
+/**
+ * Tests the Duplicate Traits validator
+ * NOTE: This validator is specific to the Trait Importer
+ * (ie. it is not also used by other importers)
+ *
+ * @group trpcultivate_phenotypes
+ * @group validators
+ * @group row_validators
+ * @group trait_importer_validators
+ */
+class ValidatorDuplicateTraitsTest extends ChadoTestKernelBase {
 
   use PhenotypeImporterTestTrait;
 

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorDuplicateTraitsTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorDuplicateTraitsTest.php
@@ -140,14 +140,26 @@ class ValidatorDuplicateTraitsTest extends ChadoTestKernelBase {
     $expected_valid = TRUE;
     $instance->setIndices(['Trait Name' => 0, 'Method Short Name' => 2, 'Unit' => 4]);
     $validation_status = $instance->validateRow($file_row);
-    $this->assertEquals($expected_valid, $validation_status['valid'], "Duplicate Trait validation was expected to pass when provided the first row of values to validate.");
+    $this->assertSame(
+      $expected_valid,
+      $validation_status['valid'],
+      "Duplicate Trait validation was expected to pass when provided the first row of values to validate."
+    );
     $unique_traits = $instance->getUniqueTraits();
-    $this->assertArrayHasUniqueCombo('My trait', 'My method', 'My unit', $unique_traits, 'Failed to find expected key within the global $unique_traits array for combo #1.');
+    $this->assertArrayHasUniqueCombo(
+      'My trait', 'My method', 'My unit',
+      $unique_traits,
+      'Failed to find expected key within the global $unique_traits array for combo #1.'
+    );
 
     // Case #1: Re-renter the same details of the default case, should fail since it's a duplicate of the previous row
     $expected_valid = FALSE;
     $validation_status = $instance->validateRow($file_row);
-    $this->assertEquals($expected_valid, $validation_status['valid'], "Validation was expected to fail when passed in a duplicate trait name + method + unit combination.");
+    $this->assertSame(
+      $expected_valid,
+      $validation_status['valid'],
+      "Validation was expected to fail when passed in a duplicate trait name + method + unit combination."
+    );
 
     // Case #2: Provide an incorrect key to $context['indices']
     $instance->setIndices([ 'Trait Name' => 0, 'method name' => 2, 'Unit' => 3 ]);
@@ -160,8 +172,15 @@ class ValidatorDuplicateTraitsTest extends ChadoTestKernelBase {
       $exception_caught = TRUE;
       $exception_message = $e->getMessage();
     }
-    $this->assertTrue($exception_caught, 'Did not catch exception that should have occurred due to passing in the wrong index key "method name" to $context[\'indices\'].');
-    $this->assertStringContainsString('The method name (key: Method Short Name) was not set', $exception_message, "Did not get the expected exception message when providing the wrong index key \"method name\".");
+    $this->assertTrue(
+      $exception_caught,
+      'Did not catch exception that should have occurred due to passing in the wrong index key "method name" to $context[\'indices\'].'
+    );
+    $this->assertStringContainsString(
+      'The method name (key: Method Short Name) was not set',
+      $exception_message,
+      "Did not get the expected exception message when providing the wrong index key \"method name\"."
+    );
 
     // Case #3: Enter a second unique row and check our global $unique_traits array
     // Note: unit is at a different index
@@ -177,9 +196,17 @@ class ValidatorDuplicateTraitsTest extends ChadoTestKernelBase {
     $expected_valid = TRUE;
     $instance->setIndices([ 'Trait Name' => 0, 'Method Short Name' => 2, 'Unit' => 5 ]);
     $validation_status = $instance->validateRow($file_row_2);
-    $this->assertEquals($expected_valid, $validation_status['valid'], "Validation was expected to pass for row #2 which contains a unique trait name + method + unit combination.");
+    $this->assertSame(
+      $expected_valid,
+      $validation_status['valid'],
+      "Validation was expected to pass for row #2 which contains a unique trait name + method + unit combination."
+    );
     $unique_traits = $instance->getUniqueTraits();
-    $this->assertArrayHasUniqueCombo('My trait 2', 'My method 2', 'My unit 2', $unique_traits, 'Failed to find expected key within the global $unique_traits array for combo #2.');
+    $this->assertArrayHasUniqueCombo(
+      'My trait 2', 'My method 2', 'My unit 2',
+      $unique_traits,
+      'Failed to find expected key within the global $unique_traits array for combo #2.'
+    );
 
     // Case #4: Enter a third row that has same trait name and method name as row #1, and same unit as row #2.
     // Technically this combo is considered unique and should pass
@@ -195,9 +222,17 @@ class ValidatorDuplicateTraitsTest extends ChadoTestKernelBase {
     $expected_valid = TRUE;
     $instance->setIndices([ 'Trait Name' => 0, 'Method Short Name' => 2, 'Unit' => 4 ]);
     $validation_status = $instance->validateRow($file_row_3);
-    $this->assertEquals($expected_valid, $validation_status['valid'], "Validation was expected to pass for row #3 which contains a unique trait name + method + unit combination.");
+    $this->assertSame(
+      $expected_valid,
+      $validation_status['valid'],
+      "Validation was expected to pass for row #3 which contains a unique trait name + method + unit combination."
+    );
     $unique_traits = $instance->getUniqueTraits();
-    $this->assertArrayHasUniqueCombo('My trait', 'My method', 'My unit 2', $unique_traits, 'Failed to find expected key within the global $unique_traits array for combo #3.');
+    $this->assertArrayHasUniqueCombo(
+      'My trait', 'My method', 'My unit 2',
+      $unique_traits,
+      'Failed to find expected key within the global $unique_traits array for combo #3.'
+    );
 
   }
 
@@ -236,12 +271,20 @@ class ValidatorDuplicateTraitsTest extends ChadoTestKernelBase {
     // Default case: Validate a single row and check against an empty database
     $expected_valid = TRUE;
     $validation_status = $instance->validateRow($file_row);
-    $this->assertEquals($expected_valid, $validation_status['valid'], "Duplicate Trait validation was expected to pass when provided the first row of values to validate and an empty database.");
+    $this->assertSame(
+      $expected_valid,
+      $validation_status['valid'],
+      "Duplicate Trait validation was expected to pass when provided the first row of values to validate and an empty database."
+    );
 
     // Verify this trait isn't in the database
     $my_trait_id = $this->service_traits->getTrait($file_row_default['Trait Name']);
-    $expected_trait_id = 0;
-    $this->assertEquals($expected_trait_id, $my_trait_id, "Duplicate Trait validation did not fail, yet a trait ID was queried from the database for the same trait name.");
+    $expected_trait_id = null;
+    $this->assertSame(
+      $expected_trait_id,
+      $my_trait_id,
+      "Duplicate Trait validation did not fail, yet a trait ID was queried from the database for the same trait name."
+    );
 
     // Case #1: Enter a trait into the database first and then try to validate it
     $file_row_case_1 = [
@@ -257,13 +300,21 @@ class ValidatorDuplicateTraitsTest extends ChadoTestKernelBase {
     $combo_ids = $this->service_traits->insertTrait($file_row_case_1);
     $my_trait_record = $this->service_traits->getTrait($file_row_case_1['Trait Name']);
     $expected_trait_id = $combo_ids['trait'];
-    $this->assertEquals($expected_trait_id, $my_trait_record->cvterm_id, "The trait ID returned from inserting into the database and the trait ID that was queried for the same trait name do not match.");
+    $this->assertSame(
+      $expected_trait_id,
+      $my_trait_record->cvterm_id,
+      "The trait ID returned from inserting into the database and the trait ID that was queried for the same trait name do not match."
+    );
 
     // Now that the trait is confirmed to be in the database, our validator should
     // return a fail status when trying to validate the same trait again
     $expected_valid = FALSE;
     $validation_status = $instance->validateRow($file_row_1);
-    $this->assertEquals($expected_valid, $validation_status['valid'], "Duplicate Trait validation was expected to fail when provided a row of values for which there already exists a trait+method+unit combo in the database.");
+    $this->assertSame(
+      $expected_valid,
+      $validation_status['valid'],
+      "Duplicate Trait validation was expected to fail when provided a row of values for which there already exists a trait+method+unit combo in the database."
+    );
 
     // Case #2: Validate trait details where trait name and method name already
     // exist in the database, but unit is unique
@@ -279,12 +330,20 @@ class ValidatorDuplicateTraitsTest extends ChadoTestKernelBase {
 
     $expected_valid = TRUE;
     $validation_status = $instance->validateRow($file_row_2);
-    $this->assertEquals($expected_valid, $validation_status['valid'], "Duplicate Trait validation was expected to pass when provided the second row of values to validate the situation where trait and method are in the database but the unit is not.");
+    $this->assertSame(
+      $expected_valid,
+      $validation_status['valid'],
+      "Duplicate Trait validation was expected to pass when provided the second row of values to validate the situation where trait and method are in the database but the unit is not."
+    );
 
     // Verify this combo does not exist in the database yet
     $my_trait_2_record = $this->service_traits->getTraitMethodUnitCombo('My trait 1', 'My method 1', 'My unit 2');
     $expected_trait_record = null; // The getTraitMethodUnitCombo method is expected to return null
-    $this->assertEquals($expected_trait_record, $my_trait_2_record, "Duplicate Trait validation did not fail, yet a trait ID was queried from the database for the same trait name.");
+    $this->assertSame(
+      $expected_trait_record,
+      $my_trait_2_record,
+      "Duplicate Trait validation did not fail, yet a trait ID was queried from the database for the same trait name."
+    );
 
     // Case #3: Validate where a trait + method + unit combo is duplicated in
     // BOTH the database level and the file level
@@ -302,18 +361,34 @@ class ValidatorDuplicateTraitsTest extends ChadoTestKernelBase {
     $expected_valid = FALSE;
     $expected_case = 'A duplicate trait was found in the database';
     $validation_status = $instance->validateRow($file_row_3);
-    $this->assertEquals($expected_valid, $validation_status['valid'], "Duplicate Trait validation was expected to fail when provided the third row of values to validate where trait + method + unit already exist in the database.");
+    $this->assertSame(
+      $expected_valid,
+      $validation_status['valid'],
+      "Duplicate Trait validation was expected to fail when provided the third row of values to validate where trait + method + unit already exist in the database."
+    );
     // Check that we are getting the right error code for a database duplicate
-    $this->assertStringContainsString($expected_case, $validation_status['case'], 'Duplicate Trait validation did not report that there was a duplicate in the database when validating the third row.');
+    $this->assertStringContainsString(
+      $expected_case,
+      $validation_status['case'],
+      "Duplicate Trait validation did not report that there was a duplicate in the database when validating the third row."
+    );
 
     // Now try validating a row with the exact same values as the previous one
     $file_row_4 = $file_row_3;
 
     $expected_valid = FALSE;
-    $expected_case = 'A duplicate trait was found within both the input file and the database.';
+    $expected_case = 'A duplicate trait was found within both the input file and the database';
     $validation_status = $instance->validateRow($file_row_4);
-    $this->assertEquals($expected_valid, $validation_status['valid'], "Duplicate Trait validation was expected to fail when provided the fourth row of values to validate where trait + method + unit was in the previous row AND exists in the database.");
-    $this->assertStringContainsString($expected_case, $validation_status['case'], 'Duplicate Trait validation did not report that there was a duplicate in the file AND the database when validating the fourth row.');
+    $this->assertEquals(
+      $expected_valid,
+      $validation_status['valid'],
+      "Duplicate Trait validation was expected to fail when provided the fourth row of values to validate where trait + method + unit was in the previous row AND exists in the database."
+    );
+    $this->assertStringContainsString(
+      $expected_case,
+      $validation_status['case'],
+      "Duplicate Trait validation did not report that there was a duplicate in the file AND the database when validating the fourth row."
+    );
   }
 
   /*

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorDuplicateTraitsTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorDuplicateTraitsTest.php
@@ -113,6 +113,113 @@ class ValidatorDuplicateTraitsTest extends ChadoTestKernelBase {
   }
 
   /**
+   * Data Provider: Provides a set of indices for different scenarios that would
+   *   trigger an exception in the DuplicateTraits validator
+   *
+   * For each scenario we have:
+   * -- a label, which is the name of the index key that we're trying to trigger
+   *    an exception message for
+   * -- an array containing the 2 of the following 3 key-value pairs (whichever
+   *    one doesn't match the label, that one will be appended with 'WRONG KEY')
+   *    - 'Trait Name' => 0
+   *    - 'Method Short Name' => 2
+   *    - 'Unit' => 4
+   *
+   * @return $scenarios
+   */
+  public function provideWrongIndexKeys() {
+
+    $scenarios = [
+      // #0: Incorrect 'Trait Name' key
+      [
+        "Trait Name",
+        [
+          'Trait Name WRONG KEY' => 0,
+          'Method Short Name' => 2,
+          'Unit' => 4
+        ]
+      ],
+      // #1: Incorrect 'Method Short Name' key
+      [
+        "Method Short Name",
+        [
+          'Trait Name' => 0,
+          'Method Short Name WRONG KEY' => 2,
+          'Unit' => 4
+        ]
+      ],
+      // #2: Incorrect 'Unit' key
+      [
+        "Unit",
+        [
+          'Trait Name' => 0,
+          'Method Short Name' => 2,
+          'Unit WRONG KEY' => 4
+        ]
+      ]
+    ];
+
+    return $scenarios;
+  }
+
+  /**
+   * Test for the required keys in the indices array set by SetIndices()
+   * for the DuplicateTraits Validator
+   *
+   * @param string $label
+   *   The expected name of the index key that will be failing in its scenario.
+   *   It is used to check the exception message that gets thrown and to
+   *   provide better feedback messages if any of the asserts fail.
+   * @param array $indices
+   *   The array that gets provided to setIndices for this instance of the
+   *   DuplicateTraits validator. Each scenario provides an incorrect key in
+   *   their array for a different index.
+   *
+   * @return void
+   *
+   * @dataProvider provideWrongIndexKeys
+   */
+  public function testIndexKeyExceptions($label, $indices) {
+
+    // Create a plugin instance for this validator
+    $validator_id = 'duplicate_traits';
+    $instance = $this->plugin_manager->createInstance($validator_id);
+
+    // Set the genus
+    $instance->setConfiguredGenus($this->genus);
+
+    // Simulates a row within the Trait Importer
+    $file_row = [
+      'My trait',
+      'My trait description',
+      'My method',
+      'My method description',
+      'My unit',
+      'Quantitative'
+    ];
+
+    $instance->setIndices($indices);
+    $exception_caught = FALSE;
+    $exception_message = '';
+    $expected_message = "key: " . $label . ") was not set by setIndices()";
+    try {
+      $validation_status = $instance->validateRow($file_row);
+    } catch (\Exception $e) {
+      $exception_caught = TRUE;
+      $exception_message = $e->getMessage();
+    }
+    $this->assertTrue(
+      $exception_caught,
+      "Did not catch exception that should have occurred due to passing in the incorrect '" . $label . "' to setIndices()."
+    );
+    $this->assertStringContainsString(
+      $expected_message,
+      $exception_message,
+      "Did not get the expected exception message when providing the wrong index key '" . $label . "'"
+    );
+  }
+
+  /**
    * Test Duplicate Traits Plugin Validator at the file level
    * -- ONLY tests with the context of traits that are being imported and
    *    compared to other traits that exist within the same input file
@@ -185,28 +292,7 @@ class ValidatorDuplicateTraitsTest extends ChadoTestKernelBase {
       "Duplicate Trait validation failed items was expected to contain the trait, method and unit column headers and contents since this was a duplicate in the file."
     );
 
-    // Case #2: Provide an incorrect key to $context['indices']
-    $instance->setIndices([ 'Trait Name' => 0, 'method name' => 2, 'Unit' => 3 ]);
-    $exception_caught = FALSE;
-    $exception_message = '';
-    try {
-      $validation_status = $instance->validateRow($file_row);
-    }
-    catch ( \Exception $e ) {
-      $exception_caught = TRUE;
-      $exception_message = $e->getMessage();
-    }
-    $this->assertTrue(
-      $exception_caught,
-      'Did not catch exception that should have occurred due to passing in the wrong index key "method name" to $context[\'indices\'].'
-    );
-    $this->assertStringContainsString(
-      'The method name (key: Method Short Name) was not set',
-      $exception_message,
-      "Did not get the expected exception message when providing the wrong index key \"method name\"."
-    );
-
-    // Case #3: Enter a second unique row and check our global $unique_traits array
+    // Case #2: Enter a second unique row and check our global $unique_traits array
     // Note: unit is at a different index
     $file_row_2 = [
       'My trait 2',
@@ -244,7 +330,7 @@ class ValidatorDuplicateTraitsTest extends ChadoTestKernelBase {
       'Failed to find expected key within the global $unique_traits array for combo #2.'
     );
 
-    // Case #4: Enter a third row that has same trait name and method name as row #1, and same unit as row #2.
+    // Case #3: Enter a third row that has same trait name and method name as row #1, and same unit as row #2.
     // Technically this combo is considered unique and should pass
     $file_row_3 = [
       'My trait',

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorDuplicateTraitsTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorDuplicateTraitsTest.php
@@ -138,12 +138,24 @@ class ValidatorDuplicateTraitsTest extends ChadoTestKernelBase {
 
     // Default case: Enter a single row of data
     $expected_valid = TRUE;
+    $expected_case = 'Confirmed that the current trait being validated is unique';
+    $expected_failedItems = [];
     $instance->setIndices(['Trait Name' => 0, 'Method Short Name' => 2, 'Unit' => 4]);
     $validation_status = $instance->validateRow($file_row);
     $this->assertSame(
       $expected_valid,
       $validation_status['valid'],
       "Duplicate Trait validation was expected to pass when provided the first row of values to validate."
+    );
+    $this->assertEquals(
+      $expected_case,
+      $validation_status['case'],
+      "Duplicate Trait validation case message did not confirm that the very first trait being validated was unique."
+    );
+    $this->assertSame(
+      $expected_failedItems,
+      $validation_status['failedItems'],
+      "Duplicate Trait validation failed items was expected to be empty since validation passed."
     );
     $unique_traits = $instance->getUniqueTraits();
     $this->assertArrayHasUniqueCombo(
@@ -154,11 +166,23 @@ class ValidatorDuplicateTraitsTest extends ChadoTestKernelBase {
 
     // Case #1: Re-renter the same details of the default case, should fail since it's a duplicate of the previous row
     $expected_valid = FALSE;
+    $expected_case = 'A duplicate trait was found within the input file';
+    $expected_failedItems = ['combo_provided' => ['Trait Name' => 'My trait', 'Method Short Name' => 'My method', 'Unit' => 'My unit']];
     $validation_status = $instance->validateRow($file_row);
     $this->assertSame(
       $expected_valid,
       $validation_status['valid'],
       "Validation was expected to fail when passed in a duplicate trait name + method + unit combination."
+    );
+    $this->assertEquals(
+      $expected_case,
+      $validation_status['case'],
+      "Duplicate Trait validation case message was expected to report a duplicate trait within the file."
+    );
+    $this->assertSame(
+      $expected_failedItems,
+      $validation_status['failedItems'],
+      "Duplicate Trait validation failed items was expected to contain the trait, method and unit column headers and contents since this was a duplicate in the file."
     );
 
     // Case #2: Provide an incorrect key to $context['indices']
@@ -194,12 +218,24 @@ class ValidatorDuplicateTraitsTest extends ChadoTestKernelBase {
     ];
 
     $expected_valid = TRUE;
+    $expected_case = 'Confirmed that the current trait being validated is unique';
+    $expected_failedItems = [];
     $instance->setIndices([ 'Trait Name' => 0, 'Method Short Name' => 2, 'Unit' => 5 ]);
     $validation_status = $instance->validateRow($file_row_2);
     $this->assertSame(
       $expected_valid,
       $validation_status['valid'],
       "Validation was expected to pass for row #2 which contains a unique trait name + method + unit combination."
+    );
+    $this->assertEquals(
+      $expected_case,
+      $validation_status['case'],
+      "Duplicate Trait validation case message did not confirm that a second unique trait combo being validated was unique."
+    );
+    $this->assertSame(
+      $expected_failedItems,
+      $validation_status['failedItems'],
+      "Duplicate Trait validation failed items was expected to be empty since validation passed."
     );
     $unique_traits = $instance->getUniqueTraits();
     $this->assertArrayHasUniqueCombo(
@@ -220,12 +256,24 @@ class ValidatorDuplicateTraitsTest extends ChadoTestKernelBase {
     ];
 
     $expected_valid = TRUE;
+    $expected_case = 'Confirmed that the current trait being validated is unique';
+    $expected_failedItems = [];
     $instance->setIndices([ 'Trait Name' => 0, 'Method Short Name' => 2, 'Unit' => 4 ]);
     $validation_status = $instance->validateRow($file_row_3);
     $this->assertSame(
       $expected_valid,
       $validation_status['valid'],
       "Validation was expected to pass for row #3 which contains a unique trait name + method + unit combination."
+    );
+    $this->assertEquals(
+      $expected_case,
+      $validation_status['case'],
+      "Duplicate Trait validation case message did not confirm that a third unique trait combo being validated was unique."
+    );
+    $this->assertSame(
+      $expected_failedItems,
+      $validation_status['failedItems'],
+      "Duplicate Trait validation failed items was expected to be empty since validation passed."
     );
     $unique_traits = $instance->getUniqueTraits();
     $this->assertArrayHasUniqueCombo(
@@ -270,11 +318,23 @@ class ValidatorDuplicateTraitsTest extends ChadoTestKernelBase {
 
     // Default case: Validate a single row and check against an empty database
     $expected_valid = TRUE;
+    $expected_case = 'Confirmed that the current trait being validated is unique';
+    $expected_failedItems = [];
     $validation_status = $instance->validateRow($file_row);
     $this->assertSame(
       $expected_valid,
       $validation_status['valid'],
       "Duplicate Trait validation was expected to pass when provided the first row of values to validate and an empty database."
+    );
+    $this->assertEquals(
+      $expected_case,
+      $validation_status['case'],
+      "Duplicate Trait validation case message did not confirm that the very first trait combo being validated was unique."
+    );
+    $this->assertSame(
+      $expected_failedItems,
+      $validation_status['failedItems'],
+      "Duplicate Trait validation failed items was expected to be empty since validation passed."
     );
 
     // Verify this trait isn't in the database
@@ -309,11 +369,29 @@ class ValidatorDuplicateTraitsTest extends ChadoTestKernelBase {
     // Now that the trait is confirmed to be in the database, our validator should
     // return a fail status when trying to validate the same trait again
     $expected_valid = FALSE;
+    $expected_case = 'A duplicate trait was found in the database';
+    $expected_failedItems = [
+      'combo_provided' => [
+        'Trait Name' => 'My trait 1',
+        'Method Short Name' => 'My method 1',
+        'Unit' => 'My unit 1'
+      ]
+    ];
     $validation_status = $instance->validateRow($file_row_1);
     $this->assertSame(
       $expected_valid,
       $validation_status['valid'],
       "Duplicate Trait validation was expected to fail when provided a row of values for which there already exists a trait+method+unit combo in the database."
+    );
+    $this->assertEquals(
+      $expected_case,
+      $validation_status['case'],
+      "Duplicate Trait validation case message was expected to report a duplicate trait within the database."
+    );
+    $this->assertSame(
+      $expected_failedItems,
+      $validation_status['failedItems'],
+      "Duplicate Trait validation failed items was expected to contain the trait, method and unit column headers and contents since this was a duplicate in the database."
     );
 
     // Case #2: Validate trait details where trait name and method name already
@@ -329,11 +407,23 @@ class ValidatorDuplicateTraitsTest extends ChadoTestKernelBase {
     $file_row_2 = array_values($file_row_case_2);
 
     $expected_valid = TRUE;
+    $expected_case = 'Confirmed that the current trait being validated is unique';
+    $expected_failedItems = [];
     $validation_status = $instance->validateRow($file_row_2);
     $this->assertSame(
       $expected_valid,
       $validation_status['valid'],
       "Duplicate Trait validation was expected to pass when provided the second row of values to validate the situation where trait and method are in the database but the unit is not."
+    );
+    $this->assertEquals(
+      $expected_case,
+      $validation_status['case'],
+      "Duplicate Trait validation case message did not confirm that the second unique trait combo being validated was unique."
+    );
+    $this->assertSame(
+      $expected_failedItems,
+      $validation_status['failedItems'],
+      "Duplicate Trait validation failed items was expected to be empty since validation passed."
     );
 
     // Verify this combo does not exist in the database yet
@@ -360,6 +450,13 @@ class ValidatorDuplicateTraitsTest extends ChadoTestKernelBase {
     $combo_ids_3 = $this->service_traits->insertTrait($file_row_case_3);
     $expected_valid = FALSE;
     $expected_case = 'A duplicate trait was found in the database';
+    $expected_failedItems = [
+      'combo_provided' => [
+        'Trait Name' => 'My trait 3',
+        'Method Short Name' => 'My method 3',
+        'Unit' => 'My unit 3'
+      ]
+    ];
     $validation_status = $instance->validateRow($file_row_3);
     $this->assertSame(
       $expected_valid,
@@ -372,12 +469,24 @@ class ValidatorDuplicateTraitsTest extends ChadoTestKernelBase {
       $validation_status['case'],
       "Duplicate Trait validation did not report that there was a duplicate in the database when validating the third row."
     );
+    $this->assertSame(
+      $expected_failedItems,
+      $validation_status['failedItems'],
+      "Duplicate Trait validation failed items was expected to contain the trait, method and unit column headers and contents of the third row since this was a duplicate in the database."
+    );
 
     // Now try validating a row with the exact same values as the previous one
     $file_row_4 = $file_row_3;
 
     $expected_valid = FALSE;
     $expected_case = 'A duplicate trait was found within both the input file and the database';
+    $expected_failedItems = [
+      'combo_provided' => [
+        'Trait Name' => 'My trait 3',
+        'Method Short Name' => 'My method 3',
+        'Unit' => 'My unit 3'
+      ]
+    ];
     $validation_status = $instance->validateRow($file_row_4);
     $this->assertEquals(
       $expected_valid,
@@ -388,6 +497,11 @@ class ValidatorDuplicateTraitsTest extends ChadoTestKernelBase {
       $expected_case,
       $validation_status['case'],
       "Duplicate Trait validation did not report that there was a duplicate in the file AND the database when validating the fourth row."
+    );
+    $this->assertSame(
+      $expected_failedItems,
+      $validation_status['failedItems'],
+      "Duplicate Trait validation failed items was expected to contain the trait, method and unit column headers and contents of the fourth row since this was a duplicate in the database AND file."
     );
   }
 

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorDuplicateTraitsTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorDuplicateTraitsTest.php
@@ -137,17 +137,17 @@ class ValidatorDuplicateTraitsTest extends ChadoTestKernelBase {
     ];
 
     // Default case: Enter a single row of data
-    $expected_status = 'pass';
+    $expected_valid = TRUE;
     $instance->setIndices(['Trait Name' => 0, 'Method Short Name' => 2, 'Unit' => 4]);
     $validation_status = $instance->validateRow($file_row);
-    $this->assertEquals($expected_status, $validation_status['status'], "Duplicate Trait validation was expected to pass when provided the first row of values to validate.");
+    $this->assertEquals($expected_valid, $validation_status['valid'], "Duplicate Trait validation was expected to pass when provided the first row of values to validate.");
     $unique_traits = $instance->getUniqueTraits();
     $this->assertArrayHasUniqueCombo('My trait', 'My method', 'My unit', $unique_traits, 'Failed to find expected key within the global $unique_traits array for combo #1.');
 
     // Case #1: Re-renter the same details of the default case, should fail since it's a duplicate of the previous row
-    $expected_status = 'fail';
+    $expected_valid = FALSE;
     $validation_status = $instance->validateRow($file_row);
-    $this->assertEquals($expected_status, $validation_status['status'], "Validation was expected to fail when passed in a duplicate trait name + method + unit combination.");
+    $this->assertEquals($expected_valid, $validation_status['valid'], "Validation was expected to fail when passed in a duplicate trait name + method + unit combination.");
 
     // Case #2: Provide an incorrect key to $context['indices']
     $instance->setIndices([ 'Trait Name' => 0, 'method name' => 2, 'Unit' => 3 ]);
@@ -174,10 +174,10 @@ class ValidatorDuplicateTraitsTest extends ChadoTestKernelBase {
       'My unit 2'
     ];
 
-    $expected_status = 'pass';
+    $expected_valid = TRUE;
     $instance->setIndices([ 'Trait Name' => 0, 'Method Short Name' => 2, 'Unit' => 5 ]);
     $validation_status = $instance->validateRow($file_row_2);
-    $this->assertEquals($expected_status, $validation_status['status'], "Validation was expected to pass for row #2 which contains a unique trait name + method + unit combination.");
+    $this->assertEquals($expected_valid, $validation_status['valid'], "Validation was expected to pass for row #2 which contains a unique trait name + method + unit combination.");
     $unique_traits = $instance->getUniqueTraits();
     $this->assertArrayHasUniqueCombo('My trait 2', 'My method 2', 'My unit 2', $unique_traits, 'Failed to find expected key within the global $unique_traits array for combo #2.');
 
@@ -192,10 +192,10 @@ class ValidatorDuplicateTraitsTest extends ChadoTestKernelBase {
       'Qualitative'
     ];
 
-    $expected_status = 'pass';
+    $expected_valid = TRUE;
     $instance->setIndices([ 'Trait Name' => 0, 'Method Short Name' => 2, 'Unit' => 4 ]);
     $validation_status = $instance->validateRow($file_row_3);
-    $this->assertEquals($expected_status, $validation_status['status'], "Validation was expected to pass for row #3 which contains a unique trait name + method + unit combination.");
+    $this->assertEquals($expected_valid, $validation_status['valid'], "Validation was expected to pass for row #3 which contains a unique trait name + method + unit combination.");
     $unique_traits = $instance->getUniqueTraits();
     $this->assertArrayHasUniqueCombo('My trait', 'My method', 'My unit 2', $unique_traits, 'Failed to find expected key within the global $unique_traits array for combo #3.');
 
@@ -234,9 +234,9 @@ class ValidatorDuplicateTraitsTest extends ChadoTestKernelBase {
     $file_row = array_values($file_row_default);
 
     // Default case: Validate a single row and check against an empty database
-    $expected_status = 'pass';
+    $expected_valid = TRUE;
     $validation_status = $instance->validateRow($file_row);
-    $this->assertEquals($expected_status, $validation_status['status'], "Duplicate Trait validation was expected to pass when provided the first row of values to validate and an empty database.");
+    $this->assertEquals($expected_valid, $validation_status['valid'], "Duplicate Trait validation was expected to pass when provided the first row of values to validate and an empty database.");
 
     // Verify this trait isn't in the database
     $my_trait_id = $this->service_traits->getTrait($file_row_default['Trait Name']);
@@ -261,9 +261,9 @@ class ValidatorDuplicateTraitsTest extends ChadoTestKernelBase {
 
     // Now that the trait is confirmed to be in the database, our validator should
     // return a fail status when trying to validate the same trait again
-    $expected_status = 'fail';
+    $expected_valid = FALSE;
     $validation_status = $instance->validateRow($file_row_1);
-    $this->assertEquals($expected_status, $validation_status['status'], "Duplicate Trait validation was expected to fail when provided a row of values for which there already exists a trait+method+unit combo in the database.");
+    $this->assertEquals($expected_valid, $validation_status['valid'], "Duplicate Trait validation was expected to fail when provided a row of values for which there already exists a trait+method+unit combo in the database.");
 
     // Case #2: Validate trait details where trait name and method name already
     // exist in the database, but unit is unique
@@ -277,9 +277,9 @@ class ValidatorDuplicateTraitsTest extends ChadoTestKernelBase {
     ];
     $file_row_2 = array_values($file_row_case_2);
 
-    $expected_status = 'pass';
+    $expected_valid = TRUE;
     $validation_status = $instance->validateRow($file_row_2);
-    $this->assertEquals($expected_status, $validation_status['status'], "Duplicate Trait validation was expected to pass when provided the second row of values to validate the situation where trait and method are in the database but the unit is not.");
+    $this->assertEquals($expected_valid, $validation_status['valid'], "Duplicate Trait validation was expected to pass when provided the second row of values to validate the situation where trait and method are in the database but the unit is not.");
 
     // Verify this combo does not exist in the database yet
     $my_trait_2_record = $this->service_traits->getTraitMethodUnitCombo('My trait 1', 'My method 1', 'My unit 2');
@@ -299,20 +299,21 @@ class ValidatorDuplicateTraitsTest extends ChadoTestKernelBase {
     $file_row_3 = array_values($file_row_case_3);
 
     $combo_ids_3 = $this->service_traits->insertTrait($file_row_case_3);
-    $expected_status = 'fail';
+    $expected_valid = FALSE;
+    $expected_case = 'A duplicate trait was found in the database';
     $validation_status = $instance->validateRow($file_row_3);
-    $this->assertEquals($expected_status, $validation_status['status'], "Duplicate Trait validation was expected to fail when provided the third row of values to validate where trait + method + unit already exist in the database.");
+    $this->assertEquals($expected_valid, $validation_status['valid'], "Duplicate Trait validation was expected to fail when provided the third row of values to validate where trait + method + unit already exist in the database.");
     // Check that we are getting the right error code for a database duplicate
-    $this->assertStringEndsWith('is already found in the database.', $validation_status['details'], 'Duplicate Trait validation did not report that there was a duplicate in the database when validating the third row.');
+    $this->assertStringContainsString($expected_case, $validation_status['case'], 'Duplicate Trait validation did not report that there was a duplicate in the database when validating the third row.');
 
     // Now try validating a row with the exact same values as the previous one
     $file_row_4 = $file_row_3;
 
-    $expected_status = 'fail';
+    $expected_valid = FALSE;
+    $expected_case = 'A duplicate trait was found within both the input file and the database.';
     $validation_status = $instance->validateRow($file_row_4);
-    $this->assertEquals($expected_status, $validation_status['status'], "Duplicate Trait validation was expected to fail when provided the fourth row of values to validate where trait + method + unit was in the previous row AND exists in the database.");
-    $this->assertStringEndsWith('within both the input file and the database.', $validation_status['details'], 'Duplicate Trait validation did not report that there was a duplicate in the file AND the database when validating the fourth row.');
-
+    $this->assertEquals($expected_valid, $validation_status['valid'], "Duplicate Trait validation was expected to fail when provided the fourth row of values to validate where trait + method + unit was in the previous row AND exists in the database.");
+    $this->assertStringContainsString($expected_case, $validation_status['case'], 'Duplicate Trait validation did not report that there was a duplicate in the file AND the database when validating the fourth row.');
   }
 
   /*

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorDuplicateTraitsTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorDuplicateTraitsTest.php
@@ -113,14 +113,15 @@ class ValidatorDuplicateTraitsTest extends ChadoTestKernelBase {
   }
 
   /**
-   * Data Provider: Provides a set of indices for different scenarios that would
-   *   trigger an exception in the DuplicateTraits validator
+   * Data Provider: Provides a set of indices for different scenarios. Each
+   *   scenario is expected to trigger an exception during validation for
+   *   having provided an incorrect key to setIndices()
    *
    * For each scenario we have:
-   * -- a label, which is the name of the index key that we're trying to trigger
+   * -- a label, which is the same as the index key that we're trying to trigger
    *    an exception message for
-   * -- an array containing the 2 of the following 3 key-value pairs (whichever
-   *    one doesn't match the label, that one will be appended with 'WRONG KEY')
+   * -- an array containing 2 of the following 3 key-value pairs (whichever
+   *    one matches the label, that one will be appended with 'WRONG KEY')
    *    - 'Trait Name' => 0
    *    - 'Method Short Name' => 2
    *    - 'Unit' => 4
@@ -167,13 +168,12 @@ class ValidatorDuplicateTraitsTest extends ChadoTestKernelBase {
    * for the DuplicateTraits Validator
    *
    * @param string $label
-   *   The expected name of the index key that will be failing in its scenario.
+   *   The expected index key that will be failing in its scenario.
    *   It is used to check the exception message that gets thrown and to
    *   provide better feedback messages if any of the asserts fail.
    * @param array $indices
-   *   The array that gets provided to setIndices for this instance of the
-   *   DuplicateTraits validator. Each scenario provides an incorrect key in
-   *   their array for a different index.
+   *   The array that gets provided to setIndices() for this instance of the
+   *   DuplicateTraits validator. Each scenario has a different incorrect index.
    *
    * @return void
    *
@@ -215,7 +215,7 @@ class ValidatorDuplicateTraitsTest extends ChadoTestKernelBase {
     $this->assertStringContainsString(
       $expected_message,
       $exception_message,
-      "Did not get the expected exception message when providing the wrong index key '" . $label . "'"
+      "Did not get the expected exception message when providing the wrong index key '" . $label . "'."
     );
   }
 

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorEmptyCellTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorEmptyCellTest.php
@@ -91,7 +91,7 @@ class ValidatorEmptyCellTest extends ChadoTestKernelBase {
     $expected_failedItems = [];
     $instance->setIndices($indices);
     $validation_status = $instance->validateRow($file_row);
-    $this->assertEquals(
+    $this->assertSame(
       $expected_valid,
       $validation_status['valid'],
       "Empty cell validation was expected to pass when provided only non-empty cells to check."
@@ -114,7 +114,7 @@ class ValidatorEmptyCellTest extends ChadoTestKernelBase {
     $expected_failedItems = ['empty_indices' => $indices];
     $instance->setIndices($indices);
     $validation_status = $instance->validateRow($file_row);
-    $this->assertEquals(
+    $this->assertSame(
       $expected_valid,
       $validation_status['valid'],
       "Empty cell validation was expected to fail when provided a list of 3 empty cells to check."
@@ -137,7 +137,7 @@ class ValidatorEmptyCellTest extends ChadoTestKernelBase {
     $expected_failedItems = ['empty_indices' => [ 1, 3, 5 ]];
     $instance->setIndices($indices);
     $validation_status = $instance->validateRow($file_row);
-    $this->assertEquals(
+    $this->assertSame(
       $expected_valid,
       $validation_status['valid'],
        "Empty cell validation was expected to fail when provided a mixture of 3 empty and 3 non-empty cells to check."

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorEmptyCellTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorEmptyCellTest.php
@@ -86,7 +86,7 @@ class ValidatorEmptyCellTest extends ChadoTestKernelBase {
 
     // Case #1: Provide a list of indices for cells that are not empty
     $expected_valid = TRUE;
-    $expected_case = 'No empty values found in required column(s).';
+    $expected_case = 'No empty values found in required column(s)';
     $indices = [ 0, 2, 4 ];
     $expected_failedItems = [];
     $instance->setIndices($indices);
@@ -109,7 +109,7 @@ class ValidatorEmptyCellTest extends ChadoTestKernelBase {
 
     // Case #2: Provide a list of indices that includes only empty cells
     $expected_valid = FALSE;
-    $expected_case = 'Empty value found in required column(s).';
+    $expected_case = 'Empty value found in required column(s)';
     $indices = [ 1, 3, 5 ];
     $expected_failedItems = ['empty_indices' => $indices];
     $instance->setIndices($indices);
@@ -132,7 +132,7 @@ class ValidatorEmptyCellTest extends ChadoTestKernelBase {
 
     // Case #3: Provide a list of indices for the entire row (mixture of 3 empty and 3 non-empty cells)
     $expected_valid = FALSE;
-    $expected_case = 'Empty value found in required column(s).';
+    $expected_case = 'Empty value found in required column(s)';
     $indices = [ 0, 1, 2, 3, 4, 5 ];
     $expected_failedItems = ['empty_indices' => [ 1, 3, 5 ]];
     $instance->setIndices($indices);

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorEmptyCellTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorEmptyCellTest.php
@@ -85,26 +85,72 @@ class ValidatorEmptyCellTest extends ChadoTestKernelBase {
     ];
 
     // Case #1: Provide a list of indices for cells that are not empty
-    $expected_status = 'pass';
+    $expected_valid = TRUE;
+    $expected_case = 'No empty values found in required column(s).';
     $indices = [ 0, 2, 4 ];
+    $expected_failedItems = [];
     $instance->setIndices($indices);
     $validation_status = $instance->validateRow($file_row);
-    $this->assertEquals($expected_status, $validation_status['status'], "Empty cell validation was expected to pass when provided only non-empty cells to check.");
+    $this->assertEquals(
+      $expected_valid,
+      $validation_status['valid'],
+      "Empty cell validation was expected to pass when provided only non-empty cells to check."
+    );
+    $this->assertStringContainsString(
+      $expected_case,
+      $validation_status['case'],
+      "Empty cell validation case message did not match the expected when provided only non-empty cells to check."
+    );
+    $this->assertEquals(
+      $expected_failedItems,
+      $validation_status['failedItems'],
+      "Empty cell validation failed items should have been empty since validation passed."
+    );
 
     // Case #2: Provide a list of indices that includes only empty cells
-    $expected_status = 'fail';
+    $expected_valid = FALSE;
+    $expected_case = 'Empty value found in required column(s).';
     $indices = [ 1, 3, 5 ];
+    $expected_failedItems = ['empty_indices' => $indices];
     $instance->setIndices($indices);
     $validation_status = $instance->validateRow($file_row);
-    $this->assertEquals($expected_status, $validation_status['status'], "Empty cell validation was expected to fail when provided 3 empty cells to check.");
-    $this->assertStringEndsWith(': 1, 3, 5', $validation_status['details'], "Empty cell validation details did not contain the index of the empty cell.");
+    $this->assertEquals(
+      $expected_valid,
+      $validation_status['valid'],
+      "Empty cell validation was expected to fail when provided a list of 3 empty cells to check."
+    );
+    $this->assertStringContainsString(
+      $expected_case,
+      $validation_status['case'],
+      "Empty cell validation case message did not match the expected when provided a list of 3 empty cells to check."
+    );
+    $this->assertEquals(
+      $expected_failedItems,
+      $validation_status['failedItems'],
+      "Empty cell validation failed items did not contain the correct list of indices with empty cells."
+    );
 
     // Case #3: Provide a list of indices for the entire row (mixture of 3 empty and 3 non-empty cells)
-    $expected_status = 'fail';
+    $expected_valid = FALSE;
+    $expected_case = 'Empty value found in required column(s).';
     $indices = [ 0, 1, 2, 3, 4, 5 ];
+    $expected_failedItems = ['empty_indices' => [ 1, 3, 5 ]];
     $instance->setIndices($indices);
     $validation_status = $instance->validateRow($file_row);
-    $this->assertEquals($expected_status, $validation_status['status'], "Empty cell validation was expected to fail when provided a mixture of 3 empty and 3 non-empty cells to check.");
-    $this->assertStringEndsWith(': 1, 3, 5', $validation_status['details'], "Empty cell validation details did not contain the indices of the empty cells.");
+    $this->assertEquals(
+      $expected_valid,
+      $validation_status['valid'],
+       "Empty cell validation was expected to fail when provided a mixture of 3 empty and 3 non-empty cells to check."
+    );
+    $this->assertStringContainsString(
+      $expected_case,
+      $validation_status['case'],
+      "Empty cell validation case message did not match the expected when provided a mixture of 3 empty and 3 non-empty cells to check."
+    );
+    $this->assertEquals(
+      $expected_failedItems,
+      $validation_status['failedItems'],
+      "Empty cell validation failed items list did not contain the correct list of indices with empty cells."
+    );
   }
 }

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorEmptyCellTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorEmptyCellTest.php
@@ -1,0 +1,110 @@
+<?php
+namespace Drupal\Tests\trpcultivate_phenotypes\Kernel\Validators;
+
+use Drupal\tripal_chado\Database\ChadoConnection;
+use Drupal\Tests\tripal_chado\Kernel\ChadoTestKernelBase;
+
+/**
+ * Tests the Empty Cell validator
+ *
+ * @group trpcultivate_phenotypes
+ * @group validators
+ * @group row_validators
+ */
+class ValidatorEmptyCellTest extends ChadoTestKernelBase {
+  /**
+   * Plugin Manager service.
+   */
+  protected $plugin_manager;
+
+  /**
+   * A Database query interface for querying Chado using Tripal DBX.
+   *
+   * @var ChadoConnection
+   */
+  protected ChadoConnection $chado_connection;
+
+  /**
+   * Configuration
+   *
+   * @var config_entity
+   */
+  private $config;
+
+  /**
+   * Modules to enable.
+   */
+  protected static $modules = [
+    'file',
+    'user',
+    'tripal',
+    'tripal_chado',
+    'trpcultivate_phenotypes'
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    // Set test environment.
+    \Drupal::state()->set('is_a_test_environment', TRUE);
+
+    // Install module configuration.
+    $this->installConfig(['trpcultivate_phenotypes']);
+    $this->config = \Drupal::configFactory()->getEditable('trpcultivate_phenotypes.settings');
+
+    // Test Chado database.
+    // Create a test chado instance and then set it in the container for use by our service.
+    $this->chado_connection = $this->createTestSchema(ChadoTestKernelBase::PREPARE_TEST_CHADO);
+    $this->container->set('tripal_chado.database', $this->chado_connection);
+
+    // Set plugin manager service.
+    $this->plugin_manager = \Drupal::service('plugin.manager.trpcultivate_validator');
+  }
+
+  /**
+   * Test Empty Cell Plugin Validator.
+   */
+  public function testValidatorEmptyCell() {
+
+    // Create a plugin instance for this validator
+    $validator_id = 'empty_cell';
+    $instance = $this->plugin_manager->createInstance($validator_id);
+
+    // Simulates a row within the Trait Importer
+    // Includes 3 types of empty cells
+    $file_row = [
+      'My trait',
+      '',  // No whitespace
+      'My method',
+      ' ', // Single whitespace
+      'My unit',
+      '  ' // Double whitespace
+    ];
+
+    // Case #1: Provide a list of indices for cells that are not empty
+    $expected_status = 'pass';
+    $indices = [ 0, 2, 4 ];
+    $instance->setIndices($indices);
+    $validation_status = $instance->validateRow($file_row);
+    $this->assertEquals($expected_status, $validation_status['status'], "Empty cell validation was expected to pass when provided only non-empty cells to check.");
+
+    // Case #2: Provide a list of indices that includes only empty cells
+    $expected_status = 'fail';
+    $indices = [ 1, 3, 5 ];
+    $instance->setIndices($indices);
+    $validation_status = $instance->validateRow($file_row);
+    $this->assertEquals($expected_status, $validation_status['status'], "Empty cell validation was expected to fail when provided 3 empty cells to check.");
+    $this->assertStringEndsWith(': 1, 3, 5', $validation_status['details'], "Empty cell validation details did not contain the index of the empty cell.");
+
+    // Case #3: Provide a list of indices for the entire row (mixture of 3 empty and 3 non-empty cells)
+    $expected_status = 'fail';
+    $indices = [ 0, 1, 2, 3, 4, 5 ];
+    $instance->setIndices($indices);
+    $validation_status = $instance->validateRow($file_row);
+    $this->assertEquals($expected_status, $validation_status['status'], "Empty cell validation was expected to fail when provided a mixture of 3 empty and 3 non-empty cells to check.");
+    $this->assertStringEndsWith(': 1, 3, 5', $validation_status['details'], "Empty cell validation details did not contain the indices of the empty cells.");
+  }
+}

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorFileRowScopeTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorFileRowScopeTest.php
@@ -152,23 +152,23 @@ class ValidatorFileRowScopeTest extends ChadoTestKernelBase {
 
     // Case #1: Provide a list of indices for cells that are not empty
     $expected_status = 'pass';
-    $context['indices'] = [ 0, 2, 4 ];
-    $instance->context = $context;
+    $indices = [ 0, 2, 4 ];
+    $instance->setIndices($indices);
     $validation_status = $instance->validateRow($file_row);
     $this->assertEquals($expected_status, $validation_status['status'], "Empty cell validation was expected to pass when provided only non-empty cells to check.");
 
     // Case #2: Provide a list of indices that includes only empty cells
     $expected_status = 'fail';
-    $context['indices'] = [ 1, 3, 5 ];
-    $instance->context = $context;
+    $indices = [ 1, 3, 5 ];
+    $instance->setIndices($indices);
     $validation_status = $instance->validateRow($file_row);
     $this->assertEquals($expected_status, $validation_status['status'], "Empty cell validation was expected to fail when provided 3 empty cells to check.");
     $this->assertStringEndsWith(': 1, 3, 5', $validation_status['details'], "Empty cell validation details did not contain the index of the empty cell.");
 
     // Case #3: Provide a list of indices for the entire row (mixture of 3 empty and 3 non-empty cells)
     $expected_status = 'fail';
-    $context['indices'] = [ 0, 1, 2, 3, 4, 5 ];
-    $instance->context = $context;
+    $indices = [ 0, 1, 2, 3, 4, 5 ];
+    $instance->setIndices($indices);
     $validation_status = $instance->validateRow($file_row);
     $this->assertEquals($expected_status, $validation_status['status'], "Empty cell validation was expected to fail when provided a mixture of 3 empty and 3 non-empty cells to check.");
     $this->assertStringEndsWith(': 1, 3, 5', $validation_status['details'], "Empty cell validation details did not contain the indices of the empty cells.");

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorFileRowScopeTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorFileRowScopeTest.php
@@ -86,45 +86,50 @@ class ValidatorFileRowScopeTest extends ChadoTestKernelBase {
 
     // Case #1: Check for a valid value in a single column
     $expected_status = 'pass';
-    $context['indices'] = [ 5 ];
-    $context['valid_values'] = [ 'Qualitative', 'Quantitative' ];
-    $instance->context = $context;
+    $indices = [ 5 ];
+    $valid_values = [ 'Qualitative', 'Quantitative' ];
+    $instance->setIndices($indices);
+    $instance->setValidValues($valid_values);
     $validation_status = $instance->validateRow($file_row);
     $this->assertEquals($expected_status, $validation_status['status'], "Value in list validation was expected to pass when provided a cell with a valid value in the list.");
     $this->assertStringContainsString('Value at index 5 was one of:', $validation_status['details'], "Value in list validation details did not report that index 5 contained a valid value.");
 
     // Case #2: Check for an invalid value in a single column
     $expected_status = 'fail';
-    $context['indices'] = [ 2 ];
-    $context['valid_values'] = [ 'Qualitative', 'Quantitative' ];
-    $instance->context = $context;
+    $indices = [ 2 ];
+    $valid_values = [ 'Qualitative', 'Quantitative' ];
+    $instance->setIndices($indices);
+    $instance->setValidValues($valid_values);
     $validation_status = $instance->validateRow($file_row);
     $this->assertEquals($expected_status, $validation_status['status'], "Value in list validation was expected to fail when provided a cell with a value not in the provided list.");
     $this->assertStringEndsWith(': 2', $validation_status['details'], "Value in list validation details did not contain the index of the cell with an invalid value.");
 
     // Case #3: Check for a valid value in multiple columns
     $expected_status = 'pass';
-    $context['indices'] = [ 0, 2, 4 ];
-    $context['valid_values'] = [ 'My trait', 'My method', 'My unit' ];
-    $instance->context = $context;
+    $indices = [ 0, 2, 4 ];
+    $valid_values = [ 'My trait', 'My method', 'My unit' ];
+    $instance->setIndices($indices);
+    $instance->setValidValues($valid_values);
     $validation_status = $instance->validateRow($file_row);
     $this->assertEquals($expected_status, $validation_status['status'], "Value in list validation was expected to pass when provided a cell with a valid value in the list.");
     $this->assertStringContainsString('Value at index 0, 2, 4 was one of:', $validation_status['details'], "Value in list validation details did not report that indices 0, 2, 4 all contained a valid value.");
 
     // Case #4: Check for 1 column with a valid value, 1 with invalid value
     $expected_status = 'fail';
-    $context['indices'] = [ 0, 3 ];
-    $context['valid_values'] = [ 'My trait description', 'My method description' ];
-    $instance->context = $context;
+    $indices = [ 0, 3 ];
+    $valid_values = [ 'My trait description', 'My method description' ];
+    $instance->setIndices($indices);
+    $instance->setValidValues($valid_values);
     $validation_status = $instance->validateRow($file_row);
     $this->assertEquals($expected_status, $validation_status['status'], "Value in list validation was expected to fail when provided 2 cells; 1 with with valid input and 1 invalid.");
     $this->assertStringEndsWith(': 0', $validation_status['details'], "Value in list validation details did not contain the index of the cell with an invalid value.");
 
     // Case #5: Check for 1 column that has the wrong case compared to the valid values
     $expected_status = 'fail';
-    $context['indices'] = [ 1 ];
-    $context['valid_values'] = [ 'My Trait Description' ];
-    $instance->context = $context;
+    $indices = [ 1 ];
+    $valid_values = [ 'My Trait Description' ];
+    $instance->setIndices($indices);
+    $instance->setValidValues($valid_values);
     $validation_status = $instance->validateRow($file_row);
     $this->assertEquals($expected_status, $validation_status['status'], "Value in list validation was expected to fail when provided 1 cell with the same text but wrong case as the one valid value provided.");
     $this->assertStringEndsWith('with >=1 case insensitive match', $validation_status['title'], "Value in list validation title did not specify that a case insensitive match was found.");

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorValueInListTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorValueInListTest.php
@@ -4,15 +4,14 @@ namespace Drupal\Tests\trpcultivate_phenotypes\Kernel\Validators;
 use Drupal\tripal_chado\Database\ChadoConnection;
 use Drupal\Tests\tripal_chado\Kernel\ChadoTestKernelBase;
 
- /**
-  * Tests Tripal Cultivate Phenotypes Validator Plugins that apply to a single row
-  * of the input file - the "FILE ROW" scope
-  *
-  * @group trpcultivate_phenotypes
-  * @group validators
-  * @group file_row_scope
-  */
-class ValidatorFileRowScopeTest extends ChadoTestKernelBase {
+/**
+ * Tests the Value In List validator
+ *
+ * @group trpcultivate_phenotypes
+ * @group validators
+ * @group row_validators
+ */
+class ValidatorValueInListTest extends ChadoTestKernelBase {
   /**
    * Plugin Manager service.
    */
@@ -133,49 +132,5 @@ class ValidatorFileRowScopeTest extends ChadoTestKernelBase {
     $validation_status = $instance->validateRow($file_row);
     $this->assertEquals($expected_status, $validation_status['status'], "Value in list validation was expected to fail when provided 1 cell with the same text but wrong case as the one valid value provided.");
     $this->assertStringEndsWith('with >=1 case insensitive match', $validation_status['title'], "Value in list validation title did not specify that a case insensitive match was found.");
-  }
-
-  /**
-   * Test Empty Cell Plugin Validator.
-   */
-  public function testValidatorEmptyCell() {
-
-    // Create a plugin instance for this validator
-    $validator_id = 'empty_cell';
-    $instance = $this->plugin_manager->createInstance($validator_id);
-
-    // Simulates a row within the Trait Importer
-    // Includes 3 types of empty cells
-    $file_row = [
-      'My trait',
-      '',  // No whitespace
-      'My method',
-      ' ', // Single whitespace
-      'My unit',
-      '  ' // Double whitespace
-    ];
-
-    // Case #1: Provide a list of indices for cells that are not empty
-    $expected_status = 'pass';
-    $indices = [ 0, 2, 4 ];
-    $instance->setIndices($indices);
-    $validation_status = $instance->validateRow($file_row);
-    $this->assertEquals($expected_status, $validation_status['status'], "Empty cell validation was expected to pass when provided only non-empty cells to check.");
-
-    // Case #2: Provide a list of indices that includes only empty cells
-    $expected_status = 'fail';
-    $indices = [ 1, 3, 5 ];
-    $instance->setIndices($indices);
-    $validation_status = $instance->validateRow($file_row);
-    $this->assertEquals($expected_status, $validation_status['status'], "Empty cell validation was expected to fail when provided 3 empty cells to check.");
-    $this->assertStringEndsWith(': 1, 3, 5', $validation_status['details'], "Empty cell validation details did not contain the index of the empty cell.");
-
-    // Case #3: Provide a list of indices for the entire row (mixture of 3 empty and 3 non-empty cells)
-    $expected_status = 'fail';
-    $indices = [ 0, 1, 2, 3, 4, 5 ];
-    $instance->setIndices($indices);
-    $validation_status = $instance->validateRow($file_row);
-    $this->assertEquals($expected_status, $validation_status['status'], "Empty cell validation was expected to fail when provided a mixture of 3 empty and 3 non-empty cells to check.");
-    $this->assertStringEndsWith(': 1, 3, 5', $validation_status['details'], "Empty cell validation details did not contain the indices of the empty cells.");
   }
 }

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorValueInListTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorValueInListTest.php
@@ -84,53 +84,128 @@ class ValidatorValueInListTest extends ChadoTestKernelBase {
     ];
 
     // Case #1: Check for a valid value in a single column
-    $expected_status = 'pass';
+    $expected_valid = TRUE;
+    $expected_case = 'Values in required column(s) are valid';
     $indices = [ 5 ];
     $valid_values = [ 'Qualitative', 'Quantitative' ];
+    $expected_failedItems = [];
     $instance->setIndices($indices);
     $instance->setValidValues($valid_values);
     $validation_status = $instance->validateRow($file_row);
-    $this->assertEquals($expected_status, $validation_status['status'], "Value in list validation was expected to pass when provided a cell with a valid value in the list.");
-    $this->assertStringContainsString('Value at index 5 was one of:', $validation_status['details'], "Value in list validation details did not report that index 5 contained a valid value.");
+    $this->assertEquals(
+      $expected_valid,
+      $validation_status['valid'],
+      "Value in list validation was expected to pass when provided a cell with a valid value in the list."
+    );
+    $this->assertStringContainsString(
+      $expected_case,
+      $validation_status['case'],
+      "Value in list validation case message did not report that values in the specified columns were valid."
+    );
+    $this->assertEquals(
+      $expected_failedItems,
+      $validation_status['failedItems'],
+      "Value in list validation failed items was expected to be empty since validation passed."
+    );
 
     // Case #2: Check for an invalid value in a single column
-    $expected_status = 'fail';
+    $expected_valid = FALSE;
+    $expected_case = 'Invalid value(s) in required column(s)';
     $indices = [ 2 ];
     $valid_values = [ 'Qualitative', 'Quantitative' ];
+    $expected_failedItems = [ 2 => 'My method' ];
     $instance->setIndices($indices);
     $instance->setValidValues($valid_values);
     $validation_status = $instance->validateRow($file_row);
-    $this->assertEquals($expected_status, $validation_status['status'], "Value in list validation was expected to fail when provided a cell with a value not in the provided list.");
-    $this->assertStringEndsWith(': 2', $validation_status['details'], "Value in list validation details did not contain the index of the cell with an invalid value.");
+    $this->assertEquals(
+      $expected_valid,
+      $validation_status['valid'],
+      "Value in list validation was expected to fail when provided a cell with a value not in the provided list."
+    );
+    $this->assertStringEndsWith(
+      $expected_case,
+      $validation_status['case'],
+      "Value in list validation case message did not report that the value in the specified column was invalid"
+    );
+    $this->assertEquals(
+      $expected_failedItems,
+      $validation_status['failedItems'],
+      "Value in list validation failed items was expected to contain one item since validation failed."
+    );
 
     // Case #3: Check for a valid value in multiple columns
-    $expected_status = 'pass';
+    $expected_valid = TRUE;
+    $expected_case = 'Values in required column(s) are valid';
     $indices = [ 0, 2, 4 ];
     $valid_values = [ 'My trait', 'My method', 'My unit' ];
+    $expected_failedItems = [];
     $instance->setIndices($indices);
     $instance->setValidValues($valid_values);
     $validation_status = $instance->validateRow($file_row);
-    $this->assertEquals($expected_status, $validation_status['status'], "Value in list validation was expected to pass when provided a cell with a valid value in the list.");
-    $this->assertStringContainsString('Value at index 0, 2, 4 was one of:', $validation_status['details'], "Value in list validation details did not report that indices 0, 2, 4 all contained a valid value.");
+    $this->assertEquals(
+      $expected_valid,
+      $validation_status['valid'],
+      "Value in list validation was expected to pass when provided multiple cells all containing valid values.");
+    $this->assertStringContainsString(
+      $expected_case,
+      $validation_status['case'],
+      "Value in list validation case message did not report that all indices contained a valid value."
+    );
+    $this->assertEquals(
+      $expected_failedItems,
+      $validation_status['failedItems'],
+      "Value in list validation failed items was expected to be empty since validation passed."
+    );
 
     // Case #4: Check for 1 column with a valid value, 1 with invalid value
-    $expected_status = 'fail';
+    $expected_valid = FALSE;
+    $expected_case = 'Invalid value(s) in required column(s)';
     $indices = [ 0, 3 ];
     $valid_values = [ 'My trait description', 'My method description' ];
+    $expected_failedItems = [ 0 => 'My trait' ];
     $instance->setIndices($indices);
     $instance->setValidValues($valid_values);
     $validation_status = $instance->validateRow($file_row);
-    $this->assertEquals($expected_status, $validation_status['status'], "Value in list validation was expected to fail when provided 2 cells; 1 with with valid input and 1 invalid.");
-    $this->assertStringEndsWith(': 0', $validation_status['details'], "Value in list validation details did not contain the index of the cell with an invalid value.");
+    $this->assertEquals(
+      $expected_valid,
+      $validation_status['valid'],
+      "Value in list validation was expected to fail when provided 2 cells; 1 with with valid input and 1 invalid."
+    );
+    $this->assertStringEndsWith(
+      $expected_case,
+      $validation_status['case'],
+      "Value in list validation case message did not report that there was a cell with an invalid value."
+    );
+    $this->assertEquals(
+      $expected_failedItems,
+      $validation_status['failedItems'],
+      "Value in list validation failed items was expected to contain one item since validation failed."
+    );
+
 
     // Case #5: Check for 1 column that has the wrong case compared to the valid values
-    $expected_status = 'fail';
+    $expected_valid = FALSE;
+    $expected_case = 'Invalid value(s) in required column(s) with >=1 case insensitive match';
     $indices = [ 1 ];
     $valid_values = [ 'My Trait Description' ];
     $instance->setIndices($indices);
     $instance->setValidValues($valid_values);
+    $expected_failedItems = [ 1 => 'My trait description' ];
     $validation_status = $instance->validateRow($file_row);
-    $this->assertEquals($expected_status, $validation_status['status'], "Value in list validation was expected to fail when provided 1 cell with the same text but wrong case as the one valid value provided.");
-    $this->assertStringEndsWith('with >=1 case insensitive match', $validation_status['title'], "Value in list validation title did not specify that a case insensitive match was found.");
+    $this->assertEquals(
+      $expected_valid,
+      $validation_status['valid'],
+      "Value in list validation was expected to fail when provided 1 cell with the same text but wrong case as the one valid value provided."
+    );
+    $this->assertStringEndsWith(
+      $expected_case,
+      $validation_status['case'],
+      "Value in list validation case message did not specify that a case insensitive match was found."
+    );
+    $this->assertEquals(
+      $expected_failedItems,
+      $validation_status['failedItems'],
+      "Value in list validation failed items was expected to contain one item since validation failed."
+    );
   }
 }

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorValueInListTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorValueInListTest.php
@@ -92,7 +92,7 @@ class ValidatorValueInListTest extends ChadoTestKernelBase {
     $instance->setIndices($indices);
     $instance->setValidValues($valid_values);
     $validation_status = $instance->validateRow($file_row);
-    $this->assertEquals(
+    $this->assertSame(
       $expected_valid,
       $validation_status['valid'],
       "Value in list validation was expected to pass when provided a cell with a valid value in the list."
@@ -102,7 +102,7 @@ class ValidatorValueInListTest extends ChadoTestKernelBase {
       $validation_status['case'],
       "Value in list validation case message did not report that values in the specified columns were valid."
     );
-    $this->assertEquals(
+    $this->assertSame(
       $expected_failedItems,
       $validation_status['failedItems'],
       "Value in list validation failed items was expected to be empty since validation passed."
@@ -117,7 +117,7 @@ class ValidatorValueInListTest extends ChadoTestKernelBase {
     $instance->setIndices($indices);
     $instance->setValidValues($valid_values);
     $validation_status = $instance->validateRow($file_row);
-    $this->assertEquals(
+    $this->assertSame(
       $expected_valid,
       $validation_status['valid'],
       "Value in list validation was expected to fail when provided a cell with a value not in the provided list."
@@ -127,7 +127,7 @@ class ValidatorValueInListTest extends ChadoTestKernelBase {
       $validation_status['case'],
       "Value in list validation case message did not report that the value in the specified column was invalid"
     );
-    $this->assertEquals(
+    $this->assertSame(
       $expected_failedItems,
       $validation_status['failedItems'],
       "Value in list validation failed items was expected to contain one item since validation failed."
@@ -142,7 +142,7 @@ class ValidatorValueInListTest extends ChadoTestKernelBase {
     $instance->setIndices($indices);
     $instance->setValidValues($valid_values);
     $validation_status = $instance->validateRow($file_row);
-    $this->assertEquals(
+    $this->assertSame(
       $expected_valid,
       $validation_status['valid'],
       "Value in list validation was expected to pass when provided multiple cells all containing valid values.");
@@ -151,7 +151,7 @@ class ValidatorValueInListTest extends ChadoTestKernelBase {
       $validation_status['case'],
       "Value in list validation case message did not report that all indices contained a valid value."
     );
-    $this->assertEquals(
+    $this->assertSame(
       $expected_failedItems,
       $validation_status['failedItems'],
       "Value in list validation failed items was expected to be empty since validation passed."
@@ -166,7 +166,7 @@ class ValidatorValueInListTest extends ChadoTestKernelBase {
     $instance->setIndices($indices);
     $instance->setValidValues($valid_values);
     $validation_status = $instance->validateRow($file_row);
-    $this->assertEquals(
+    $this->assertSame(
       $expected_valid,
       $validation_status['valid'],
       "Value in list validation was expected to fail when provided 2 cells; 1 with with valid input and 1 invalid."
@@ -176,7 +176,7 @@ class ValidatorValueInListTest extends ChadoTestKernelBase {
       $validation_status['case'],
       "Value in list validation case message did not report that there was a cell with an invalid value."
     );
-    $this->assertEquals(
+    $this->assertSame(
       $expected_failedItems,
       $validation_status['failedItems'],
       "Value in list validation failed items was expected to contain one item since validation failed."
@@ -192,7 +192,7 @@ class ValidatorValueInListTest extends ChadoTestKernelBase {
     $instance->setValidValues($valid_values);
     $expected_failedItems = [ 1 => 'My trait description' ];
     $validation_status = $instance->validateRow($file_row);
-    $this->assertEquals(
+    $this->assertSame(
       $expected_valid,
       $validation_status['valid'],
       "Value in list validation was expected to fail when provided 1 cell with the same text but wrong case as the one valid value provided."
@@ -202,7 +202,7 @@ class ValidatorValueInListTest extends ChadoTestKernelBase {
       $validation_status['case'],
       "Value in list validation case message did not specify that a case insensitive match was found."
     );
-    $this->assertEquals(
+    $this->assertSame(
       $expected_failedItems,
       $validation_status['failedItems'],
       "Value in list validation failed items was expected to contain one item since validation failed."


### PR DESCRIPTION
**Issue #85**

## Dependencies
#105 - complete!

## Motivation
The 3 validators I have been primarily working on - EmptyCell, ValueInList, and Duplicate Traits - needed to be updated to accept configuration using setters and to return the new return values. This involved updating the tests and configuring the validators in the importer formValidate().
 
## What does this PR do?

1. Updates each validator to use their respective traits to set and get configuration values

   **EmptyCell**: 
   - [x] Use getIndices() in validateRow()
   - [x] Use setIndices() in configureValidators()

   **ValueInList**:
   - [x] Use getIndices() in validateRow()
   - [x] Use setIndices() in configureValidators()
   - [x] Use getValidValues() in validateRow()
   - [x] Use setValidValues() in configureValidators()

   **DuplicateTraits**:
   - [x] Use getConfiguredGenus() in validateRow()
   - [x] Use setConfiguredGenus() in configureValidators()
   - [x] Use getIndices() in validateRow()
   - [x] Use setIndices() in configureValidators()

2. Updates the validators to indicate their inputType and removes their scope in the annotation block.
   - [x] EmptyCell
   - [x] ValueInList
   - [x] DuplicateTraits
   - [x] Update ValidatorFileRowScopeTest and ValidatorTraitImporterTest to remove mention of scope

3. Updates the validators to return the new style of return information:
   > 'case': a developer focused string describing the case checked
   > 'valid': either TRUE or FALSE depending on if the data is valid or not
   > 'failedItems': an array of "items" to be used in the message to the user. This is empty if the data was valid

   - [x] EmptyCell
   - [x] ValueInList
   - [x] DuplicateTraits

4. Updates were made to the formValidate() method in the Traits Importer class:
   - [x] Removed all reference to the old return style specifically for data-row validators
   - [x] Removed the declaration of the $validation array and its use- validation results are no longer stored as they happen
   - [x] Instead, validation results are now being stored in the $failures array only if validation fails. The $failures[$validation_name] array only gets declared if validation occurs at all for that validator instance, which will be used later to determine which validation statuses need to be 'pass' vs 'todo'.
   - [x] Added a new method processValidationMessages() to handle the $failures array and to define the default messages which will later be passed to the user through the UI

## Testing

### Automated Testing
**Some tests were re-organized as follows:**
- [x] `ValidatorFileRowScopeTest.php` was removed
   - [x] `ValidatorFileRowScopeTest::testValidatorValueInList()` => `ValidatorValueInListTest::testValidatorValueInList()`
   - [x] `ValidatorFileRowScopeTest::testValidatorEmptyCell()` => `ValidatorEmptyCellTest::testValidatorEmptyCell()`
- [x] `ValidatorTraitImporterTest` was renamed and all of its methods moved to `ValidatorDuplicateTraitsTest`

**NEW Test added**
- [x] `testIndexKeyExceptions()` was added to `ValidatorDuplicateTraitsTest`
   - checks for each of the index keys that were configured with setIndices() using data provider `provideWrongIndexKeys()`
      - [x] Trait Name
      - [x] Method Short Name
      - [x] Unit

**The following tests were updated by adding additional asserts to check for all of the expected values in the return array**

- [x] ValidatorValueInListTest::testValidatorValueInList()
- [x] ValidatorEmptyCellTest::testValidatorEmptyCell()
- [x] ValidatorDuplicateTraitsTest::testValidatorDuplicateTraitsFile()
- [x] ValidatorDuplicateTraitsTest::testValidatorDuplicateTraitsDatabase()

**Miscellaneous updates**
- [x] TraitImporterFormValidateTest::testTraitFormValidation() has a new assert for ensure the 'details' value in the data provider is not an empty string
   - [x] also added documentation to both the data provider and test method
- [x] ValidatorBaseTest was modified to use the base fake validator instead of being dependent on an instance of the ValueInList validator
