### PR TITLE
G2.121 Improve PHP/Drupal standards for the Traits Importer

### DIFF
--- a/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
+++ b/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
@@ -4,6 +4,7 @@ namespace Drupal\trpcultivate_phenotypes\Plugin\TripalImporter;
 
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\file\Entity\File;
+use Drupal\tripal_chado\Database\ChadoConnection;
 use Drupal\tripal_chado\TripalImporter\ChadoImporterBase;
 use Drupal\trpcultivate_phenotypes\Service\TripalCultivatePhenotypesGenusOntologyService;
 use Drupal\trpcultivate_phenotypes\Service\TripalCultivatePhenotypesTraitsService;
@@ -88,6 +89,13 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
   ];
 
   /**
+   * A Database query interface for querying Chado using Tripal DBX.
+   *
+   * @var Drupal\tripal_chado\Database\ChadoConnection
+   */
+  protected ChadoConnection $chado_connection;
+
+  /**
    * Genus Ontology service.
    *
    * @var \Drupal\trpcultivate_phenotypes\Service\TripalCultivatePhenotypesGenusOntologyService
@@ -109,35 +117,48 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
   private $validation_result = 'validation_result';
 
   /**
-   * Injection of services through setter methods.
+   * Constructs the traits importer.
    *
-   * @param \Symfony\Component\DependencyInjection\ContainerInterface $container
    * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
    * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
    * @param mixed $plugin_definition
-   *
-   * @return static
+   *   The plugin implementation definition.
+   * @param Drupal\tripal_chado\Database\ChadoConnection $chado_connection
+   *   The connection to the Chado database.
+   * @param \Drupal\trpcultivate_phenotypes\Service\TripalCultivatePhenotypesGenusOntologyService $service_PhenoGenusOntology
+   *   The genus ontology service.
+   * @param \Drupal\trpcultivate_phenotypes\Service\TripalCultivatePhenotypesTraitsService $service_PhenoTraits
+   *   The traits service.
+   */
+  public function __construct(
+    array $configuration,
+    string $plugin_id,
+    mixed $plugin_definition,
+    ChadoConnection $chado_connection,
+    TripalCultivatePhenotypesGenusOntologyService $service_PhenoGenusOntology,
+    TripalCultivatePhenotypesTraitsService $service_PhenoTraits,
+  ) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $chado_connection);
+
+    // Call service setter method to set the service.
+    $this->setServiceGenusOntology($service_PhenoGenusOntology);
+    $this->setServiceTraits($service_PhenoTraits);
+  }
+
+  /**
+   * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
-    // Service genus ontology.
-    $service_PhenoGenusOntology = $container->get('trpcultivate_phenotypes.genus_ontology');
-    // Service traits.
-    $service_PhenoTraits = $container->get('trpcultivate_phenotypes.traits');
-
-    $instance = new static(
+    return new static(
       $configuration,
       $plugin_id,
       $plugin_definition,
       $container->get('tripal_chado.database'),
-      $service_PhenoGenusOntology,
-      $service_PhenoTraits
+      $container->get('trpcultivate_phenotypes.genus_ontology'),
+      $container->get('trpcultivate_phenotypes.traits'),
     );
-
-    // Call service setter method to set the service.
-    $instance->setServiceGenusOntology($service_PhenoGenusOntology);
-    $instance->setServiceTraits($service_PhenoTraits);
-
-    return $instance;
   }
 
   /**
@@ -788,22 +809,22 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
   }
 
   /**
-   * Set genus ontology configuration service.
+   * Set phenotype genus ontology configuration service.
    *
-   * @param $service
-   *   Service as created/injected through create method.
+   * @param Drupal\trpcultivate_phenotypes\Service\TripalCultivatePhenotypesGenusOntologyService $service
+   *   The PhenoGenoOntology service as created/injected through create method.
    */
