### PR TITLE
Remove return statement check

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -30,9 +30,9 @@ checks:
     config:
       threshold: 6
   return-statements:
-    enabled: true
+    enabled: false
     config:
-      threshold: 6
+      threshold: 100
   similar-code:
     enabled: false
     config:


### PR DESCRIPTION
This PR just removes the return statement check from code climate as I believe limiting return statements often reduces readability by requiring more if/else blocks.