### PR TITLE
g5.105 Implement TripalLogger to allow validators/traits to log their own messages

### DIFF
--- a/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
+++ b/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
@@ -223,6 +223,9 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
       'Unit' => $header_index['Unit']
     ];
     $instance->context = $context;
+    // Set the logger since this validator uses a setter (setConfiguredGenus)
+    // which may log messages
+    $instance->setLogger($this->logger);
     $validators['data-row']['duplicate_traits'] = $instance;
 
     //$this->validatorObjects = $validators;

--- a/trpcultivate_phenotypes/src/TripalCultivateValidator/TripalCultivatePhenotypesValidatorBase.php
+++ b/trpcultivate_phenotypes/src/TripalCultivateValidator/TripalCultivatePhenotypesValidatorBase.php
@@ -3,6 +3,7 @@
 namespace Drupal\trpcultivate_phenotypes\TripalCultivateValidator;
 
 use Drupal\Component\Plugin\PluginBase;
+use Drupal\tripal\Services\TripalLogger;
 
 abstract class TripalCultivatePhenotypesValidatorBase extends PluginBase implements TripalCultivatePhenotypesValidatorInterface {
 
@@ -265,7 +266,7 @@ abstract class TripalCultivatePhenotypesValidatorBase extends PluginBase impleme
    *   on a delimiter value.
    */
   public static function splitRowIntoColumns(string $row, string $mime_type) {
-    
+
     $mime_to_delimiter_mapping = self::$mime_to_delimiter_mapping;
 
     // Ensure that the mime type is in our delimiter mapping...
@@ -366,5 +367,45 @@ abstract class TripalCultivatePhenotypesValidatorBase extends PluginBase impleme
     else {
       throw new \Exception('Cannot retrieve file delimiters for the mime-type provided: ' . $mime_type);
     }
+  }
+
+  /**
+   * The TripalLogger service used to report status and errors to both site users
+   * and administrators through the server log.
+   *
+   * @var TripalLogger
+   */
+  public TripalLogger $logger;
+
+  /**
+   * Sets the TripalLogger instance for the importer using this validator.
+   *
+   * @param TripalLogger $logger
+   *   The TripalLogger instance. In the case of validation done on the form
+   *   the job will not be set but in the case of any validation done in the
+   *   import run job, the job will be set.
+   */
+  public function setLogger(TripalLogger $logger) {
+    $this->logger = $logger;
+  }
+
+  /**
+   * Provides a configured TripalLogger instance for reporting things to
+   * site maintainers.
+   *
+   * @return TripalLogger
+   *   An instance of the Tripal logger.
+   *
+   * @throws \Exception
+   *   If the $logger property has not been set by the setLogger() method.
+   */
+  public function getLogger() {
+    if(!empty($this->logger)) {
+      return $this->logger;
+    }
+    else {
+      throw new \Exception('Cannot retrieve the Tripal Logger property as one has not been set for this validator using the setLogger() method.');
+    }
+
   }
 }