-  public function setServiceGenusOntology($service) {
+  public function setServiceGenusOntology(TripalCultivatePhenotypesGenusOntologyService $service) {
     if ($service) {
       $this->service_PhenoGenusOntology = $service;
     }
   }
 
   /**
-   * Set traits service.
+   * Set phenotype traits service.
    *
-   * @param $service
-   *   Service as created/injected through create method.
+   * @param \Drupal\trpcultivate_phenotypes\Service\TripalCultivatePhenotypesTraitsService $service
+   *   The PhenoTraits service as created/injected through create method.
    */
   public function setServiceTraits($service) {
     if ($service) {

--- a/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
+++ b/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
@@ -735,13 +735,10 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
    * {@inheritDoc}
    */
   public function run() {
-    // Traits service.
-    $service_traits = \Drupal::service('trpcultivate_phenotypes.traits');
-
     // Values provided by user in the importer page.
     $genus = $this->arguments['run_args']['genus'];
     // Tell trait service that all trait assets will be contained in this genus.
-    $service_traits->setTraitGenus($genus);
+    $this->service_PhenoTraits->setTraitGenus($genus);
     // Traits data file id.
     $file_id = $this->arguments['files'][0]['fid'];
     // Load file object.
@@ -782,7 +779,7 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
         // NOTE: Loading of this file is performed using a database transaction.
         // If it fails or is terminated prematurely, then all insertions and
         // updates are rolled back and will not be found in the database.
-        $service_traits->insertTrait($trait);
+        $this->service_PhenoTraits->insertTrait($trait);
 
         unset($data);
       }

--- a/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
+++ b/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
@@ -1,20 +1,14 @@
 <?php
 
-/**
- * @file
- * Tripal Importer Plugin implementation for Tripal Cultivate Phenotypes - Traits Importer.
- */
-
 namespace Drupal\trpcultivate_phenotypes\Plugin\TripalImporter;
 
-use Drupal\tripal_chado\TripalImporter\ChadoImporterBase;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\file\Entity\File;
-use Drupal\Core\Url;
-use Drupal\trpcultivate_phenotypes\TripalCultivateValidator\TripalCultivatePhenotypesValidatorBase;
-use Drupal\trpcultivate_phenotypes\Service\TripalCultivatePhenotypesTraitsService;
+use Drupal\tripal_chado\TripalImporter\ChadoImporterBase;
 use Drupal\trpcultivate_phenotypes\Service\TripalCultivatePhenotypesGenusOntologyService;
+use Drupal\trpcultivate_phenotypes\Service\TripalCultivatePhenotypesTraitsService;
+use Drupal\trpcultivate_phenotypes\TripalCultivateValidator\TripalCultivatePhenotypesValidatorBase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Tripal Cultivate Phenotypes - Traits Importer.
@@ -46,56 +40,72 @@ use Drupal\trpcultivate_phenotypes\Service\TripalCultivatePhenotypesGenusOntolog
  */
 class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implements ContainerFactoryPluginInterface {
 
-  // Headers required by this importer.
+  /**
+   * Headers required by this importer.
+   *
+   * @var array
+   *
+   * The following keys are required:
+   * - 'name': The column header name as it should appear in the input file.
+   * - 'description': A user-friendly description of the header that will be
+   *   displayed to the user through the form.
+   * - 'type': one of "required" or "optional" to indicate whether the column
+   *   needs to have values present or not.
+   *
+   * NOTE: Order MUST reflect the desired order of headers in the input file.
+   */
   private $headers = [
     [
       'name' => 'Trait Name',
       'description' => 'The name of the trait, as you would like it to appear to the user (e.g. Days to Flower)',
-      'type' => 'required'
+      'type' => 'required',
     ],
     [
       'name' => 'Trait Description',
       'description' => 'A full description of the trait. This is recommended to be at least one paragraph.',
-      'type' => 'required'
+      'type' => 'required',
     ],
     [
       'name' => 'Method Short Name',
       'description' => 'A full, unique title for the method (e.g. Days till 10% of plants/plot have flowers)',
-      'type' => 'required'
+      'type' => 'required',
     ],
     [
       'name' => 'Collection Method',
       'description' => 'A full description of how the trait was collected. This is also recommended to be at least one paragraph.',
-      'type' => 'required'
+      'type' => 'required',
     ],
     [
       'name' => 'Unit',
       'description' => 'The full name of the unit used (e.g. days, centimeters)',
-      'type' => 'required'
+      'type' => 'required',
     ],
     [
       'name' => 'Type',
       'description' => 'One of "Qualitative" or "Quantitative".',
-      'type' => 'required'
-    ]
+      'type' => 'required',
+    ],
   ];
 
   /**
    * Genus Ontology service.
    *
-   * @var TripalCultivatePhenotypesGenusOntologyService
+   * @var \Drupal\trpcultivate_phenotypes\Service\TripalCultivatePhenotypesGenusOntologyService
    */
   protected TripalCultivatePhenotypesGenusOntologyService $service_PhenoGenusOntology;
 
   /**
    * Traits service.
    *
-   * @var TripalCultivatePhenotypesTraitsService
+   * @var \Drupal\trpcultivate_phenotypes\Service\TripalCultivatePhenotypesTraitsService
    */
   protected TripalCultivatePhenotypesTraitsService $service_PhenoTraits;
 
-  // Reference the validation result summary values in Drupal storage
-  // system using this variable.
+  /**
+   * Used to reference the validation result summary in the form.
+   *
+   * @var string
+   */
   private $validation_result = 'validation_result';
 
   /**
@@ -150,16 +160,16 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
 
     $validators = [];
 
-    // Setup the plugin manager
+    // Setup the plugin manager.
     $manager = \Drupal::service('plugin.manager.trpcultivate_validator');
 
-    // Grab the genus from our form to use in configuring some validators
+    // Grab the genus from our form to use in configuring some validators.
     $genus = $form_values['genus'];
 
-    // Make the header columns into a simplified array for easy reference
-    //  - Keyed by the column header name
-    //  - Values are the column header's position in the $headers property (ie.
-    //    its index if we assume no keys were assigned)
+    // Make the header columns into a simplified array for easy reference:
+    // - Keyed by the column header name.
+    // - Values are the column header's position in the $headers property (ie.
+    //   its index if we assume no keys were assigned).
     $header_index = [];
     $headers = $this->headers;
     foreach ($headers as $i => $column_details) {
@@ -177,7 +187,7 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
     // - File exists and is the expected type
     $instance = $manager->createInstance('valid_data_file');
     // Set supported mime-types using the valid file extensions (file_types) as
-    // defined in the annotation for this importer on line 28
+    // defined in the annotation for this importer on line 28.
     $supported_file_extensions = $this->plugin_definition['file_types'];
     $instance->setSupportedMimeTypes($supported_file_extensions);
     $validators['file']['valid_data_file'] = $instance;
@@ -190,7 +200,7 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
     // this number to be strict = TRUE, thus no extra columns are allowed.
     $num_columns = count($this->headers);
     $instance->setExpectedColumns($num_columns, TRUE);
-    // Set the MIME type of this input file
+    // Set the MIME type of this input file.
     $instance->setFileMimeType($file_mime_type);
     $validators['raw-row']['valid_delimited_file'] = $instance;
 
@@ -199,9 +209,9 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
     // - All column headers match expected header format
     $instance = $manager->createInstance('valid_headers');
     // Use our $headers property to configure what we expect for a header in the
-    // input file
+    // input file.
     $instance->setHeaders($this->headers);
-    // Configure the expected number of columns and set it to be strict
+    // Configure the expected number of columns and set it to be strict.
     $instance->setExpectedColumns($num_columns, TRUE);
     $validators['header-row']['valid_header'] = $instance;
 
@@ -213,7 +223,7 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
       $header_index['Trait Name'],
       $header_index['Method Short Name'],
       $header_index['Unit'],
-      $header_index['Type']
+      $header_index['Type'],
     ];
     $instance->setIndices($indices);
     $validators['data-row']['empty_cell'] = $instance;
@@ -223,20 +233,20 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
     $instance->setIndices([$header_index['Type']]);
     $instance->setValidValues([
       'Quantitative',
-      'Qualitative'
+      'Qualitative',
     ]);
     $validators['data-row']['valid_data_type'] = $instance;
 
     // - The combination of Trait Name, Method Short Name and Unit is unique
     $instance = $manager->createInstance('duplicate_traits');
     // Set the logger since this validator uses a setter (setConfiguredGenus)
-    // which may log messages
+    // which may log messages.
     $instance->setLogger($this->logger);
     $instance->setConfiguredGenus($genus);
     $instance->setIndices([
       'Trait Name' => $header_index['Trait Name'],
       'Method Short Name' => $header_index['Method Short Name'],
-      'Unit' => $header_index['Unit']
+      'Unit' => $header_index['Unit'],
     ]);
     $validators['data-row']['duplicate_traits'] = $instance;
 
@@ -254,16 +264,16 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
     $storage = $form_state->getStorage();
 
     // Full validation result summary.
-    if (isset($storage[ $this->validation_result ])) {
-      $validation_result = $storage[ $this->validation_result ];
+    if (isset($storage[$this->validation_result])) {
+      $validation_result = $storage[$this->validation_result];
 
       $form['validation_result'] = [
         '#type' => 'inline_template',
         '#theme' => 'result_window',
         '#data' => [
-          'validation_result' => $validation_result
+          'validation_result' => $validation_result,
         ],
-        '#weight' => -100
+        '#weight' => -100,
       ];
     }
 
@@ -289,7 +299,7 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
     }
 
     // Field genus.
-    $form['genus'] = array(
+    $form['genus'] = [
       '#type' => 'select',
       '#title' => 'Genus',
       '#description' => t('The genus of the germplasm being phenotyped with the supplied traits.
@@ -299,8 +309,8 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
       '#options' => $active_genus,
       '#default_value' => $default_genus,
       '#weight' => -99,
-      '#required' => TRUE
-    );
+      '#required' => TRUE,
+    ];
 
     // This importer does not support using file sources from existing field.
     // #access: (bool) Whether the element is accessible or not; when FALSE,
@@ -326,10 +336,10 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
 
     $file_id = $form_values['file_upload'];
 
-    // Load our file object
+    // Load our file object.
     $file = File::load($file_id);
 
-    // Get the mime type which is used to validate the file and split the rows
+    // Get the mime type which is used to validate the file and split the rows.
     $file_mime_type = $file->getMimeType();
 
     // Configure the validators.
@@ -340,11 +350,13 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
     // current input-type pass.
     $failed_validator = FALSE;
 
-    // Keep track of failed items.
-    // We expect the first key to be a unique name of the validator instance
-    // (as declared by the configureValidators() method) as there can be multiple
-    // instances of one validator. For row-level input-type validators, this will
-    // be further keyed by line number.
+    // Keep track of failed items. This is a nested array keyed as follows:
+    // - The unique name of a validator instance, which maps to the second level
+    //   of the $validators array.
+    //   - For row-level input-type validators, this is further keyed by the
+    //     row number that the failure for this validator instance occurred.
+    // The value (level 1 for non row-level validators, level 2 for row-level
+    // validators) is the validation results array returned by the validator.
     $failures = [];
 
     // ************************************************************************
@@ -357,7 +369,7 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
       // Validate metadata input value.
       $result = $validator->validateMetadata($form_values);
 
-      // Check if validation failed and save the results if it did
+      // Check if validation failed and save the results if it did.
       if (array_key_exists('valid', $result) && $result['valid'] === FALSE) {
         $failed_validator = TRUE;
         $failures[$validator_name] = $result;
@@ -372,11 +384,11 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
       // **********************************************************************
       foreach ($validators['file'] as $validator_name => $validator) {
         // Set failures for this validator name to an empty array to signal that
-        // this validator has been run
+        // this validator has been run.
         $failures[$validator_name] = [];
         $result = $validator->validateFile('', $file_id);
 
-        // Check if validation failed and save the results if it did
+        // Check if validation failed and save the results if it did.
         if (array_key_exists('valid', $result) && $result['valid'] === FALSE) {
           $failed_validator = TRUE;
           $failures[$validator_name] = $result;
@@ -396,7 +408,7 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
       $line_no = 0;
 
       // Begin column and row validation.
-      while(!feof($handle)) {
+      while (!feof($handle)) {
         // This variable will indicate if the validator has failed. It is set to
         // FALSE for every row to indicate that the line is valid to start with,
         // then execute the tests below to prove otherwise.
@@ -405,22 +417,24 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
         // Current row.
         $line = fgets($handle);
         $line_no++;
-        // Skip this line if its empty, but line numbers should remain accurate
-        if (empty(trim($line))) { continue; }
+        // Skip this line if its empty, but line numbers should remain accurate.
+        if (empty(trim($line))) {
+          continue;
+        }
 
         // ********************************************************************
         // Raw Row Validation
         // ********************************************************************
         foreach ($validators['raw-row'] as $validator_name => $validator) {
-          // Set failures for this validator name to an empty array to signal that
-          // this validator has been run
+          // Set failures for this validator name to an empty array to signal
+          // that this validator has been run.
           if (!array_key_exists($validator_name, $failures)) {
             $failures[$validator_name] = [];
           }
 
           $result = $validator->validateRawRow($line);
 
-          // Check if validation failed and save the results if it did
+          // Check if validation failed and save the results if it did.
           if (array_key_exists('valid', $result) && $result['valid'] === FALSE) {
             $row_has_failed = TRUE;
             $failures[$validator_name][$line_no] = $result;
@@ -443,22 +457,22 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
 
           foreach ($validators['header-row'] as $validator_name => $validator) {
             // Set failures for this validator name to an empty array to signal
-            // that this validator has been run
+            // that this validator has been run.
             if (!array_key_exists($validator_name, $failures)) {
               $failures[$validator_name] = [];
             }
 
             $result = $validator->validateRow($header_row);
 
-            // Check if validation failed and save the results if it did
+            // Check if validation failed and save the results if it did.
             if (array_key_exists('valid', $result) && $result['valid'] === FALSE) {
               $row_has_failed = TRUE;
               $failures[$validator_name] = $result;
             }
           }
 
-          // If any header-row validators failed, skip validation of the data rows
-          // and stop entire validation.
+          // If any header-row validators failed, skip validation of the data
+          // rows.
           if ($row_has_failed === TRUE) {
             $failed_validator = TRUE;
             break;
@@ -469,16 +483,17 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
         // Data Row Validation
         // ********************************************************************
         elseif ($line_no > 1) {
-          // Split line into an array using the delimiter defined by this
-          // importer in the configure values method above.
+          // Split line into an array using the delimiter supported by this
+          // importer when it was configured.
           $data_row = TripalCultivatePhenotypesValidatorBase::splitRowIntoColumns($line, $file_mime_type);
 
           // Call each validator on this row of the file.
-          foreach($validators['data-row'] as $validator_name => $validator) {
+          foreach ($validators['data-row'] as $validator_name => $validator) {
             // Set failures for this validator name to an empty array to signal
-            // that this validator has been run, ONLY if it doesn't already exist
-            // (ie. this validator may have already failed on a previous row).
-            if(!array_key_exists($validator_name, $failures)) {
+            // that this validator has been run, but ONLY if it doesn't exist.
+            // (ie. this validator may have already failed on a previous row, so
+            // we don't want to overwrite previous validation failures.)
+            if (!array_key_exists($validator_name, $failures)) {
               $failures[$validator_name] = [];
             }
             $result = $validator->validateRow($data_row);
@@ -510,17 +525,18 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
   }
 
   /**
-   * Configures and processes the validation messages that will be shown to the
-   * user of the importer
+   * Configures and processes validation messages for the user.
    *
    * @param array $failures
    *   An array containing the return values from any failed validators, keyed
-   *   by the unique name assigned to each validator-input type combination
+   *   by the unique name assigned to each validator-input type combination, and
+   *   further keyed by row number IF the validator was run on each data row.
    *
    * @return array
-   *   An array of feedback to provide to the user which summarizes the validation results
-   *   reported by the validators in the formValidate (i.e. $failures). This array is keyed
-   *   by a string that is associated with a line in the validate UI. Specifically,
+   *   An array of feedback to provide to the user. It summarizes the validation
+   *   results reported by the validators in formValidate (i.e. $failures). This
+   *   array is keyed by a string that is associated with a line in the validate
+   *   UI. Specifically:
    *   - 'validation_line': A string associated with a line that will be
    *     displayed to the user in the validate UI
    *     - 'title': A user-focussed message describing the validation that took
@@ -533,72 +549,72 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
    *       contents of $failures['validator_name'].
    */
   public function processValidationMessages($failures) {
-    // Array to hold all the user feedback. Currently this includes an entry for each
-    // validator. However, in future designs we may combine more then one validator into a
-    // single line in the validate UI and, thus, a single entry in this array. Everything is
-    // set to status of 'todo' to start and will only change to one of 'pass' or
-    // 'fail' if the $failures[] array is defined for that validator, indicating
-    // that validation did take place.
-    // IMPORTANT: Order matters here and is not necessarily reflective of the order
-    // that validators are run in. Think of these validators as being in 2 groups:
-    // Validators that get run once, and ones that get run for every line in the
-    // input file.
+    // Array to hold all the user feedback. Currently this includes an entry for
+    // each validator. However, in future designs we may combine more then one
+    // validator into a single line in the validate UI and, thus, a single entry
+    // in this array. Everything is set to status of 'todo' to start and will
+    // only change to one of 'pass' or 'fail' if the $failures[] array is
+    // defined for that validator, indicating that validation did take place.
+    // IMPORTANT: Order matters here and is not necessarily reflective of the
+    // order that validators are run in. Think of these validators as being in 2
+    // groups: Validators that get run once, and ones that get run for every
+    // line in the input file.
     $messages = [
       // ----------------------- Validators run once ---------------------------
       // ----------------------------- METADATA --------------------------------
       'genus_exists' => [
         'title' => 'The genus is valid',
         'status' => 'todo',
-        'details' => ''
+        'details' => '',
       ],
       // ------------------------------- FILE ----------------------------------
       'valid_data_file' => [
         'title' => 'File is valid and not empty',
         'status' => 'todo',
-        'details' => ''
+        'details' => '',
       ],
       // ---------------------------- HEADER ROW -------------------------------
       'valid_header' => [
         'title' => 'File has all of the column headers expected',
         'status' => 'todo',
-        'details' => ''
+        'details' => '',
       ],
       // --------------------- Validators run per row --------------------------
       // ----------------------------- RAW ROW ---------------------------------
       'valid_delimited_file' => [
         'title' => 'Row is properly delimited',
         'status' => 'todo',
-        'details' => ''
+        'details' => '',
       ],
       // ----------------------------- DATA ROW --------------------------------
       'empty_cell' => [
         'title' => 'Required cells contain a value',
         'status' => 'todo',
-        'details' => ''
+        'details' => '',
       ],
       'valid_data_type' => [
         'title' => 'Values in required cells are valid',
         'status' => 'todo',
-        'details' => ''
+        'details' => '',
       ],
       'duplicate_traits' => [
         'title' => 'All trait-method-unit combinations are unique',
         'status' => 'todo',
-        'details' => ''
-      ]
+        'details' => '',
+      ],
     ];
 
-    // @TODO: an alternative way to identify the validators input type.
+    // @todo an alternative way to identify the validators input type.
     $raw_row_validators = [
-      'valid_delimited_file'
+      'valid_delimited_file',
     ];
 
     $raw_row_failed = FALSE;
 
     foreach (array_keys($messages) as $validator_name) {
       // Check if this validator exists in the failures array, which indicates
-      // that it was run. If it was not run then continue as it is already marked
-      // todo in $messages above.
+      // it was run. If it was not run then continue as it is already marked.
+      // @todo in $messages above.
       if (!array_key_exists($validator_name, $failures)) {
         continue;
       }
@@ -613,7 +629,7 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
         // order of the validators in the default messages array ensures
         // that the raw row validators are checked for failures directly
         // before the data row validators. It also assumes that only data row
-        // validators are after raw row validators in the default messages array.
+        // validators are after raw row validators in the messages array.
         if (!$raw_row_failed) {
           $messages[$validator_name]['status'] = 'pass';
         }
@@ -624,8 +640,7 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
         // Check if $failures[$validator_name] contains one of the results
         // keys, indicating that this is not a row-level validator and therefore
         // doesn't keep track of line numbers.
-
-        // @todo: Update the message to not use the 'case' string by default
+        // @todo Update the message to not use the 'case' string by default
         // and to incorporate the 'failed_details'.
         $messages[$validator_name]['status'] = 'fail';
 
@@ -634,11 +649,11 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
         $messages[$validator_name]['raw_results'] = $failures[$validator_name];
       }
       else {
-        // @todo: Check if this is a validator that keeps track of line numbers.
+        // @todo Check if this is a validator that keeps track of line numbers.
         // @assumption: Only row-level validators enter this else
         // block since BOTH:
-        //   a) $failures[$validator_name] is not empty
-        //   b) $failures[$validator_name]['case'] is not set
+        // a) $failures[$validator_name] is not empty
+        // b) $failures[$validator_name]['case'] is not set
         // It would be better to validate that we have line numbers (integers)
         // then leave the else {} for anything outside of these options to throw
         // an exception for the developer. Reminder that:
@@ -646,11 +661,11 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
         // $failures[$validator_name]['failures']
         // also are valid but this scenario should have already been caught by
         // the previous if block.
-
-        // @todo: Update this current approach to not report only the first
+        // @todo Update this current approach to not report only the first
         // failure, but instead collect all the cases and failedItems and
         // formulate one concise, helpful feedback message.
-        //foreach ($failures[$validator_name] as $line_no => $validator_results) {
+        // phpcs:ignore
+        // foreach ($failures[$validator_name] as $line_no => $validator_results) {
         $messages[$validator_name]['status'] = 'fail';
 
         $first_failed_row = array_key_first($failures[$validator_name]);
@@ -677,9 +692,8 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
     $service_traits = \Drupal::service('trpcultivate_phenotypes.traits');
 
     // Values provided by user in the importer page.
-    // Genus.
     $genus = $this->arguments['run_args']['genus'];
-    // Instruct trait service that all trait assets will be contained in this genus.
+    // Tell trait service that all trait assets will be contained in this genus.
     $service_traits->setTraitGenus($genus);
     // Traits data file id.
     $file_id = $this->arguments['files'][0]['fid'];
@@ -692,11 +706,11 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
     // Line counter.
     $line_no = 0;
     // Headers.
-    // Only the header names are needed, so pull them out into a new array
+    // Only the header names are needed, so pull them out into a new array.
     $headers = array_column($this->headers, 'name');
     $headers_count = count($headers);
 
-    while(!feof($handle)) {
+    while (!feof($handle)) {
       // Current row.
       $line = fgets($handle);
 
@@ -704,29 +718,29 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
         // Line split into individual data point.
         $data_columns = str_getcsv($line, "\t");
         // Sanitize every data in rows and columns.
-        $data = array_map(function($col) { return isset($col) ? trim(str_replace(['"','\''], '', $col)) : ''; }, $data_columns);
+        $data = array_map(function ($col) {
+          return isset($col) ? trim(str_replace(['"', '\''], '', $col)) : '';
+        }, $data_columns);
 
-        // Construct trait array so that each data (value) in a line/row corresponds
+        // Build trait array so that each data (value) in a line/row corresponds
         // to the column header (key).
-        // ie. ['Trait Name' => data 1, 'Trait Description' => data 2 ...]
+        // ie. ['Trait Name' => data 1, 'Trait Description' => data 2 ...].
         $trait = [];
-
         // Fill trait metadata: name, description, method, unit and type.
         for ($i = 0; $i < $headers_count; $i++) {
-          $trait[ $headers[ $i ] ] = $data[ $i ];
+          $trait[$headers[$i]] = $data[$i];
         }
 
         // Create the trait.
-
         // NOTE: Loading of this file is performed using a database transaction.
-        // If it fails or is terminated prematurely then all insertions and updates
-        // are rolled back and will not be found in the database.
+        // If it fails or is terminated prematurely, then all insertions and
+        // updates are rolled back and will not be found in the database.
         $service_traits->insertTrait($trait);
 
         unset($data);
       }
 
-      // Next line;
+      // Next line.
       $line_no++;
     }
 
@@ -747,7 +761,8 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
   public function describeUploadFileFormat() {
     // A template file has been generated and is ready for download.
     $importer_id = $this->pluginDefinition['id'];
-    // Only the header names are needed for making the template file, so pull them out into a new array
+    // Only the header names are needed for making the template file, so pull
+    // them out into a new array.
     $column_headers = array_column($this->headers, 'name');
 
     $file_link = \Drupal::service('trpcultivate_phenotypes.template_generator')
@@ -765,21 +780,18 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
       '#data' => [
         'headers' => $this->headers,
         'notes' => $notes,
-        'template_file' => $file_link
-      ]
+        'template_file' => $file_link,
+      ],
     ];
 
     return \Drupal::service('renderer')->renderPlain($build);
   }
 
   /**
-   * Service setter method:
    * Set genus ontology configuration service.
    *
    * @param $service
    *   Service as created/injected through create method.
-   *
-   * @return void
    */
   public function setServiceGenusOntology($service) {
     if ($service) {
@@ -788,17 +800,15 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
   }
 
   /**
-   * Service setter method:
    * Set traits service.
    *
    * @param $service
    *   Service as created/injected through create method.
-   *
-   * @return void
    */
   public function setServiceTraits($service) {
     if ($service) {
       $this->service_PhenoTraits = $service;
     }
   }
+
 }

--- a/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
+++ b/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
@@ -171,8 +171,8 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
    *   file object using $file->getMimeType()
    *
    * @return array
-   *   A listing of configured validator objects first keyed by
-   *   their inputType. More specifically,
+   *   A listing of configured validator objects first keyed by their inputType.
+   *   More specifically:
    *   - [inputType]: and array of validator instances. Not an
    *     associative array although the keys do indicate what
    *     order they should be run in.
@@ -208,7 +208,7 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
     // - File exists and is the expected type
     $instance = $manager->createInstance('valid_data_file');
     // Set supported mime-types using the valid file extensions (file_types) as
-    // defined in the annotation for this importer on line 28.
+    // defined in the annotation for this importer on line 23.
     $supported_file_extensions = $this->plugin_definition['file_types'];
     $instance->setSupportedMimeTypes($supported_file_extensions);
     $validators['file']['valid_data_file'] = $instance;

--- a/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterFormTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterFormTest.php
@@ -1,11 +1,13 @@
 <?php
+
 namespace Drupal\Tests\trpcultivate_phenotypes\Kernel\TripalImporter;
 
-use Drupal\Core\Url;
-use Drupal\tripal_chado\Database\ChadoConnection;
+use Drupal\Core\Form\FormState;
 use Drupal\Tests\tripal_chado\Kernel\ChadoTestKernelBase;
-use Drupal\Tests\user\Traits\UserCreationTrait;
 use Drupal\Tests\trpcultivate_phenotypes\Traits\PhenotypeImporterTestTrait;
+use Drupal\Tests\user\Traits\UserCreationTrait;
+use Drupal\tripal\Services\TripalLogger;
+use Drupal\tripal_chado\Database\ChadoConnection;
 
 /**
  * Tests the form + form-related functionality of the Trait Importer.
@@ -14,36 +16,62 @@ use Drupal\Tests\trpcultivate_phenotypes\Traits\PhenotypeImporterTestTrait;
  */
 class TraitImporterFormTest extends ChadoTestKernelBase {
 
-	protected string $defaultTheme = 'stark';
-
-	protected static $modules = ['system', 'user', 'file', 'tripal', 'tripal_chado', 'trpcultivate_phenotypes'];
-
   use UserCreationTrait;
   use PhenotypeImporterTestTrait;
 
   /**
+   * Theme used in the test environment.
+   *
+   * @var string
+   */
+  protected string $defaultTheme = 'stark';
+
+  /**
+   * Modules to enable.
+   *
+   * @var array
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'file',
+    'tripal',
+    'tripal_chado',
+    'trpcultivate_phenotypes',
+  ];
+
+  /**
    * A Database query interface for querying Chado using Tripal DBX.
    *
-   * @var ChadoConnection
+   * @var \Drupal\tripal_chado\Database\ChadoConnection
    */
   protected ChadoConnection $chado_connection;
 
   /**
    * Saves details regarding the config.
+   *
+   * @var array
    */
   protected array $cvdbon;
 
   /**
    * The terms required by this module mapped to the cvterm_ids they are set to.
+   *
+   * @var array
    */
   protected array $terms;
 
+  /**
+   * A default listing of annotations associated with our importer.
+   *
+   * @var array
+   */
   protected array $definitions = [
     'test-trait-importer' => [
       'id' => 'trpcultivate-phenotypes-traits-importer',
       'label' => 'Tripal Cultivate: Phenotypic Trait Importer',
       'description' => 'Loads Traits for phenotypic data into the system. This is useful for large phenotypic datasets to ease the upload process.',
-      'file_types' => ["tsv", "txt"],
+      'file_types' => ["tsv"],
       'use_analysis' => FALSE,
       'require_analysis' => FALSE,
       'upload_title' => 'Phenotypic Trait Data File*',
@@ -57,7 +85,7 @@ class TraitImporterFormTest extends ChadoTestKernelBase {
     ],
   ];
 
-	/**
+  /**
    * {@inheritdoc}
    */
   protected function setUp(): void {
@@ -66,8 +94,8 @@ class TraitImporterFormTest extends ChadoTestKernelBase {
     // Ensure we see all logging in tests.
     \Drupal::state()->set('is_a_test_environment', TRUE);
 
-		// Open connection to Chado
-		$this->chado_connection = $this->getTestSchema(ChadoTestKernelBase::PREPARE_TEST_CHADO);
+    // Open connection to Chado.
+    $this->chado_connection = $this->getTestSchema(ChadoTestKernelBase::PREPARE_TEST_CHADO);
 
     // Ensure we can access file_managed related functionality from Drupal.
     // ... users need access to system.action config?
@@ -85,16 +113,16 @@ class TraitImporterFormTest extends ChadoTestKernelBase {
 
     // We need to mock the logger to test the progress reporting.
     $container = \Drupal::getContainer();
-    $mock_logger = $this->getMockBuilder(\Drupal\tripal\Services\TripalLogger::class)
+    $mock_logger = $this->getMockBuilder(TripalLogger::class)
       ->onlyMethods(['error'])
       ->getMock();
     $mock_logger->method('error')
-    ->willReturnCallback(function ($message, $context, $options) {
-      // @todo: Revisit print out of log messages, but perhaps setting an option
-      // for log messages to not print to the UI?
-      //print str_replace(array_keys($context), $context, $message);
-      return NULL;
-    });
+      ->willReturnCallback(function ($message, $context, $options) {
+        // @todo Revisit print out of log messages, but perhaps setting an option
+        // for log messages to not print to the UI?
+        // print str_replace(array_keys($context), $context, $message);
+        return NULL;
+      });
     $container->set('tripal.logger', $mock_logger);
   }
 
@@ -103,7 +131,7 @@ class TraitImporterFormTest extends ChadoTestKernelBase {
    */
   public function testTraitImporterFormValid() {
 
-	  $plugin_id = 'trpcultivate-phenotypes-traits-importer';
+    $plugin_id = 'trpcultivate-phenotypes-traits-importer';
     $importer_label = 'Tripal Cultivate: Phenotypic Trait Importer';
 
     // Configure the module.
@@ -129,8 +157,8 @@ class TraitImporterFormTest extends ChadoTestKernelBase {
     $this->assertEquals('tripal_admin_form_tripalimporter', $form['#form_id'],
       'We did not get the form id we expected.');
 
-    // We expect there to be a Drupal message indicating that the module is not configured.
-    // There is also always a message about not importing phenotypic measurements here.
+    // Expect a Drupal message regarding not importing phenotypic data using
+    // this importer.
     $warnings = \Drupal::messenger()->messagesByType('warning');
     $this->assertCount(1, $warnings,
       "We expect a single warning since the module is configured.");
@@ -142,13 +170,13 @@ class TraitImporterFormTest extends ChadoTestKernelBase {
       "The form should have a title set.");
     $this->assertEquals($importer_label, $form['#title'],
       "The title should match the label annotated for our plugin.");
-    // the plugin_id stored in a value form element.
+    // The plugin_id stored in a value form element.
     $this->assertArrayHasKey('importer_plugin_id', $form,
       "The form should have an element to save the plugin_id.");
     $this->assertEquals($plugin_id, $form['importer_plugin_id']['#value'],
       "The importer_plugin_id[#value] should be set to our plugin_id.");
 
-    // Check the file fieldset contents
+    // Check the file fieldset contents.
     $this->assertArrayHasKey('file', $form,
       "We expect there to be a file fieldset but there is not.");
     $this->assertEquals('fieldset', $form['file']['#type'],
@@ -181,7 +209,7 @@ class TraitImporterFormTest extends ChadoTestKernelBase {
    * Tests submitting the importer form when all should be well.
    */
   public function testTraitImporterFormSubmitValid() {
-	  $plugin_id = 'trpcultivate-phenotypes-traits-importer';
+    $plugin_id = 'trpcultivate-phenotypes-traits-importer';
 
     // Configure the module.
     $organism_id = $this->chado_connection->insert('1:organism')
@@ -202,7 +230,7 @@ class TraitImporterFormTest extends ChadoTestKernelBase {
     ]);
 
     // Setup the form_state.
-    $form_state = new \Drupal\Core\Form\FormState();
+    $form_state = new FormState();
     $form_state->addBuildInfo('args', [$plugin_id]);
     $form_state->setValue('genus', 'Tripalus');
     $form_state->setValue('file_upload', $file->id());
@@ -216,7 +244,7 @@ class TraitImporterFormTest extends ChadoTestKernelBase {
     // Check that we got an error about the genus not being valid.
     $this->assertTrue($form_state->isValidationComplete(),
       "We expect the form state to have been updated to indicate that validation is complete.");
-    //   Looking for form validation errors
+    // Looking for form validation errors.
     $form_validation_messages = $form_state->getErrors();
     $helpful_output = [];
     foreach ($form_validation_messages as $element => $markup) {
@@ -231,7 +259,7 @@ class TraitImporterFormTest extends ChadoTestKernelBase {
    */
   public function testTraitImporterFormNoOrganism() {
 
-	  $plugin_id = 'trpcultivate-phenotypes-traits-importer';
+    $plugin_id = 'trpcultivate-phenotypes-traits-importer';
     $importer_label = 'Tripal Cultivate: Phenotypic Trait Importer';
 
     // Build the form using the Drupal form builder.
@@ -245,8 +273,9 @@ class TraitImporterFormTest extends ChadoTestKernelBase {
     $this->assertEquals('tripal_admin_form_tripalimporter', $form['#form_id'],
       'We did not get the form id we expected.');
 
-    // We expect there to be a Drupal message indicating that the module is not configured.
-    // There is also always a message about not importing phenotypic measurements here.
+    // Expect a Drupal message indicating that the module is not configured.
+    // This is in addition to a message regarding not importing phenotypic
+    // data using this importer.
     $warnings = \Drupal::messenger()->messagesByType('warning');
     $this->assertCount(2, $warnings,
       "We expect two warnings since the module is not configured.");
@@ -260,13 +289,13 @@ class TraitImporterFormTest extends ChadoTestKernelBase {
       "The form should have a title set.");
     $this->assertEquals($importer_label, $form['#title'],
       "The title should match the label annotated for our plugin.");
-    // the plugin_id stored in a value form element.
+    // The plugin_id stored in a value form element.
     $this->assertArrayHasKey('importer_plugin_id', $form,
       "The form should have an element to save the plugin_id.");
     $this->assertEquals($plugin_id, $form['importer_plugin_id']['#value'],
       "The importer_plugin_id[#value] should be set to our plugin_id.");
 
-    // Check the file fieldset contents
+    // Check the file fieldset contents.
     $this->assertArrayHasKey('file', $form,
       "We expect there to be a file fieldset but there is not.");
     $this->assertEquals('fieldset', $form['file']['#type'],
@@ -299,7 +328,7 @@ class TraitImporterFormTest extends ChadoTestKernelBase {
    * Tests submitting the importer form when the module is not configured.
    */
   public function testTraitImporterFormSubmitNoOrganism() {
-	  $plugin_id = 'trpcultivate-phenotypes-traits-importer';
+    $plugin_id = 'trpcultivate-phenotypes-traits-importer';
 
     // Create a file to upload.
     $file = $this->createTestFile([
@@ -309,7 +338,7 @@ class TraitImporterFormTest extends ChadoTestKernelBase {
 
     // INVALID ORGANISM.
     // Setup the form_state.
-    $form_state = new \Drupal\Core\Form\FormState();
+    $form_state = new FormState();
     $form_state->addBuildInfo('args', [$plugin_id]);
     $form_state->setValue('genus', 'NONexistingOrganism');
     $form_state->setValue('file_upload', $file->id());
@@ -323,7 +352,7 @@ class TraitImporterFormTest extends ChadoTestKernelBase {
     // Check that we got an error about the genus not being valid.
     $this->assertTrue($form_state->isValidationComplete(),
       "We expect the form state to have been updated to indicate that validation is complete.");
-    //   Looking for form validation errors
+    // Looking for form validation errors.
     $form_validation_messages = $form_state->getErrors();
     $helpful_output = [];
     foreach ($form_validation_messages as $element => $markup) {
@@ -336,7 +365,7 @@ class TraitImporterFormTest extends ChadoTestKernelBase {
 
     // NO ORGANISM.
     // Setup the form_state.
-    $form_state = new \Drupal\Core\Form\FormState();
+    $form_state = new FormState();
     $form_state->addBuildInfo('args', [$plugin_id]);
     $form_state->setValue('genus', 0);
     $form_state->setValue('file_upload', $file->id());
@@ -350,7 +379,7 @@ class TraitImporterFormTest extends ChadoTestKernelBase {
     // Check that we got an error about the genus not being valid.
     $this->assertTrue($form_state->isValidationComplete(),
       "We expect the form state to have been updated to indicate that validation is complete.");
-    //   Looking for form validation errors
+    // Looking for form validation errors.
     $form_validation_messages = $form_state->getErrors();
     $helpful_output = [];
     foreach ($form_validation_messages as $element => $markup) {
@@ -361,4 +390,5 @@ class TraitImporterFormTest extends ChadoTestKernelBase {
     $this->assertArrayHasKey('genus', $form_validation_messages,
       "We expected the genus form element specifically to have a validation error but instead we have: " . implode(" AND ", $helpful_output));
   }
+
 }

--- a/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterFormTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterFormTest.php
@@ -10,9 +10,9 @@ use Drupal\tripal\Services\TripalLogger;
 use Drupal\tripal_chado\Database\ChadoConnection;
 
 /**
- * Tests the form + form-related functionality of the Trait Importer.
+ * Tests the form + form-related functionality of the Traits Importer.
  *
- * @group traitImporter
+ * @group traitsImporter
  */
 class TraitImporterFormTest extends ChadoTestKernelBase {
 

--- a/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterFormValidateTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterFormValidateTest.php
@@ -1,51 +1,84 @@
 <?php
+
 namespace Drupal\Tests\trpcultivate_phenotypes\Kernel\TripalImporter;
 
-use Drupal\Core\Url;
-use Drupal\tripal_chado\Database\ChadoConnection;
+use Drupal\Core\Form\FormState;
 use Drupal\Tests\tripal_chado\Kernel\ChadoTestKernelBase;
-use Drupal\Tests\user\Traits\UserCreationTrait;
 use Drupal\Tests\trpcultivate_phenotypes\Traits\PhenotypeImporterTestTrait;
+use Drupal\Tests\user\Traits\UserCreationTrait;
+use Drupal\tripal\Services\TripalLogger;
+use Drupal\tripal_chado\Database\ChadoConnection;
 
 /**
- * Tests the form + form-related functionality of the Trait Importer.
+ * Tests the formValidate() functionality of the Traits Importer.
  *
- * @group traitImporter
+ * @group traitsImporter
  */
 class TraitImporterFormValidateTest extends ChadoTestKernelBase {
-
-	protected $defaultTheme = 'stark';
-
-	protected static $modules = ['system', 'user', 'file', 'tripal', 'tripal_chado', 'trpcultivate_phenotypes'];
 
   use UserCreationTrait;
   use PhenotypeImporterTestTrait;
 
-  protected $importer;
+  /**
+   * Theme used in the test environment.
+   *
+   * @var string
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
+   * Modules to enable.
+   *
+   * @var array
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'file',
+    'tripal',
+    'tripal_chado',
+    'trpcultivate_phenotypes',
+  ];
+
+  /**
+   * Our instance of the Traits Importer for testing.
+   *
+   * @var Drupal\trpcultivate_phenotypes\Plugin\TripalImporter\TripalCultivatePhenotypesTraitsImporter
+   */
+  protected TripalCultivatePhenotypesTraitsImporter $importer;
 
   /**
    * A Database query interface for querying Chado using Tripal DBX.
    *
-   * @var ChadoConnection
+   * @var \Drupal\tripal_chado\Database\ChadoConnection
    */
   protected ChadoConnection $chado_connection;
 
   /**
    * Saves details regarding the config.
+   *
+   * @var array
    */
   protected array $cvdbon;
 
   /**
    * The terms required by this module mapped to the cvterm_ids they are set to.
+   *
+   * @var array
    */
   protected array $terms;
 
+  /**
+   * A default listing of annotations associated with our importer.
+   *
+   * @var array
+   */
   protected $definitions = [
     'test-trait-importer' => [
       'id' => 'trpcultivate-phenotypes-traits-importer',
       'label' => 'Tripal Cultivate: Phenotypic Trait Importer',
       'description' => 'Loads Traits for phenotypic data into the system. This is useful for large phenotypic datasets to ease the upload process.',
-      'file_types' => ["tsv", "txt"],
+      'file_types' => ["tsv"],
       'use_analysis' => FALSE,
       'require_analysis' => FALSE,
       'upload_title' => 'Phenotypic Trait Data File*',
@@ -59,7 +92,7 @@ class TraitImporterFormValidateTest extends ChadoTestKernelBase {
     ],
   ];
 
-	/**
+  /**
    * {@inheritdoc}
    */
   protected function setUp(): void {
@@ -68,8 +101,8 @@ class TraitImporterFormValidateTest extends ChadoTestKernelBase {
     // Ensure we see all logging in tests.
     \Drupal::state()->set('is_a_test_environment', TRUE);
 
-		// Open connection to Chado
-		$this->chado_connection = $this->getTestSchema(ChadoTestKernelBase::PREPARE_TEST_CHADO);
+    // Open connection to Chado.
+    $this->chado_connection = $this->getTestSchema(ChadoTestKernelBase::PREPARE_TEST_CHADO);
 
     // Ensure we can access file_managed related functionality from Drupal.
     // ... users need access to system.action config?
@@ -87,44 +120,46 @@ class TraitImporterFormValidateTest extends ChadoTestKernelBase {
 
     // We need to mock the logger to test the progress reporting.
     $container = \Drupal::getContainer();
-    $mock_logger = $this->getMockBuilder(\Drupal\tripal\Services\TripalLogger::class)
+    $mock_logger = $this->getMockBuilder(TripalLogger::class)
       ->onlyMethods(['notice', 'error'])
       ->getMock();
     $mock_logger->method('error')
-    ->willReturnCallback(function ($message, $context, $options) {
-      // @todo: Revisit print out of log messages, but perhaps setting an option
-      // for log messages to not print to the UI?
-      //print str_replace(array_keys($context), $context, $message);
-      return NULL;
-    });
+      ->willReturnCallback(function ($message, $context, $options) {
+        // @todo Revisit print out of log messages, but perhaps setting an option
+        // for log messages to not print to the UI?
+        // print str_replace(array_keys($context), $context, $message);
+        return NULL;
+      });
     $container->set('tripal.logger', $mock_logger);
   }
 
   /**
    * Data Provider: provides files with expected validation result.
    *
-   * For each scenario we expect the following:
-   * -- the genus name that gets selected in the dropdown of the form
-   * -- the filename of the test file used for this scenario (test files are
-   *    located in: tests/src/Fixtures/TraitImporterFiles/)
-   * -- an array indicating the expected validation results
-   *    - Each key is the unique name of a feedback line provided to the validator UI
-   *      by the processValidationMessages(). Currently there is a feedback line for
-   *      each unique validator instance that was instantiated by the
-   *      configureValidators() method in the Traits Importer class
-   *      - 'status': [REQUIRED] One of 'pass', 'todo', or 'fail'
-   *      - 'title': [REQUIRED if 'status' = 'fail'] A string that matches the
-   *        title set in processValidationMessages() method in the Trait Importer
-   *        class for this validator instance.
-   *      - 'details': [REQUIRED if 'status' = 'fail'] A string that is passed
-   *        to the user through the UI if this validation instance failed.
-   * -- an integer of the number of form validation messages we expect to see
-   *    when the form is submitted. NOTE: These validation messages are produced
-   *    by the form via Drupal and are not related to this module's use of
-   *    validator plugins.
+   * @return array
+   *   Each scenario is an array with the following:
+   *   - The genus name that gets selected in the dropdown of the form
+   *   - The filename of the test file used for this scenario (test files are
+   *     located in: tests/src/Fixtures/TraitImporterFiles/)
+   *   - An array indicating the expected validation results:
+   *     - Each key is the unique name of a feedback line provided to the UI
+   *       through processValidationMessages(). Currently, there is a feedback
+   *       line for each unique validator instance that was instantiated by the
+   *       configureValidators() method in the Traits Importer class.
+   *       - 'status': [REQUIRED] One of 'pass', 'todo', or 'fail'
+   *       - 'title': [REQUIRED if 'status' = 'fail'] A string that matches the
+   *         title set in processValidationMessages() method in the Traits
+   *         Importer class for this validator instance.
+   *       - 'details': [REQUIRED if 'status' = 'fail'] A string that is passed
+   *         to the user through the UI if this validation instance failed.
+   *   - an integer indicating the number of form validation messages we expect
+   *     to see when the form is submitted.
+   *     NOTE: These validation messages are produced by the form via Drupal and
+   *     are not related to this module's use of validator plugins.
    */
   public function provideFilesForValidation() {
 
+    // Set our default variables for genus.
     $valid_genus = 'Tripalus';
     $invalid_genus = 'INVALID';
     // Set our number of expected validation messages to 0, since only the
@@ -141,19 +176,21 @@ class TraitImporterFormValidateTest extends ChadoTestKernelBase {
         'genus_exists' => [
           'title' => 'The genus is valid',
           'status' => 'fail',
-          'details' => 'Genus does not exist'
+          'details' => 'Genus does not exist',
         ],
         'valid_data_file' => ['status' => 'todo'],
         'valid_delimited_file' => ['status' => 'todo'],
         'valid_header' => ['status' => 'todo'],
         'empty_cell' => ['status' => 'todo'],
         'valid_data_type' => ['status' => 'todo'],
-        'duplicate_traits' => ['status' => 'todo']
+        'duplicate_traits' => ['status' => 'todo'],
       ],
-      1 // Since selecting an invalid genus should be impossible, 1 form validation error is expected
+      // Selecting an invalid genus should be impossible, so 1 form validation
+      // error is expected.
+      1,
     ];
 
-    // #1: File is empty
+    // #1: File is empty.
     $scenarios[] = [
       $valid_genus,
       'empty_file.txt',
@@ -162,18 +199,18 @@ class TraitImporterFormValidateTest extends ChadoTestKernelBase {
         'valid_data_file' => [
           'title' => 'File is valid and not empty',
           'status' => 'fail',
-          'details' => 'The file has no data and is an empty file'
+          'details' => 'The file has no data and is an empty file',
         ],
         'valid_delimited_file' => ['status' => 'todo'],
         'valid_header' => ['status' => 'todo'],
         'empty_cell' => ['status' => 'todo'],
         'valid_data_type' => ['status' => 'todo'],
-        'duplicate_traits' => ['status' => 'todo']
+        'duplicate_traits' => ['status' => 'todo'],
       ],
-      $num_form_validation_messages
+      $num_form_validation_messages,
     ];
 
-    // #2: Header is improperly delimited, with proper data rows
+    // #2: Header is improperly delimited, with proper data rows.
     $scenarios[] = [
       $valid_genus,
       'improperly_delimited_header_with_data.tsv',
@@ -183,17 +220,17 @@ class TraitImporterFormValidateTest extends ChadoTestKernelBase {
         'valid_delimited_file' => [
           'title' => 'Row is properly delimited',
           'status' => 'fail',
-          'details' => 'Raw row is not delimited'
+          'details' => 'Raw row is not delimited',
         ],
         'valid_header' => ['status' => 'todo'],
         'empty_cell' => ['status' => 'todo'],
         'valid_data_type' => ['status' => 'todo'],
-        'duplicate_traits' => ['status' => 'todo']
+        'duplicate_traits' => ['status' => 'todo'],
       ],
-      $num_form_validation_messages
+      $num_form_validation_messages,
     ];
 
-    // #3: 2nd row of file is improperly delimited
+    // #3: 2nd row of file is improperly delimited.
     $scenarios[] = [
       $valid_genus,
       'correct_header_improperly_delimited_data_row.tsv',
@@ -203,20 +240,20 @@ class TraitImporterFormValidateTest extends ChadoTestKernelBase {
         'valid_delimited_file' => [
           'title' => 'Row is properly delimited',
           'status' => 'fail',
-          'details' => 'Raw row is not delimited'
+          'details' => 'Raw row is not delimited',
         ],
-        // Since the header row has the correct number of columns, validation for
-        // valid_header is expected to pass
+        // Since the header row has the correct number of columns, validation
+        // for valid_header is expected to pass.
         'valid_header' => ['status' => 'pass'],
         'empty_cell' => ['status' => 'todo'],
         'valid_data_type' => ['status' => 'todo'],
-        'duplicate_traits' => ['status' => 'todo']
+        'duplicate_traits' => ['status' => 'todo'],
       ],
-      $num_form_validation_messages
+      $num_form_validation_messages,
     ];
 
-    // #4: Contains correct header but no data
-    // Never reaches the validators for data-row since file content is empty
+    // #4: Contains correct header but no data.
+    // Never reaches the validators for data-row since file content is empty.
     $scenarios[] = [
       $valid_genus,
       'correct_header_no_data.tsv',
@@ -227,12 +264,12 @@ class TraitImporterFormValidateTest extends ChadoTestKernelBase {
         'valid_header' => ['status' => 'pass'],
         'empty_cell' => ['status' => 'todo'],
         'valid_data_type' => ['status' => 'todo'],
-        'duplicate_traits' => ['status' => 'todo']
+        'duplicate_traits' => ['status' => 'todo'],
       ],
-      $num_form_validation_messages
+      $num_form_validation_messages,
     ];
 
-    // #5: Contains incorrect header and one line of correct data
+    // #5: Contains incorrect header and one line of correct data.
     $scenarios[] = [
       $valid_genus,
       'incorrect_header_with_data.tsv',
@@ -247,13 +284,13 @@ class TraitImporterFormValidateTest extends ChadoTestKernelBase {
         ],
         'empty_cell' => ['status' => 'todo'],
         'valid_data_type' => ['status' => 'todo'],
-        'duplicate_traits' => ['status' => 'todo']
+        'duplicate_traits' => ['status' => 'todo'],
       ],
-      $num_form_validation_messages
+      $num_form_validation_messages,
     ];
 
-    // #6: Contains correct header and one line of correct data,
-    // 3rd line has an empty 'Short Method Name'
+    // #6: Contains correct header and one line of correct data.
+    // 3rd line has an empty 'Short Method Name'.
     $scenarios[] = [
       $valid_genus,
       'correct_header_emptycell_method.tsv',
@@ -265,17 +302,17 @@ class TraitImporterFormValidateTest extends ChadoTestKernelBase {
         'empty_cell' => [
           'title' => 'Required cells contain a value',
           'status' => 'fail',
-          'details' => 'Empty value found in required column(s) at row #: 3'
+          'details' => 'Empty value found in required column(s) at row #: 3',
         ],
         'valid_data_type' => ['status' => 'pass'],
-        'duplicate_traits' => ['status' => 'pass']
+        'duplicate_traits' => ['status' => 'pass'],
       ],
-      $num_form_validation_messages
+      $num_form_validation_messages,
     ];
 
-    // #7: Contains correct header and one line of correct data,
-    // 3rd line has an empty line (not a validation error)
-    // 4th line has an empty 'Short Method Name'
+    // #7: Contains correct header and one line of correct data.
+    // 3rd line has an empty line (not a validation error).
+    // 4th line has an empty 'Short Method Name'.
     $scenarios[] = [
       $valid_genus,
       'correct_header_emptycell_after_empty_line.tsv',
@@ -287,16 +324,16 @@ class TraitImporterFormValidateTest extends ChadoTestKernelBase {
         'empty_cell' => [
           'title' => 'Required cells contain a value',
           'status' => 'fail',
-          'details' => 'Empty value found in required column(s) at row #: 4'
+          'details' => 'Empty value found in required column(s) at row #: 4',
         ],
         'valid_data_type' => ['status' => 'pass'],
-        'duplicate_traits' => ['status' => 'pass']
+        'duplicate_traits' => ['status' => 'pass'],
       ],
-      $num_form_validation_messages
+      $num_form_validation_messages,
     ];
 
-    // #8: Contains correct header and two lines of data
-    // First line has an invalid value for 'Type' column
+    // #8: Contains correct header and two lines of data.
+    // First line has an invalid value for 'Type' column.
     $scenarios[] = [
       $valid_genus,
       'correct_header_invalid_datatype.tsv',
@@ -309,15 +346,15 @@ class TraitImporterFormValidateTest extends ChadoTestKernelBase {
         'valid_data_type' => [
           'title' => 'Values in required cells are valid',
           'status' => 'fail',
-          'details' => 'Invalid value(s) in required column(s) at row #: 2'
+          'details' => 'Invalid value(s) in required column(s) at row #: 2',
         ],
-        'duplicate_traits' => ['status' => 'pass']
+        'duplicate_traits' => ['status' => 'pass'],
       ],
-      $num_form_validation_messages
+      $num_form_validation_messages,
     ];
 
-    // #9: Contains correct header and a duplicate trait-method-unit combo
-     $scenarios[] = [
+    // #9: Contains correct header and a duplicate trait-method-unit combo.
+    $scenarios[] = [
       $valid_genus,
       'correct_header_duplicate_traitMethodUnit.tsv',
       [
@@ -330,10 +367,10 @@ class TraitImporterFormValidateTest extends ChadoTestKernelBase {
         'duplicate_traits' => [
           'title' => 'All trait-method-unit combinations are unique',
           'status' => 'fail',
-          'details' => 'A duplicate trait was found within the input file at row #: 3'
-        ]
+          'details' => 'A duplicate trait was found within the input file at row #: 3',
+        ],
       ],
-      $num_form_validation_messages
+      $num_form_validation_messages,
     ];
 
     return $scenarios;
@@ -345,27 +382,24 @@ class TraitImporterFormValidateTest extends ChadoTestKernelBase {
    * @param string $submitted_genus
    *   The name of the genus that is submitted with the form.
    * @param string $filename
-   *   The name of the file being tested. This file is located in:
-   *   tests/src/Fixtures/TraitImporterFiles/
+   *   The name of the file being tested. (Test files are located in
+   *   tests/src/Fixtures/TraitImporterFiles/)
    * @param array $expected_validator_results
    *   An array that is keyed by the unique name of each validator instance
-   *   (these keys are declared in the configureValidators() method in the Traits
-   *   Importer class). Each validator instance in the array is further keyed by
-   *   the following. Some are required but others are optional, dependent upon
-   *   the expected validation results.
-   *   - 'status': [REQUIRED] One of 'pass', 'todo', or 'fail'
+   *   (these names are declared in the configureValidators() method in the
+   *   Traits Importer class). Each validator instance in the array is further
+   *   keyed by the following. Some are required but others are optional,
+   *   dependent upon the expected validation results.
+   *   - 'status': [REQUIRED] One of 'pass', 'todo', or 'fail'.
    *   - 'title': [REQUIRED if 'status' = 'fail'] A string that matches the
    *     title set in processValidationMessages() method in the Trait Importer
    *     class for this validator instance.
    *   - 'details': [REQUIRED if 'status' = 'fail'] A string that is passed to
    *     the user through the UI if this validation instance failed.
-   * @param integer $expected_num_form_validation_errors
-   *   The number of form validation messages we expect to see
-   *   when the form is submitted. NOTE: These validation messages are produced
-   *   by the form via Drupal and are not related to this module's use of
-   *   validator plugins.
-   *
-   * @return void
+   * @param int $expected_num_form_validation_errors
+   *   The number of form validation messages we expect to see when the form is
+   *   submitted. NOTE: These validation messages are produced by the form via
+   *   Drupal and are not related to this module's use of validator plugins.
    *
    * @dataProvider provideFilesForValidation
    */
@@ -373,7 +407,7 @@ class TraitImporterFormValidateTest extends ChadoTestKernelBase {
 
     $formBuilder = \Drupal::formBuilder();
     $form_id = 'Drupal\tripal\Form\TripalImporterForm';
-	  $plugin_id = 'trpcultivate-phenotypes-traits-importer';
+    $plugin_id = 'trpcultivate-phenotypes-traits-importer';
 
     // Configure the module.
     $genus = 'Tripalus';
@@ -395,47 +429,45 @@ class TraitImporterFormValidateTest extends ChadoTestKernelBase {
     ]);
 
     // Setup the form_state.
-    $form_state = new \Drupal\Core\Form\FormState();
+    $form_state = new FormState();
     $form_state->addBuildInfo('args', [$plugin_id]);
 
-    // Submit our genus
+    // Submit our genus.
     $form_state->setValue('genus', $submitted_genus);
 
-    // Submit our file
+    // Submit our file.
     $form_state->setValue('file_upload', $file->id());
 
     // Now try validation!
     $formBuilder->submitForm($form_id, $form_state);
     // And retrieve the form that would be shown after the above submit.
     $form = $formBuilder->retrieveForm($form_id, $form_state);
-    // And the form state storage where our importers store their validation.
-    $storage = $form_state->getStorage();
 
     // Check that we did validation.
     $this->assertTrue($form_state->isValidationComplete(),
       "We expect the form state to have been updated to indicate that validation is complete.");
 
-    // Looking for form validation errors
+    // Looking for form validation errors.
     $form_validation_messages = $form_state->getErrors();
     $helpful_output = [];
     foreach ($form_validation_messages as $element => $markup) {
       $helpful_output[] = $element . " => " . (string) $markup;
     }
 
-    // Compare the number of form validation errors we received to the number we expect
+    // Compare number of form validation errors received to the number expected.
     $this->assertCount(
       $expected_num_form_validation_errors,
       $form_validation_messages,
       "The number of form state errors we expected (" . $expected_num_form_validation_errors . ") does not match what we received: " . implode(" AND ", $helpful_output)
     );
-    // Confirm that there is a validation window open
+    // Confirm that there is a validation window open.
     $this->assertArrayHasKey('validation_result', $form,
       "We expected a validation failure reported via our plugin setup but it's not showing up in the form.");
     $validation_element_data = $form['validation_result']['#data']['validation_result'];
 
     // Now check our expectations are met.
     foreach ($expected_validator_results as $validation_plugin => $expected) {
-      // Check status
+      // Check status.
       $this->assertEquals(
         $expected['status'],
         $validation_element_data[$validation_plugin]['status'],
@@ -451,7 +483,7 @@ class TraitImporterFormValidateTest extends ChadoTestKernelBase {
           $expected['details'],
           "An empty string was provided with a 'details' key within the data provider - trust me, don't do that!"
         );
-        // Now check details
+        // Now check details.
         $this->assertStringContainsString(
           $expected['details'],
           $validation_element_data[$validation_plugin]['details'],
@@ -460,4 +492,5 @@ class TraitImporterFormValidateTest extends ChadoTestKernelBase {
       }
     }
   }
+
 }

--- a/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterRunTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterRunTest.php
@@ -10,20 +10,42 @@ use Drupal\tripal_chado\Database\ChadoConnection;
 use Drupal\trpcultivate_phenotypes\Plugin\TripalImporter\TripalCultivatePhenotypesTraitsImporter;
 
 /**
- * Tests the functionality of the Trait Importer.
+ * Tests the functionality of the run() method of the Traits Importer.
  *
  * @group traitImporter
  */
 class TraitImporterRunTest extends ChadoTestKernelBase {
 
-  protected $defaultTheme = 'stark';
-
-  protected static $modules = ['system', 'user', 'file', 'tripal', 'tripal_chado', 'trpcultivate_phenotypes'];
-
   use UserCreationTrait;
   use PhenotypeImporterTestTrait;
 
-  protected $importer;
+  /**
+   * Theme used in the test environment.
+   *
+   * @var string
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
+   * Modules to enable.
+   *
+   * @var array
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'file',
+    'tripal',
+    'tripal_chado',
+    'trpcultivate_phenotypes',
+  ];
+
+  /**
+   * Our instance of the Traits Importer for testing.
+   *
+   * @var Drupal\trpcultivate_phenotypes\Plugin\TripalImporter\TripalCultivatePhenotypesTraitsImporter
+   */
+  protected TripalCultivatePhenotypesTraitsImporter $importer;
 
   /**
    * A Database query interface for querying Chado using Tripal DBX.
@@ -34,19 +56,30 @@ class TraitImporterRunTest extends ChadoTestKernelBase {
 
   /**
    * Config factory.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
    */
-  protected $config_factory;
+  protected ConfigFactoryInterface $config_factory;
 
   /**
    * Saves details regarding the config.
+   *
+   * @var array
    */
   protected array $cvdbon;
 
   /**
    * The terms required by this module mapped to the cvterm_ids they are set to.
+   *
+   * @var array
    */
   protected array $terms;
 
+  /**
+   * A default listing of annotations associated with our importer.
+   *
+   * @var array
+   */
   protected $definitions = [
     'test-trait-importer' => [
       'id' => 'trpcultivate-phenotypes-traits-importer',
@@ -135,8 +168,10 @@ class TraitImporterRunTest extends ChadoTestKernelBase {
   }
 
   /**
-   * Tests focusing on the run() function using a simple example file that
-   * populates all columns.
+   * Tests the run() function using a simple example file.
+   *
+   * Example file located at:
+   *   tests/src/Fixtures/TraitImporterFiles/simple_example.txt.
    */
   public function testTraitImporterRunSimple() {
 

--- a/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterRunTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterRunTest.php
@@ -157,6 +157,8 @@ class TraitImporterRunTest extends ChadoTestKernelBase {
       $this->container->get('trpcultivate_phenotypes.traits'),
       $this->container->get('plugin.manager.trpcultivate_validator'),
       $this->container->get('entity_type.manager'),
+      $this->container->get('trpcultivate_phenotypes.template_generator'),
+      $this->container->get('renderer'),
     );
 
   }

--- a/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterRunTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterRunTest.php
@@ -55,13 +55,6 @@ class TraitImporterRunTest extends ChadoTestKernelBase {
   protected ChadoConnection $chado_connection;
 
   /**
-   * Config factory.
-   *
-   * @var \Drupal\Core\Config\ConfigFactoryInterface
-   */
-  protected ConfigFactoryInterface $config_factory;
-
-  /**
    * Saves details regarding the config.
    *
    * @var array
@@ -151,11 +144,10 @@ class TraitImporterRunTest extends ChadoTestKernelBase {
       ->execute();
     $this->assertIsNumeric($organism_id,
       "We were not able to create an organism for testing.");
-    $this->cvdbon = $this->setOntologyConfig('Tripalus');
 
+    $this->cvdbon = $this->setOntologyConfig('Tripalus');
     $this->terms = $this->setTermConfig();
 
-    $this->config_factory = \Drupal::configFactory();
     $this->importer = new TripalCultivatePhenotypesTraitsImporter(
       [],
       'trpcultivate-phenotypes-traits-importer',

--- a/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterRunTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterRunTest.php
@@ -1,11 +1,13 @@
 <?php
+
 namespace Drupal\Tests\trpcultivate_phenotypes\Kernel\TripalImporter;
 
-use Drupal\Core\Url;
-use Drupal\tripal_chado\Database\ChadoConnection;
 use Drupal\Tests\tripal_chado\Kernel\ChadoTestKernelBase;
-use Drupal\Tests\user\Traits\UserCreationTrait;
 use Drupal\Tests\trpcultivate_phenotypes\Traits\PhenotypeImporterTestTrait;
+use Drupal\Tests\user\Traits\UserCreationTrait;
+use Drupal\tripal\Services\TripalLogger;
+use Drupal\tripal_chado\Database\ChadoConnection;
+use Drupal\trpcultivate_phenotypes\Plugin\TripalImporter\TripalCultivatePhenotypesTraitsImporter;
 
 /**
  * Tests the functionality of the Trait Importer.
@@ -14,9 +16,9 @@ use Drupal\Tests\trpcultivate_phenotypes\Traits\PhenotypeImporterTestTrait;
  */
 class TraitImporterRunTest extends ChadoTestKernelBase {
 
-	protected $defaultTheme = 'stark';
+  protected $defaultTheme = 'stark';
 
-	protected static $modules = ['system', 'user', 'file', 'tripal', 'tripal_chado', 'trpcultivate_phenotypes'];
+  protected static $modules = ['system', 'user', 'file', 'tripal', 'tripal_chado', 'trpcultivate_phenotypes'];
 
   use UserCreationTrait;
   use PhenotypeImporterTestTrait;
@@ -26,12 +28,12 @@ class TraitImporterRunTest extends ChadoTestKernelBase {
   /**
    * A Database query interface for querying Chado using Tripal DBX.
    *
-   * @var ChadoConnection
+   * @var \Drupal\tripal_chado\Database\ChadoConnection
    */
   protected ChadoConnection $chado_connection;
 
   /**
-   * Config factory
+   * Config factory.
    */
   protected $config_factory;
 
@@ -64,7 +66,7 @@ class TraitImporterRunTest extends ChadoTestKernelBase {
     ],
   ];
 
-	/**
+  /**
    * {@inheritdoc}
    */
   protected function setUp(): void {
@@ -73,8 +75,8 @@ class TraitImporterRunTest extends ChadoTestKernelBase {
     // Ensure we see all logging in tests.
     \Drupal::state()->set('is_a_test_environment', TRUE);
 
-		// Open connection to Chado
-		$this->chado_connection = $this->getTestSchema(ChadoTestKernelBase::PREPARE_TEST_CHADO);
+    // Open connection to Chado.
+    $this->chado_connection = $this->getTestSchema(ChadoTestKernelBase::PREPARE_TEST_CHADO);
 
     // Ensure we can access file_managed related functionality from Drupal.
     // ... users need access to system.action config?
@@ -92,16 +94,16 @@ class TraitImporterRunTest extends ChadoTestKernelBase {
 
     // We need to mock the logger to test the progress reporting.
     $container = \Drupal::getContainer();
-    $mock_logger = $this->getMockBuilder(\Drupal\tripal\Services\TripalLogger::class)
-      ->onlyMethods(['notice','error'])
+    $mock_logger = $this->getMockBuilder(TripalLogger::class)
+      ->onlyMethods(['notice', 'error'])
       ->getMock();
     $mock_logger->method('notice')
-       ->willReturnCallback(function($message, $context, $options) {
+      ->willReturnCallback(function ($message, $context, $options) {
          print str_replace(array_keys($context), $context, $message);
          return NULL;
-       });
+      });
     $mock_logger->method('error')
-      ->willReturnCallback(function($message, $context, $options) {
+      ->willReturnCallback(function ($message, $context, $options) {
         print str_replace(array_keys($context), $context, $message);
         return NULL;
       });
@@ -121,11 +123,13 @@ class TraitImporterRunTest extends ChadoTestKernelBase {
     $this->terms = $this->setTermConfig();
 
     $this->config_factory = \Drupal::configFactory();
-    $this->importer = new \Drupal\trpcultivate_phenotypes\Plugin\TripalImporter\TripalCultivatePhenotypesTraitsImporter(
+    $this->importer = new TripalCultivatePhenotypesTraitsImporter(
       [],
       'trpcultivate-phenotypes-traits-importer',
       $this->definitions,
-      $this->chado_connection
+      $this->chado_connection,
+      $this->container->get('trpcultivate_phenotypes.genus_ontology'),
+      $this->container->get('trpcultivate_phenotypes.traits'),
     );
 
   }
@@ -151,4 +155,5 @@ class TraitImporterRunTest extends ChadoTestKernelBase {
     $this->importer->postRun();
 
   }
+
 }

--- a/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterRunTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterRunTest.php
@@ -155,6 +155,7 @@ class TraitImporterRunTest extends ChadoTestKernelBase {
       $this->chado_connection,
       $this->container->get('trpcultivate_phenotypes.genus_ontology'),
       $this->container->get('trpcultivate_phenotypes.traits'),
+      $this->container->get('plugin.manager.trpcultivate_validator'),
       $this->container->get('entity_type.manager'),
     );
 

--- a/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterRunTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterRunTest.php
@@ -155,6 +155,7 @@ class TraitImporterRunTest extends ChadoTestKernelBase {
       $this->chado_connection,
       $this->container->get('trpcultivate_phenotypes.genus_ontology'),
       $this->container->get('trpcultivate_phenotypes.traits'),
+      $this->container->get('entity_type.manager'),
     );
 
   }

--- a/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterRunTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterRunTest.php
@@ -12,7 +12,7 @@ use Drupal\trpcultivate_phenotypes\Plugin\TripalImporter\TripalCultivatePhenotyp
 /**
  * Tests the functionality of the run() method of the Traits Importer.
  *
- * @group traitImporter
+ * @group traitsImporter
  */
 class TraitImporterRunTest extends ChadoTestKernelBase {
 


### PR DESCRIPTION
**Issue #121**

Dependant on PR #119 

## Motivation

Using the VS Code extension PHP Sniffer & Beautifier as a guideline, the Traits Importer and its test files need to be brought up to PHP/Drupal coding standards before we proceed with further development.

## What does this PR do?
Applies PHP/Drupal standards to the following files:
- [x] `trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php` Notably:
   - adding Drupal's `EntityTypeManager` service for use with loading files instead of `file::load()` directly
   - using Drupal's `StringTranslationTrait` to translate UI messages using `$this->t()`
   - docblock added to `$headers` property and clarification in various comments/docblocks. I held back from improving `processValidationMessages()` though as I know that method will be undergoing major changes soon.
- [x] `trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterFormTest.php`
- [x] `trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterFormValidateTest.php`
- [x] `trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterRunTest.php`

## Testing

### Automated Testing
No automated tests have been added, though it's good to confirm that every test is still passing.

### Manual Testing
You can check that all errors/warnings were addressed by doing the following:
1. Create a new docker from this branch and open the repo in vs code.
2. Choose any one of the files changed in this PR, and confirm that no problems are reported in your terminal window.

Additionally, please visually inspect the changes that occurred in each file as part of this PR. You may have to click on `Load diff` in the `Files Changed` tab to see changes to the Traits Importer- these changes are considered the most important to focus on review-wise. Fortunately, this PR should be far more manageable than #119 😅 🙏 