--- a/trpcultivate_phenotypes/src/TripalCultivateValidator/TripalCultivatePhenotypesValidatorBase.php
+++ b/trpcultivate_phenotypes/src/TripalCultivateValidator/TripalCultivatePhenotypesValidatorBase.php
@@ -370,7 +370,7 @@ abstract class TripalCultivatePhenotypesValidatorBase extends PluginBase impleme
   }
 
   /**
-   * The TripalLogger service used to report status and errors to both site users
+   * The TripalLogger service is used to report status and errors to both site users
    * and administrators through the server log.
    *
    * @var TripalLogger

--- a/trpcultivate_phenotypes/src/TripalCultivateValidator/ValidatorTraits/FileTypes.php
+++ b/trpcultivate_phenotypes/src/TripalCultivateValidator/ValidatorTraits/FileTypes.php
@@ -47,15 +47,17 @@ trait FileTypes {
       throw new \Exception("The setFileMimeType() setter requires a string of the input file's mime-type and must not be empty.");
     }
 
-    /** @TODO: Log the below message instead of throwing an exception
-     *         This check should occur in the DataFile validator
+    // Check if mime-type is in our mapping array
     if (!isset(self::$mime_to_delimiter_mapping[ $mime_type ])) {
-      throw new \Exception('The FileTypes Trait requires a supported mime-type but ' . $mime_type . ' is unsupported.');
+      // Since this is checking a user-provided value, the error is going to be
+      // logged and then checked by a validator so that the error can be passed
+      // to the user in a friendly way.
+      $this->logger->error("The setFileMimeType() setter requires a supported mime-type but '" . $mime_type . "' is unsupported.");
     }
-    */
-
-    // Set the mime-type
-    $this->context['file_mime_type'] = $mime_type;
+    else {
+      // Set the mime-type
+      $this->context['file_mime_type'] = $mime_type;
+    }
   }
 
   /**
@@ -148,7 +150,7 @@ trait FileTypes {
   /**
    * Gets the file mime-type of the input file.
    *
-   * @return array
+   * @return string
    *   The file mime-type set by the setFileMimeType() setter method.
    *
    * @throws \Exception

--- a/trpcultivate_phenotypes/src/TripalCultivateValidator/ValidatorTraits/FileTypes.php
+++ b/trpcultivate_phenotypes/src/TripalCultivateValidator/ValidatorTraits/FileTypes.php
@@ -52,7 +52,7 @@ trait FileTypes {
       // Since this is checking a user-provided value, the error is going to be
       // logged and then checked by a validator so that the error can be passed
       // to the user in a friendly way.
-      $this->logger->error("The setFileMimeType() setter requires a supported mime-type but '" . $mime_type . "' is unsupported.");
+      $this->logger->error("The setFileMimeType() setter requires a supported mime-type but '$mime_type' is unsupported.");
     }
     else {
       // Set the mime-type

--- a/trpcultivate_phenotypes/src/TripalCultivateValidator/ValidatorTraits/GenusConfigured.php
+++ b/trpcultivate_phenotypes/src/TripalCultivateValidator/ValidatorTraits/GenusConfigured.php
@@ -53,30 +53,35 @@ trait GenusConfigured {
     }
 
     // Check that the genus is present in at least one chado organism.
+    $genus_exists = FALSE;
     $query = $this->chado_connection->select('1:organism', 'o')
       ->fields('o', ['organism_id'])
       ->condition('o.genus', $genus);
     $exists = $query->execute()->fetchObject();
     if (!is_object($exists)) {
       throw new \Exception("The genus '$genus' does not exist in chado and GenusConfigured Trait requires it both exist and be configured to work with phenotypes. The validators using this trait should not be called if previous validators checking for a configured genus fail.");
+    } else {
+      $genus_exists = TRUE;
     }
 
     // Check that the genus is configured + get that configuration while we are at it.
     $configuration_values = $this->service_PhenoGenusOntology->getGenusOntologyConfigValues($genus);
     if (!is_array($configuration_values) OR empty($configuration_values)) {
-      
-      // @TODO: This is a user provided value, should be logged message
-      //        and checked by a validator.
-      
-      throw new \Exception("The genus '$genus' is not configured and GenusConfigured Trait requires it both exist and be configured to work with phenotypes. The validators using this trait should not be called if previous validators checking for a configured genus fail.");
+      // Since this is a user-provided value, the error is going to be logged
+      // instead of thrown as an exception and then checked by a validator so
+      // that the error can be passed to the user in a friendly way.
+      $this->logger->error("The genus '$genus' is not configured and GenusConfigured Trait requires it both exist and be configured to work with phenotypes. The validators using this trait should not be called if previous validators checking for a configured genus fail.");
     }
+    // Only set the context array if we know that both:
+    // - configuration_values exists
+    // - genus exists
+    else if ($genus_exists) {
+      // Set configured values
+      $this->context['genus']['ontology_terms'] = $configuration_values;
 
-    // Now we finally get to set things up for the validator!
-    // Set configured values
-    $this->context['genus']['ontology_terms'] = $configuration_values;
-
-    // Set the configured genus
-    $this->context['genus']['name'] = $genus;
+      // Set the configured genus
+      $this->context['genus']['name'] = $genus;
+    }
   }
 
   /**

--- a/trpcultivate_phenotypes/src/TripalCultivateValidator/ValidatorTraits/GenusConfigured.php
+++ b/trpcultivate_phenotypes/src/TripalCultivateValidator/ValidatorTraits/GenusConfigured.php
@@ -59,7 +59,10 @@ trait GenusConfigured {
       ->condition('o.genus', $genus);
     $exists = $query->execute()->fetchObject();
     if (!is_object($exists)) {
-      throw new \Exception("The genus '$genus' does not exist in chado and GenusConfigured Trait requires it both exist and be configured to work with phenotypes. The validators using this trait should not be called if previous validators checking for a configured genus fail.");
+      // Since this is a user-provided value, the error is going to be logged
+      // instead of thrown as an exception and then checked by a validator so
+      // that the error can be passed to the user in a friendly way.
+      $this->logger->error("The genus '$genus' does not exist in chado and GenusConfigured Trait requires it both exist and be configured to work with phenotypes. The validators using this trait should not be called if previous validators checking for a configured genus fail.");
     } else {
       $genus_exists = TRUE;
     }

--- a/trpcultivate_phenotypes/src/TripalCultivateValidator/ValidatorTraits/Project.php
+++ b/trpcultivate_phenotypes/src/TripalCultivateValidator/ValidatorTraits/Project.php
@@ -7,13 +7,13 @@ use Drupal\tripal_chado\Controller\ChadoProjectAutocompleteController;
 /**
  * Provides setters focused for setting a project used by the importer
  * to package datasets, and getter to retrieve the set value.
- */ 
+ */
 trait Project {
   /**
-   * The key used by the setter method to create a project element 
-   * in the context array, as well as the key used by the getter method 
+   * The key used by the setter method to create a project element
+   * in the context array, as well as the key used by the getter method
    * to reference and retrieve the project element value.
-   * 
+   *
    * @var string
    */
    private string $context_key = 'project';
@@ -27,30 +27,29 @@ trait Project {
    * @param string|int $project
    *   A string value is a project name (project.name), whereas an integer value
    *   is a project id number (project.project_id).
-   * 
+   *
    * @return void
-   * 
+   *
    * @throws \Exception
    *  - Project name is an empty string value if project name is provided (string data type parameter).
    *  - Project id is 0 if project id is provided (integer data type parameter).
    */
   public function setProject(string|int $project) {
-    
+
     // Determine if the value provided to the parameter is a project name (string)
     // or a project id number (integer).
     if (is_numeric($project)) {
       // Project id number.
       if ($project <= 0) {
-
-        // @TODO: This is a user provided value, should be logged message
-        //        and checked by a validator.
-
-        throw new \Exception('The Project Trait requires project id number to be a number greater than 0.');  
+      // Since this is a user-provided value, the error is going to be logged
+      // and then checked by a validator so that the error can be passed to the
+      // user in a friendly way.
+        $this->logger->error('The Project Trait requires project id number to be a number greater than 0.');
       }
 
       // Look up the project id to retrieve the project name.
       $project_rec = ChadoProjectAutocompleteController::getProjectName($project);
-      
+
       $set_project = [
         'project_id' => $project,     // Project Id
         'name' => $project_rec,       // Name
@@ -59,13 +58,12 @@ trait Project {
     else {
       // Project name.
       if (trim($project) === '') {
-
-        // @TODO: This is a user provided value, should be logged message
-        //        and checked by a validator.
-
-        throw new \Exception('The Project Trait requires project name to be a non-empty string value.');  
+        // Since this is a user-provided value, the error is going to be logged
+        // and then checked by a validator so that the error can be passed to the
+        // user in a friendly way.
+        $this->logger->error('The Project Trait requires project name to be a non-empty string value.');
       }
-      
+
       // Look up the project name to retrieve the project id number.
       $project_rec = ChadoProjectAutocompleteController::getProjectId($project);
 
@@ -74,16 +72,19 @@ trait Project {
         'name' => $project,           // Name
       ];
     }
-    
+
+    // Check if $set_project is set before setting the context array, and log an
+    // error if the project can't be found in the database.
     if ($set_project['project_id'] <= 0 || empty($set_project['name'])) {
-
-      // @TODO: This is a user provided value, should be logged message
-      //        and checked by a validator.
-
-      throw new \Exception('The Project Trait requires a project that exists in the database.');
+      // Since this is a user-provided value, the error is going to be logged
+      // and then checked by a validator so that the error can be passed to the
+      // user in a friendly way.
+      $this->logger->error('The Project Trait requires a project that exists in the database.');
+    }
+    else {
+      $this->context[$this->context_key] = $set_project;
     }
 
-    $this->context[ $this->context_key ] = $set_project; 
   }
 
   /**
@@ -91,15 +92,15 @@ trait Project {
    * by a validator.
    *
    * @return array
-   *   The project set by the setter method. The project includes the project id number 
+   *   The project set by the setter method. The project includes the project id number
    *   and project name keyed by project_id and name, respectively.
-   * 
+   *
    * @throws \Exception
-   *  - If the 'project' key does not exist in the context array 
+   *  - If the 'project' key does not exist in the context array
    *    (ie. the project element has NOT been set).
    */
   public function getProject() {
-    
+
     if (array_key_exists($this->context_key, $this->context)) {
       return $this->context[ $this->context_key ];
     }

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/Traits/ValidatorTraitFileTypesTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/Traits/ValidatorTraitFileTypesTest.php
@@ -324,13 +324,20 @@ class ValidatorTraitFileTypesTest extends ChadoTestKernelBase {
 
     // For each senario we expect the following:
     // -- scenario label to provide helpful feedback if a test fails.
-    // -- a string that is the mime-type to pass to setFileMimeType() and that
-    //    we also expect to have returned by getFileMimeType()
-    // -- an array indicating whether to expect an exception with the keys
-    //    being the method and the value being TRUE if we expect an exception
-    //    when calling it for this senario.
-    // -- an array of expected exception messages with the key being the method
-    //    and the value being the message we expect (NULL if no exception expected)
+    // -- a string that is the mime-type to pass to setFileMimeType()
+    // -- an array indicating the expectations when testing this scenario,
+    //      containing the following keys:
+    //    - 'returned_values': the expected return value from getFileMimeType()
+    //      for this scenario
+    //    - 'exception_thrown': whether to expect an exception with the keys
+    //      being the method and the value being TRUE if we expect an exception
+    //      when calling it for this senario.
+    //    - 'exception_message': an array of expected exception messages with
+    //      the keys being the method and the value being the message we expect
+    //      (empty string if no exception expected)
+    //    - 'logged_message': an array of expected logged messages with
+    //      the keys being the method and the value being the message we expect
+    //      (empty string if no logged message expected)
 
     // NOTE: getters have only one exception message, so assign it to a variable
     // to avoid repetition
@@ -620,12 +627,19 @@ class ValidatorTraitFileTypesTest extends ChadoTestKernelBase {
    * @param string $mime_type
    *   A string that is the mime-type to pass to setFileMimeType() and that we
    *   also expect to have returned by getFileMimeType()
-   * @param array $expected_exception_thrown
-   *   An array of expected exception outcomes (TRUE if one is expected, FALSE if
-   *   not expected) where the keys are the names of the methods.
-   * @param array $expected_exception_message
-   *   An array of expected exception messages with the key being the method name
-   *   and the value being the expected message (empty string if none expected).
+   * @param array $expectations
+   *   An array with the following 4 keys:
+   *   - 'returned_values': the expected return value from getFileMimeType()
+   *      for this scenario
+   *   - 'exception_thrown': whether to expect an exception with the keys
+   *      being the method and the value being TRUE if we expect an exception
+   *      when calling it for this senario.
+   *    - 'exception_message': an array of expected exception messages with
+   *      the keys being the method and the value being the message we expect
+   *      (empty string if no exception expected)
+   *    - 'logged_message': an array of expected logged messages with
+   *      the keys being the method and the value being the message we expect
+   *      (empty string if no logged message expected)
    *
    * @dataProvider provideMimeTypeForSetter
    *

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/Traits/ValidatorTraitFileTypesTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/Traits/ValidatorTraitFileTypesTest.php
@@ -60,6 +60,23 @@ class ValidatorTraitFileTypesTest extends ChadoTestKernelBase {
       $plugin_definition
     );
 
+    // We need to mock the logger to test the progress reporting.
+    $mock_logger = $this->getMockBuilder(\Drupal\tripal\Services\TripalLogger::class)
+      ->onlyMethods(['notice', 'error'])
+      ->getMock();
+    $mock_logger->method('notice')
+    ->willReturnCallback(function ($message, $context, $options) {
+      print str_replace(array_keys($context), $context, $message);
+      return NULL;
+    });
+    $mock_logger->method('error')
+    ->willReturnCallback(function ($message, $context, $options) {
+      print str_replace(array_keys($context), $context, $message);
+      return NULL;
+    });
+    // Finally, use setLogger() for this validator instance
+    $instance->setLogger($mock_logger);
+
     $this->assertIsObject(
       $instance,
       "Unable to create $validator_id validator instance to test the File Types trait."
@@ -323,27 +340,45 @@ class ValidatorTraitFileTypesTest extends ChadoTestKernelBase {
     $scenarios[] = [
       'empty string', // scenario label
       '', // mime-type
-      [ // expected exception thrown
-        'setFileMimeType' => TRUE,
-        'getFileMimeType' => TRUE,
-      ],
-      [ // expected exception message
-        'setFileMimeType' => "The setFileMimeType() setter requires a string of the input file's mime-type and must not be empty.",
-        'getFileMimeType' => $get_type_exception_message,
+      [
+        'returned_values' => [
+          'mime-type' => '',
+        ],
+        'exception_thrown' => [ // expected exception thrown
+          'setFileMimeType' => TRUE,
+          'getFileMimeType' => TRUE,
+        ],
+        'exception_message' => [ // expected exception message
+          'setFileMimeType' => "The setFileMimeType() setter requires a string of the input file's mime-type and must not be empty.",
+          'getFileMimeType' => $get_type_exception_message,
+        ],
+        'logged_message' => [
+          'setFileMimeType' => '',
+          'getFileMimeType' => '',
+        ],
       ]
     ];
 
     // #1: Test with the mime-type for tsv files
     $scenarios[] = [
       'tsv mime-type',
-      'text/tab-delimited-values',
+      'text/tab-separated-values',
       [
-        'setFileMimeType' => FALSE,
-        'getFileMimeType' => FALSE,
-      ],
-      [
-        'setFileMimeType' => '',
-        'getFileMimeType' => '',
+        'returned_values' => [
+          'mime-type' => 'text/tab-separated-values',
+        ],
+        'exception_thrown' => [
+          'setFileMimeType' => FALSE,
+          'getFileMimeType' => FALSE,
+        ],
+        'exception_message' => [
+          'setFileMimeType' => '',
+          'getFileMimeType' => '',
+        ],
+        'logged_message' => [
+          'setFileMimeType' => '',
+          'getFileMimeType' => '',
+        ],
       ]
     ];
 
@@ -352,12 +387,21 @@ class ValidatorTraitFileTypesTest extends ChadoTestKernelBase {
       'csv mime-type',
       'text/csv',
       [
-        'setFileMimeType' => FALSE,
-        'getFileMimeType' => FALSE,
-      ],
-      [
-        'setFileMimeType' => '',
-        'getFileMimeType' => '',
+        'returned_values' => [
+          'mime-type' => 'text/csv',
+        ],
+        'exception_thrown' => [
+          'setFileMimeType' => FALSE,
+          'getFileMimeType' => FALSE,
+        ],
+        'exception_message' => [
+          'setFileMimeType' => '',
+          'getFileMimeType' => '',
+        ],
+        'logged_message' => [
+          'setFileMimeType' => '',
+          'getFileMimeType' => '',
+        ],
       ]
     ];
 
@@ -366,12 +410,21 @@ class ValidatorTraitFileTypesTest extends ChadoTestKernelBase {
       'txt mime-type',
       'text/plain',
       [
-        'setFileMimeType' => FALSE,
-        'getFileMimeType' => FALSE,
-      ],
-      [
-        'setFileMimeType' => '',
-        'getFileMimeType' => '',
+        'returned_values' => [
+          'mime-type' => 'text/plain',
+        ],
+        'exception_thrown' => [
+          'setFileMimeType' => FALSE,
+          'getFileMimeType' => FALSE,
+        ],
+        'exception_message' => [
+          'setFileMimeType' => '',
+          'getFileMimeType' => '',
+        ],
+        'logged_message' => [
+          'setFileMimeType' => '',
+          'getFileMimeType' => '',
+        ],
       ]
     ];
 
@@ -380,12 +433,21 @@ class ValidatorTraitFileTypesTest extends ChadoTestKernelBase {
       'random string',
       'hello world',
       [
-        'setFileMimeType' => FALSE,
-        'getFileMimeType' => FALSE,
-      ],
-      [
-        'setFileMimeType' => '',
-        'getFileMimeType' => '',
+        'returned_values' => [
+          'mime-type' => '',
+        ],
+        'exception_thrown' => [
+          'setFileMimeType' => FALSE,
+          'getFileMimeType' => TRUE,
+        ],
+        'exception_message' => [
+          'setFileMimeType' => '',
+          'getFileMimeType' => 'Cannot retrieve the input file mime-type as it has not been set by setFileMimeType() method.',
+        ],
+        'logged_message' => [
+          'setFileMimeType' => "The setFileMimeType() setter requires a supported mime-type but 'hello world' is unsupported.",
+          'getFileMimeType' => '',
+        ],
       ]
     ];
 
@@ -569,7 +631,7 @@ class ValidatorTraitFileTypesTest extends ChadoTestKernelBase {
    *
    * @return void
    */
-  public function testFileMimeType($scenario, $mime_type, $expected_exception_thrown, $expected_exception_message) {
+  public function testFileMimeType($scenario, $mime_type, $expectations) {
 
     // This exception message is expected when we intially call the getter
     // method for every scenario
@@ -599,21 +661,30 @@ class ValidatorTraitFileTypesTest extends ChadoTestKernelBase {
     // --------------------------------------------------------------------------
     $exception_caught = FALSE;
     $exception_message = '';
+    $printed_output = '';
     try {
+      ob_start();
       $this->instance->setFileMimeType($mime_type);
+      $printed_output = ob_get_contents();
     } catch (\Exception $e) {
       $exception_caught = TRUE;
       $exception_message = $e->getMessage();
     }
+    ob_end_clean();
     $this->assertEquals(
-      $expected_exception_thrown['setFileMimeType'],
+      $expectations['exception_thrown']['setFileMimeType'],
       $exception_caught,
       "Unexpected exception activity occured for scenario: '" . $scenario . "'"
     );
     $this->assertEquals(
-      $expected_exception_message['setFileMimeType'],
+      $expectations['exception_message']['setFileMimeType'],
       $exception_message,
       "The expected and actual exception messages do not match when using FileTypes::setFileMimeType() for scenario: '" . $scenario . "'"
+    );
+    $this->assertEquals(
+      $expectations['logged_message']['setFileMimeType'],
+      $printed_output,
+      "The expected and actual logged messages do not match when using FileTypes::setFileMimeType() for scenario: '" . $scenario . "'"
     );
 
     // scenario: Check getFileMimeType() returns expected mime-type after
@@ -629,18 +700,18 @@ class ValidatorTraitFileTypesTest extends ChadoTestKernelBase {
       $exception_message = $e->getMessage();
     }
     $this->assertEquals(
-      $expected_exception_thrown['getFileMimeType'],
+      $expectations['exception_thrown']['getFileMimeType'],
       $exception_caught,
-      "Unexpected exception activity occured when trying to get file mime-type for scenario: '" . $scenario . "'"
+      "Unexpected exception activity occured when trying to get file mime-type for scenario: '" . $scenario . "'. Exception message: '" . $exception_message . "'."
     );
     $this->assertEquals(
-      $expected_exception_message['getFileMimeType'],
+      $expectations['exception_message']['getFileMimeType'],
       $exception_message,
       "The expected and actual exception messages do not match when calling FileTypes::getFileMimeType() for scenario: '" . $scenario . "'"
     );
     // Finally, check that our retrieved mime-type matches our expected
     $this->assertEquals(
-      $mime_type,
+      $expectations['returned_values']['mime-type'],
       $actual_type,
       "The expected mime-type using FileTypes::getFileMimeType() did not match the actual ones for scenario: '" . $scenario . "'"
     );

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/Traits/ValidatorTraitGenusConfiguredTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/Traits/ValidatorTraitGenusConfiguredTest.php
@@ -158,22 +158,14 @@ class ValidatorTraitGenusConfiguredTest extends ChadoTestKernelBase {
 
     // Check a NOT EXISTENT genus in a well setup validator.
     $genus = uniqid();
-    $expected_message = "genus '$genus' does not exist in chado";
-    $exception_caught = FALSE;
-    $exception_message = 'NONE';
-    try {
-      $this->instance->setConfiguredGenus($genus);
-    } catch (\Exception $e) {
-      $exception_caught = TRUE;
-      $exception_message = $e->getMessage();
-    }
-    $this->assertTrue(
-      $exception_caught,
-      "Calling setConfiguredGenus() with genus that is not in chado should have thrown an exception but didn't."
-    );
+    $printed_output = '';
+    $expected_message = "The genus '$genus' does not exist in chado";
+    ob_start();
+    $this->instance->setConfiguredGenus($genus);
+    $printed_output = ob_get_clean();
     $this->assertStringContainsString(
       $expected_message,
-      $exception_message,
+      $printed_output,
       "The exception thrown does not have the message we expected for a genus that doesn't even exist in chado."
     );
 

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/Traits/ValidatorTraitGenusConfiguredTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/Traits/ValidatorTraitGenusConfiguredTest.php
@@ -166,7 +166,7 @@ class ValidatorTraitGenusConfiguredTest extends ChadoTestKernelBase {
     $this->assertStringContainsString(
       $expected_message,
       $printed_output,
-      "The exception thrown does not have the message we expected for a genus that doesn't even exist in chado."
+      "The logged error message does not have the message we expected for a genus that doesn't even exist in chado."
     );
 
     // Check that a genus has NOT been set by using getConfguredGenus()
@@ -218,7 +218,7 @@ class ValidatorTraitGenusConfiguredTest extends ChadoTestKernelBase {
     $this->assertStringContainsString(
       $expected_message,
       $printed_output,
-      "The exception thrown does not have the message we expected for a genus existing in chado that is not configured."
+      "The logged error message does not have the message we expected for a genus existing in chado that is not configured."
     );
 
     // Check that a genus still has NOT been set by using getConfguredGenus()

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorBaseTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorBaseTest.php
@@ -632,7 +632,6 @@ class ValidatorBaseTest extends ChadoTestKernelBase {
     $my_logger = \Drupal::service('tripal.logger');
 
     $exception_caught = FALSE;
-    $exception_message = 'NONE';
     try {
       $instance->setLogger($my_logger);
     } catch (\Exception $e) {
@@ -647,7 +646,6 @@ class ValidatorBaseTest extends ChadoTestKernelBase {
     // Now make sure we can get the logger that was set
     $grabbed_logger = NULL;
     $exception_caught = FALSE;
-    $exception_message = 'NONE';
     try {
       $grabbed_logger = $instance->getLogger();
     } catch (\Exception $e) {

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorBaseTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorBaseTest.php
@@ -2,6 +2,7 @@
 namespace Drupal\Tests\trpcultivate_phenotypes\Kernel\Validators;
 
 use Drupal\tripal_chado\Database\ChadoConnection;
+use Drupal\tripal\Services\TripalLogger;
 use Drupal\Tests\tripal_chado\Kernel\ChadoTestKernelBase;
 use Drupal\Tests\trpcultivate_phenotypes\Kernel\Validators\FakeValidators\BasicallyBase;
 use Drupal\trpcultivate_phenotypes\TripalCultivateValidator\TripalCultivatePhenotypesValidatorBase;
@@ -337,7 +338,7 @@ class ValidatorBaseTest extends ChadoTestKernelBase {
 
   /**
    * DATA PROVIDER: tests the split row by providing mime type to delimiter options.
-   * 
+   *
    * @return array
    *   Each test scenario is an array with the following values.
    *
@@ -369,10 +370,10 @@ class ValidatorBaseTest extends ChadoTestKernelBase {
 
   /**
    * Data Provider: provide test data (mime types) to file delimiter getter method.
-   * 
+   *
    * @return array
    *   Each test scenario is an array with the following values.
-   * 
+   *
    *   - A string, human-readable short description of the test scenario.
    *   - A string, mime type input.
    *   - Boolean value, indicates if the scenario is expecting an exception thrown (TRUE) or not (FALSE).
@@ -421,7 +422,7 @@ class ValidatorBaseTest extends ChadoTestKernelBase {
 
   /**
    * Test line or row split method.
-   * 
+   *
    * @param $expected_mime_type
    *   Mime type input to the split row method.
    * @param $expected_delimiter
@@ -511,7 +512,7 @@ class ValidatorBaseTest extends ChadoTestKernelBase {
 
   /**
    * Test validator base file delimiter getter method.
-   * 
+   *
    * @param $scenario
    *   Human-readable text description of the test scenario.
    * @param $mime_type_input
@@ -522,15 +523,15 @@ class ValidatorBaseTest extends ChadoTestKernelBase {
    *   The exception message if the test scenario is expected to throw an exception.
    * @param $expected
    *   The returned file delimiter.
-   * 
+   *
    * @dataProvider provideMimeTypesForFileDelimiterGetter
    */
   public function testFileDelimiterGetter($scenario, $mime_type_input, $has_exception, $exception_message, $expected) {
-    
+
     $exception_caught = FALSE;
     $exception_get_message = '';
     $delimiter = FALSE;
-    
+
     try {
       $delimiter = TripalCultivatePhenotypesValidatorBase::getFileDelimiters($mime_type_input);
     }
@@ -538,7 +539,7 @@ class ValidatorBaseTest extends ChadoTestKernelBase {
       $exception_caught = TRUE;
       $exception_get_message = $e->getMessage();
     }
-    
+
     $this->assertEquals($exception_caught, $has_exception, 'An exception was expected by file delimiter getter method for scenario:' . $scenario);
     $this->assertStringContainsString(
       $exception_message,
@@ -585,6 +586,82 @@ class ValidatorBaseTest extends ChadoTestKernelBase {
       $expected_exception_message,
       $exception_message,
       'Expected exception message does not match message when splitRowIntoColumns() could not split line because there are too many supported delimiters.'
+    );
+  }
+
+  /**
+   * Tests the ValidatorBase::setLogger() setter
+   *       and ValidatorBase::getLogger() getter
+   *
+   * @return void
+   */
+  public function testTripalLoggerGetterSetter() {
+    $configuration = [];
+    $validator_id = 'fake_basically_base';
+    $plugin_definition = [
+      'id' => $validator_id,
+      'validator_name' => 'Basically Base Validator',
+      'input_types' => ['header-row', 'data-row'],
+    ];
+    $instance = new BasicallyBase($configuration, $validator_id, $plugin_definition);
+    $this->assertIsObject(
+      $instance,
+      "Unable to create fake_basically_base validator instance to test the base class."
+    );
+
+    // Try to get the logger before it has been set
+    // Exception message should trigger
+    $expected_message = 'Cannot retrieve the Tripal Logger property as one has not been set for this validator using the setLogger() method.';
+    $exception_caught = FALSE;
+    $exception_message = 'NONE';
+    try {
+      $instance->getLogger();
+    } catch (\Exception $e) {
+      $exception_caught = TRUE;
+      $exception_message = $e->getMessage();
+    }
+
+    $this->assertTrue($exception_caught, 'Calling getLogger() before the setLogger() method should have thrown an exception but did not.');
+    $this->assertStringContainsString(
+      $expected_message,
+      $exception_message,
+      "The exception thrown does not have the message we expected when trying to get the Tripal Logger property but it hasn't been set yet."
+    );
+
+    // Create a TripalLogger object and set it using setLogger()
+    $my_logger = \Drupal::service('tripal.logger');
+
+    $exception_caught = FALSE;
+    $exception_message = 'NONE';
+    try {
+      $instance->setLogger($my_logger);
+    } catch (\Exception $e) {
+      $exception_caught = TRUE;
+      $exception_message = $e->getMessage();
+    }
+    $this->assertFalse(
+      $exception_caught,
+      "Calling setLogger() with a valid TripalLogger object should not have thrown an exception but it threw '$exception_message'"
+    );
+
+    // Now make sure we can get the logger that was set
+    $grabbed_logger = NULL;
+    $exception_caught = FALSE;
+    $exception_message = 'NONE';
+    try {
+      $grabbed_logger = $instance->getLogger();
+    } catch (\Exception $e) {
+      $exception_caught = TRUE;
+      $exception_message = $e->getMessage();
+    }
+    $this->assertFalse(
+      $exception_caught,
+      "Calling getLogger() after being set with setLogger() should not have thrown an exception but it threw '$exception_message'"
+    );
+    $this->assertEquals(
+      $my_logger,
+      $grabbed_logger,
+      'Could not grab the TripalLogger object using getLogger() despite having called setLogger() on it.'
     );
   }
 }


### PR DESCRIPTION
**Issue #105**

## Motivation

We want the ability to allow the validators to utilize the TripalLogger instance from the Tripal Importer. This will allow us to log messages in the service logs in place of exception messages where it is more appropriate to do so.

## What does this PR do?
1. Adds a setter/getter in the validator base that allows the importer to set the TripalImporter instance it uses for the validator to use.
2. Update the Trait Importer to set the TripalLogger instance for each validator
   - In this PR, this only applies to the DuplicateTraits validator, so I've added a single call to setLogger() by this instance within the configureValidators() method. 
   - **For future discussion**: We know that once the Traits Importer is updated to use all of the new validators, there will be more calls to setLogger(). @laceysanderson has suggested we can loop through all of the validators at the end of the configureValidators() method and set it for every validator regardless if they need it or not, to cut down on maintenance every time we want to add a new validator.
4. Update exception messages currently marked as `@todo` to log those messages instead
   - **GenusConfigured Trait**:
   - [x] Check that genus exists in chado
   - [x] Check that genus is configured for the module
   - **Project Trait**:
   - [x] Check if project id <= 0
   - [x] Check if project name is an empty string
   - [x] Check if project exists in the database
   - **FileTypes Trait**:
   - [x] Check if the input file's MIME type is in the mime_to_delimiter_mapping array
5. Create and update tests accordingly

## Testing

### Automated Testing
**ValidatorBaseTest::testTripalLoggerGetterSetter**
- [x] Tests an exception is thrown when trying to get a logger that hasn't been set yet
- [x] Tests setLogger() with a valid TripalLogger object and ensures it doesn't throw an exception
- [x] Tests getLogger() after setting with a valid TripalLogger object to ensure we get the object back

_The following tests were **updated**_:

**ValidatorTraitProjectTest::testProjectSetterGetter**
- [x] Updated all cases where setProject() is called to check for logged messages instead of catching exceptions
- [x] Include checks that getProject() throws exceptions directly after setProject() was called and triggered a logged error message

**ValidatorTraitGenusConfiguredTest::testConfiguredGenusSetterGetter**
- [x] Converted the 2 cases checking if 1) a genus exists and 2) is configured from checking for exceptions thrown to checking for a logged error message

**ValidatorTraitFileTypesTest:testFileMimeType**
- [x] Added a check for logged error messages inside the try-catch whenever setFileMimeType() is tested
