### PR TITLE
G5.125 support d11

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -3,12 +3,12 @@
   "build": {
     "dockerfile": "Dockerfile",
     "args": {
-      "drupalversion": "10.4.x-dev",
+      "drupalversion": "11.1.x-dev",
       "phpversion": "8.3",
       "pgsqlversion": "16"
     }
   },
-  "initializeCommand": "docker pull knowpulse/tripalcultivate:baseonly-drupal10.4.x-dev-php8.3-pgsql16",
+  "initializeCommand": "docker pull knowpulse/tripalcultivate-base:drupal11.1.x-dev-php8.3-pgsql16",
   "workspaceMount": "source=${localWorkspaceFolder},target=/var/www/drupal/web/modules/contrib/TripalCultivate-Phenotypes,type=bind",
   "workspaceFolder": "/var/www/drupal/web/modules/contrib/TripalCultivate-Phenotypes",
   "customizations": {

--- a/.github/workflows/ALL-PHPUnit.yml
+++ b/.github/workflows/ALL-PHPUnit.yml
@@ -33,9 +33,26 @@ jobs:
           - "13"
           - "16"
         drupal-version:
-          - "10.2.x-dev"
           - "10.3.x-dev"
           - "10.4.x-dev"
+          - "10.5.x-dev"
+          - "11.0.x-dev"
+          - "11.1.x-dev"
+        exclude:
+          - php-version: "8.1"
+            drupal-version: "11.0.x-dev"
+          - php-version: "8.2"
+            drupal-version: "11.0.x-dev"
+          - php-version: "8.3"
+            pgsql-version: "13"
+            drupal-version: "11.0.x-dev"
+          - php-version: "8.1"
+            drupal-version: "11.1.x-dev"
+          - php-version: "8.2"
+            drupal-version: "11.1.x-dev"
+          - php-version: "8.3"
+            pgsql-version: "13"
+            drupal-version: "11.1.x-dev"
 
     steps:
       # Check out the repo

--- a/.github/workflows/MAIN-phpunit-Grid1A.yml
+++ b/.github/workflows/MAIN-phpunit-Grid1A.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - 4.x
+      - g5.125-supportD11
 
 ## UPDATES
 ## Update the version numbers in the job name and the action parameters

--- a/.github/workflows/MAIN-phpunit-Grid1A.yml
+++ b/.github/workflows/MAIN-phpunit-Grid1A.yml
@@ -6,16 +6,15 @@ on:
 
 ## UPDATES
 ## Update the version numbers in the job name and the action parameters
-# |-------------|-----------------|-----------------|-----------------|
-# |  Drupal     |  10.2.x         |  10.3.x         |  10.4.x         |
-# |-------------|-----------------|-----------------|-----------------|
-# | **PHP 8.1** | ![Grid1A-Badge] | ![Grid2A-Badge] | ![Grid3A-Badge] |
-# | **PHP 8.2** | ![Grid1B-Badge] | ![Grid2B-Badge] | ![Grid3B-Badge] |
-# | **PHP 8.3** | ![Grid1C-Badge] | ![Grid2C-Badge] | ![Grid3C-Badge] |
+## |  Drupal     |  10.3.x         |  10.4.x         |  10.5.x         | 11.0.x          | 11.1.x          |
+## |-------------|-----------------|-----------------|-----------------|-----------------|-----------------|
+## | **PHP 8.1** | ![Grid1A-Badge] | ![Grid2A-Badge] | ![Grid3A-Badge] |                 |                 |
+## | **PHP 8.2** | ![Grid1B-Badge] | ![Grid2B-Badge] | ![Grid3B-Badge] |                 |                 |
+## | **PHP 8.3** | ![Grid1C-Badge] | ![Grid2C-Badge] | ![Grid3C-Badge] | ![Grid4C-Badge] | ![Grid5C-Badge] |
 
 jobs:
   grid-1A:
-    name: "Drupal 10.2.x-dev - PHP 8.1 - PostgreSQL 16"
+    name: "Drupal 10.3.x-dev - PHP 8.1 - PostgreSQL 16"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -29,4 +28,4 @@ jobs:
           dockerfile: 'Dockerfile'
           php-version: 8.1
           pgsql-version: 16
-          drupal-version: 10.2.x-dev
+          drupal-version: 10.3.x-dev

--- a/.github/workflows/MAIN-phpunit-Grid1B.yml
+++ b/.github/workflows/MAIN-phpunit-Grid1B.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - 4.x
+      - g5.125-supportD11
 
 ## UPDATES
 ## Update the version numbers in the job name and the action parameters

--- a/.github/workflows/MAIN-phpunit-Grid1B.yml
+++ b/.github/workflows/MAIN-phpunit-Grid1B.yml
@@ -6,16 +6,15 @@ on:
 
 ## UPDATES
 ## Update the version numbers in the job name and the action parameters
-# |-------------|-----------------|-----------------|-----------------|
-# |  Drupal     |  10.2.x         |  10.3.x         |  10.4.x         |
-# |-------------|-----------------|-----------------|-----------------|
-# | **PHP 8.1** | ![Grid1A-Badge] | ![Grid2A-Badge] | ![Grid3A-Badge] |
-# | **PHP 8.2** | ![Grid1B-Badge] | ![Grid2B-Badge] | ![Grid3B-Badge] |
-# | **PHP 8.3** | ![Grid1C-Badge] | ![Grid2C-Badge] | ![Grid3C-Badge] |
+## |  Drupal     |  10.3.x         |  10.4.x         |  10.5.x         | 11.0.x          | 11.1.x          |
+## |-------------|-----------------|-----------------|-----------------|-----------------|-----------------|
+## | **PHP 8.1** | ![Grid1A-Badge] | ![Grid2A-Badge] | ![Grid3A-Badge] |                 |                 |
+## | **PHP 8.2** | ![Grid1B-Badge] | ![Grid2B-Badge] | ![Grid3B-Badge] |                 |                 |
+## | **PHP 8.3** | ![Grid1C-Badge] | ![Grid2C-Badge] | ![Grid3C-Badge] | ![Grid4C-Badge] | ![Grid5C-Badge] |
 
 jobs:
   grid-1B:
-    name: "Drupal 10.2.x-dev - PHP 8.2 - PostgreSQL 16"
+    name: "Drupal 10.3.x-dev - PHP 8.2 - PostgreSQL 16"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -29,4 +28,4 @@ jobs:
           dockerfile: 'Dockerfile'
           php-version: 8.2
           pgsql-version: 16
-          drupal-version: 10.2.x-dev
+          drupal-version: 10.3.x-dev

--- a/.github/workflows/MAIN-phpunit-Grid1C.yml
+++ b/.github/workflows/MAIN-phpunit-Grid1C.yml
@@ -6,16 +6,15 @@ on:
 
 ## UPDATES
 ## Update the version numbers in the job name and the action parameters
-# |-------------|-----------------|-----------------|-----------------|
-# |  Drupal     |  10.2.x         |  10.3.x         |  10.4.x         |
-# |-------------|-----------------|-----------------|-----------------|
-# | **PHP 8.1** | ![Grid1A-Badge] | ![Grid2A-Badge] | ![Grid3A-Badge] |
-# | **PHP 8.2** | ![Grid1B-Badge] | ![Grid2B-Badge] | ![Grid3B-Badge] |
-# | **PHP 8.3** | ![Grid1C-Badge] | ![Grid2C-Badge] | ![Grid3C-Badge] |
+## |  Drupal     |  10.3.x         |  10.4.x         |  10.5.x         | 11.0.x          | 11.1.x          |
+## |-------------|-----------------|-----------------|-----------------|-----------------|-----------------|
+## | **PHP 8.1** | ![Grid1A-Badge] | ![Grid2A-Badge] | ![Grid3A-Badge] |                 |                 |
+## | **PHP 8.2** | ![Grid1B-Badge] | ![Grid2B-Badge] | ![Grid3B-Badge] |                 |                 |
+## | **PHP 8.3** | ![Grid1C-Badge] | ![Grid2C-Badge] | ![Grid3C-Badge] | ![Grid4C-Badge] | ![Grid5C-Badge] |
 
 jobs:
   grid-1C:
-    name: "Drupal 10.2.x-dev - PHP 8.3 - PostgreSQL 16"
+    name: "Drupal 10.3.x-dev - PHP 8.3 - PostgreSQL 16"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -29,4 +28,4 @@ jobs:
           dockerfile: 'Dockerfile'
           php-version: 8.3
           pgsql-version: 16
-          drupal-version: 10.2.x-dev
+          drupal-version: 10.3.x-dev

--- a/.github/workflows/MAIN-phpunit-Grid1C.yml
+++ b/.github/workflows/MAIN-phpunit-Grid1C.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - 4.x
+      - g5.125-supportD11
 
 ## UPDATES
 ## Update the version numbers in the job name and the action parameters

--- a/.github/workflows/MAIN-phpunit-Grid2A.yml
+++ b/.github/workflows/MAIN-phpunit-Grid2A.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - 4.x
+      - g5.125-supportD11
 
 ## UPDATES
 ## Update the version numbers in the job name and the action parameters

--- a/.github/workflows/MAIN-phpunit-Grid2A.yml
+++ b/.github/workflows/MAIN-phpunit-Grid2A.yml
@@ -6,16 +6,15 @@ on:
 
 ## UPDATES
 ## Update the version numbers in the job name and the action parameters
-# |-------------|-----------------|-----------------|-----------------|
-# |  Drupal     |  10.2.x         |  10.3.x         |  10.4.x         |
-# |-------------|-----------------|-----------------|-----------------|
-# | **PHP 8.1** | ![Grid1A-Badge] | ![Grid2A-Badge] | ![Grid3A-Badge] |
-# | **PHP 8.2** | ![Grid1B-Badge] | ![Grid2B-Badge] | ![Grid3B-Badge] |
-# | **PHP 8.3** | ![Grid1C-Badge] | ![Grid2C-Badge] | ![Grid3C-Badge] |
+## |  Drupal     |  10.3.x         |  10.4.x         |  10.5.x         | 11.0.x          | 11.1.x          |
+## |-------------|-----------------|-----------------|-----------------|-----------------|-----------------|
+## | **PHP 8.1** | ![Grid1A-Badge] | ![Grid2A-Badge] | ![Grid3A-Badge] |                 |                 |
+## | **PHP 8.2** | ![Grid1B-Badge] | ![Grid2B-Badge] | ![Grid3B-Badge] |                 |                 |
+## | **PHP 8.3** | ![Grid1C-Badge] | ![Grid2C-Badge] | ![Grid3C-Badge] | ![Grid4C-Badge] | ![Grid5C-Badge] |
 
 jobs:
   grid-2A:
-    name: "Drupal 10.3.x-dev - PHP 8.1 - PostgreSQL 16"
+    name: "Drupal 10.4.x-dev - PHP 8.1 - PostgreSQL 16"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -29,4 +28,4 @@ jobs:
           dockerfile: 'Dockerfile'
           php-version: 8.1
           pgsql-version: 16
-          drupal-version: 10.3.x-dev
+          drupal-version: 10.4.x-dev

--- a/.github/workflows/MAIN-phpunit-Grid2B.yml
+++ b/.github/workflows/MAIN-phpunit-Grid2B.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - 4.x
+      - g5.125-supportD11
 
 ## UPDATES
 ## Update the version numbers in the job name and the action parameters

--- a/.github/workflows/MAIN-phpunit-Grid2B.yml
+++ b/.github/workflows/MAIN-phpunit-Grid2B.yml
@@ -6,16 +6,15 @@ on:
 
 ## UPDATES
 ## Update the version numbers in the job name and the action parameters
-# |-------------|-----------------|-----------------|-----------------|
-# |  Drupal     |  10.2.x         |  10.3.x         |  10.4.x         |
-# |-------------|-----------------|-----------------|-----------------|
-# | **PHP 8.1** | ![Grid1A-Badge] | ![Grid2A-Badge] | ![Grid3A-Badge] |
-# | **PHP 8.2** | ![Grid1B-Badge] | ![Grid2B-Badge] | ![Grid3B-Badge] |
-# | **PHP 8.3** | ![Grid1C-Badge] | ![Grid2C-Badge] | ![Grid3C-Badge] |
+## |  Drupal     |  10.3.x         |  10.4.x         |  10.5.x         | 11.0.x          | 11.1.x          |
+## |-------------|-----------------|-----------------|-----------------|-----------------|-----------------|
+## | **PHP 8.1** | ![Grid1A-Badge] | ![Grid2A-Badge] | ![Grid3A-Badge] |                 |                 |
+## | **PHP 8.2** | ![Grid1B-Badge] | ![Grid2B-Badge] | ![Grid3B-Badge] |                 |                 |
+## | **PHP 8.3** | ![Grid1C-Badge] | ![Grid2C-Badge] | ![Grid3C-Badge] | ![Grid4C-Badge] | ![Grid5C-Badge] |
 
 jobs:
   grid-2B:
-    name: "Drupal 10.3.x-dev - PHP 8.2 - PostgreSQL 16"
+    name: "Drupal 10.4.x-dev - PHP 8.2 - PostgreSQL 16"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -29,4 +28,4 @@ jobs:
           dockerfile: 'Dockerfile'
           php-version: 8.2
           pgsql-version: 16
-          drupal-version: 10.3.x-dev
+          drupal-version: 10.4.x-dev

--- a/.github/workflows/MAIN-phpunit-Grid2C.yml
+++ b/.github/workflows/MAIN-phpunit-Grid2C.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - 4.x
+      - g5.125-supportD11
 
 ## UPDATES
 ## Update the version numbers in the job name and the action parameters

--- a/.github/workflows/MAIN-phpunit-Grid2C.yml
+++ b/.github/workflows/MAIN-phpunit-Grid2C.yml
@@ -6,16 +6,15 @@ on:
 
 ## UPDATES
 ## Update the version numbers in the job name and the action parameters
-# |-------------|-----------------|-----------------|-----------------|
-# |  Drupal     |  10.2.x         |  10.3.x         |  10.4.x         |
-# |-------------|-----------------|-----------------|-----------------|
-# | **PHP 8.1** | ![Grid1A-Badge] | ![Grid2A-Badge] | ![Grid3A-Badge] |
-# | **PHP 8.2** | ![Grid1B-Badge] | ![Grid2B-Badge] | ![Grid3B-Badge] |
-# | **PHP 8.3** | ![Grid1C-Badge] | ![Grid2C-Badge] | ![Grid3C-Badge] |
+## |  Drupal     |  10.3.x         |  10.4.x         |  10.5.x         | 11.0.x          | 11.1.x          |
+## |-------------|-----------------|-----------------|-----------------|-----------------|-----------------|
+## | **PHP 8.1** | ![Grid1A-Badge] | ![Grid2A-Badge] | ![Grid3A-Badge] |                 |                 |
+## | **PHP 8.2** | ![Grid1B-Badge] | ![Grid2B-Badge] | ![Grid3B-Badge] |                 |                 |
+## | **PHP 8.3** | ![Grid1C-Badge] | ![Grid2C-Badge] | ![Grid3C-Badge] | ![Grid4C-Badge] | ![Grid5C-Badge] |
 
 jobs:
   grid-2C:
-    name: "Drupal 10.3.x-dev - PHP 8.3 - PostgreSQL 16"
+    name: "Drupal 10.4.x-dev - PHP 8.3 - PostgreSQL 16"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -29,4 +28,4 @@ jobs:
           dockerfile: 'Dockerfile'
           php-version: 8.3
           pgsql-version: 16
-          drupal-version: 10.3.x-dev
+          drupal-version: 10.4.x-dev

--- a/.github/workflows/MAIN-phpunit-Grid3A.yml
+++ b/.github/workflows/MAIN-phpunit-Grid3A.yml
@@ -6,16 +6,15 @@ on:
 
 ## UPDATES
 ## Update the version numbers in the job name and the action parameters
-# |-------------|-----------------|-----------------|-----------------|
-# |  Drupal     |  10.2.x         |  10.3.x         |  10.4.x         |
-# |-------------|-----------------|-----------------|-----------------|
-# | **PHP 8.1** | ![Grid1A-Badge] | ![Grid2A-Badge] | ![Grid3A-Badge] |
-# | **PHP 8.2** | ![Grid1B-Badge] | ![Grid2B-Badge] | ![Grid3B-Badge] |
-# | **PHP 8.3** | ![Grid1C-Badge] | ![Grid2C-Badge] | ![Grid3C-Badge] |
+## |  Drupal     |  10.3.x         |  10.4.x         |  10.5.x         | 11.0.x          | 11.1.x          |
+## |-------------|-----------------|-----------------|-----------------|-----------------|-----------------|
+## | **PHP 8.1** | ![Grid1A-Badge] | ![Grid2A-Badge] | ![Grid3A-Badge] |                 |                 |
+## | **PHP 8.2** | ![Grid1B-Badge] | ![Grid2B-Badge] | ![Grid3B-Badge] |                 |                 |
+## | **PHP 8.3** | ![Grid1C-Badge] | ![Grid2C-Badge] | ![Grid3C-Badge] | ![Grid4C-Badge] | ![Grid5C-Badge] |
 
 jobs:
   grid-3A:
-    name: "Drupal 10.4.x-dev - PHP 8.1 - PostgreSQL 16"
+    name: "Drupal 10.5.x-dev - PHP 8.1 - PostgreSQL 16"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -29,4 +28,4 @@ jobs:
           dockerfile: 'Dockerfile'
           php-version: 8.1
           pgsql-version: 16
-          drupal-version: 10.4.x-dev
+          drupal-version: 10.5.x-dev

--- a/.github/workflows/MAIN-phpunit-Grid3A.yml
+++ b/.github/workflows/MAIN-phpunit-Grid3A.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - 4.x
+      - g5.125-supportD11
 
 ## UPDATES
 ## Update the version numbers in the job name and the action parameters

--- a/.github/workflows/MAIN-phpunit-Grid3B.yml
+++ b/.github/workflows/MAIN-phpunit-Grid3B.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - 4.x
+      - g5.125-supportD11
 
 ## UPDATES
 ## Update the version numbers in the job name and the action parameters

--- a/.github/workflows/MAIN-phpunit-Grid3C.yml
+++ b/.github/workflows/MAIN-phpunit-Grid3C.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - 4.x
+      - g5.125-supportD11
 
 ## UPDATES
 ## Update the version numbers in the job name and the action parameters

--- a/.github/workflows/MAIN-phpunit-Grid3C.yml
+++ b/.github/workflows/MAIN-phpunit-Grid3C.yml
@@ -6,16 +6,15 @@ on:
 
 ## UPDATES
 ## Update the version numbers in the job name and the action parameters
-# |-------------|-----------------|-----------------|-----------------|
-# |  Drupal     |  10.2.x         |  10.3.x         |  10.4.x         |
-# |-------------|-----------------|-----------------|-----------------|
-# | **PHP 8.1** | ![Grid1A-Badge] | ![Grid2A-Badge] | ![Grid3A-Badge] |
-# | **PHP 8.2** | ![Grid1B-Badge] | ![Grid2B-Badge] | ![Grid3B-Badge] |
-# | **PHP 8.3** | ![Grid1C-Badge] | ![Grid2C-Badge] | ![Grid3C-Badge] |
+## |  Drupal     |  10.3.x         |  10.4.x         |  10.5.x         | 11.0.x          | 11.1.x          |
+## |-------------|-----------------|-----------------|-----------------|-----------------|-----------------|
+## | **PHP 8.1** | ![Grid1A-Badge] | ![Grid2A-Badge] | ![Grid3A-Badge] |                 |                 |
+## | **PHP 8.2** | ![Grid1B-Badge] | ![Grid2B-Badge] | ![Grid3B-Badge] |                 |                 |
+## | **PHP 8.3** | ![Grid1C-Badge] | ![Grid2C-Badge] | ![Grid3C-Badge] | ![Grid4C-Badge] | ![Grid5C-Badge] |
 
 jobs:
   grid-3C:
-    name: "Drupal 10.4.x-dev - PHP 8.3 - PostgreSQL 16"
+    name: "Drupal 10.5.x-dev - PHP 8.3 - PostgreSQL 16"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -29,4 +28,4 @@ jobs:
           dockerfile: 'Dockerfile'
           php-version: 8.3
           pgsql-version: 16
-          drupal-version: 10.4.x-dev
+          drupal-version: 10.5.x-dev

--- a/.github/workflows/MAIN-phpunit-Grid4C.yml
+++ b/.github/workflows/MAIN-phpunit-Grid4C.yml
@@ -13,8 +13,8 @@ on:
 ## | **PHP 8.3** | ![Grid1C-Badge] | ![Grid2C-Badge] | ![Grid3C-Badge] | ![Grid4C-Badge] | ![Grid5C-Badge] |
 
 jobs:
-  grid-3B:
-    name: "Drupal 10.5.x-dev - PHP 8.2 - PostgreSQL 16"
+  grid-4C:
+    name: "Drupal 11.0.x-dev - PHP 8.3 - PostgreSQL 16"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -26,6 +26,6 @@ jobs:
           modules: 'trpcultivate_phenotypes trpcultivate_phenocollect trpcultivate_phenoshare'
           build-image: TRUE
           dockerfile: 'Dockerfile'
-          php-version: 8.2
+          php-version: 8.3
           pgsql-version: 16
-          drupal-version: 10.5.x-dev
+          drupal-version: 11.0.x-dev

--- a/.github/workflows/MAIN-phpunit-Grid4C.yml
+++ b/.github/workflows/MAIN-phpunit-Grid4C.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - 4.x
+      - g5.125-supportD11
 
 ## UPDATES
 ## Update the version numbers in the job name and the action parameters

--- a/.github/workflows/MAIN-phpunit-Grid5C.yml
+++ b/.github/workflows/MAIN-phpunit-Grid5C.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - 4.x
+      - g5.125-supportD11
 
 ## UPDATES
 ## Update the version numbers in the job name and the action parameters

--- a/.github/workflows/MAIN-phpunit-Grid5C.yml
+++ b/.github/workflows/MAIN-phpunit-Grid5C.yml
@@ -13,8 +13,8 @@ on:
 ## | **PHP 8.3** | ![Grid1C-Badge] | ![Grid2C-Badge] | ![Grid3C-Badge] | ![Grid4C-Badge] | ![Grid5C-Badge] |
 
 jobs:
-  grid-3B:
-    name: "Drupal 10.5.x-dev - PHP 8.2 - PostgreSQL 16"
+  grid-5C:
+    name: "Drupal 11.1.x-dev - PHP 8.3 - PostgreSQL 16"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -26,6 +26,6 @@ jobs:
           modules: 'trpcultivate_phenotypes trpcultivate_phenocollect trpcultivate_phenoshare'
           build-image: TRUE
           dockerfile: 'Dockerfile'
-          php-version: 8.2
+          php-version: 8.3
           pgsql-version: 16
-          drupal-version: 10.5.x-dev
+          drupal-version: 11.1.x-dev

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-ARG drupalversion=10.3.x-dev
+ARG drupalversion=11.1.x-dev
 ARG phpversion=8.3
 ARG pgsqlversion=16
-FROM knowpulse/tripalcultivate:baseonly-drupal${drupalversion}-php${phpversion}-pgsql${pgsqlversion}
+FROM knowpulse/tripalcultivate-base:drupal${drupalversion}-php${phpversion}-pgsql${pgsqlversion}
 
 COPY . /var/www/drupal/web/modules/contrib/TripalCultivate-Phenotypes
 WORKDIR /var/www/drupal/web/modules/contrib/TripalCultivate-Phenotypes

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The following compatibility is proven via automated testing workflows.
 | **PHP 8.2** | ![Grid1B-Badge] | ![Grid2B-Badge] | ![Grid3B-Badge] |                 |                 |
 | **PHP 8.3** | ![Grid1C-Badge] | ![Grid2C-Badge] | ![Grid3C-Badge] | ![Grid4C-Badge] | ![Grid5C-Badge] |
 
-[our CodeClimate project page]: https://github.com/TripalCultivate/TripalCultivate-Phenotypes
+[our CodeClimate project page]: https://codeclimate.com/github/TripalCultivate/TripalCultivate-Phenotypes
 [MaintainabilityBadge]: https://api.codeclimate.com/v1/badges/03fa542e0d95dedb97e8/maintainability
 [TestCoverageBadge]: https://api.codeclimate.com/v1/badges/03fa542e0d95dedb97e8/test_coverage
 

--- a/README.md
+++ b/README.md
@@ -62,11 +62,11 @@ maintainability issues and test coverage.
 
 The following compatibility is proven via automated testing workflows.
 
-|  Drupal     |  10.2.x         |  10.3.x         |  10.4.x         |
-|-------------|-----------------|-----------------|-----------------|
-| **PHP 8.1** | ![Grid1A-Badge] | ![Grid2A-Badge] | ![Grid3A-Badge] |
-| **PHP 8.2** | ![Grid1B-Badge] | ![Grid2B-Badge] | ![Grid3B-Badge] |
-| **PHP 8.3** | ![Grid1C-Badge] | ![Grid2C-Badge] | ![Grid3C-Badge] |
+|  Drupal     |  10.3.x         |  10.4.x         |  10.5.x         | 11.0.x          | 11.1.x          |
+|-------------|-----------------|-----------------|-----------------|-----------------|-----------------|
+| **PHP 8.1** | ![Grid1A-Badge] | ![Grid2A-Badge] | ![Grid3A-Badge] |                 |                 |
+| **PHP 8.2** | ![Grid1B-Badge] | ![Grid2B-Badge] | ![Grid3B-Badge] |                 |                 |
+| **PHP 8.3** | ![Grid1C-Badge] | ![Grid2C-Badge] | ![Grid3C-Badge] | ![Grid4C-Badge] | ![Grid5C-Badge] |
 
 [our CodeClimate project page]: https://github.com/TripalCultivate/TripalCultivate-Phenotypes
 [MaintainabilityBadge]: https://api.codeclimate.com/v1/badges/03fa542e0d95dedb97e8/maintainability
@@ -83,3 +83,7 @@ The following compatibility is proven via automated testing workflows.
 [Grid3A-Badge]: https://github.com/TripalCultivate/TripalCultivate-Phenotypes/actions/workflows/MAIN-phpunit-Grid3A.yml/badge.svg
 [Grid3B-Badge]: https://github.com/TripalCultivate/TripalCultivate-Phenotypes/actions/workflows/MAIN-phpunit-Grid3B.yml/badge.svg
 [Grid3C-Badge]: https://github.com/TripalCultivate/TripalCultivate-Phenotypes/actions/workflows/MAIN-phpunit-Grid3C.yml/badge.svg
+
+[Grid4C-Badge]: https://github.com/TripalCultivate/TripalCultivate-Phenotypes/actions/workflows/MAIN-phpunit-Grid4C.yml/badge.svg
+
+[Grid5C-Badge]: https://github.com/TripalCultivate/TripalCultivate-Phenotypes/actions/workflows/MAIN-phpunit-Grid5C.yml/badge.svg

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
   ],
   "require": {
     "php": "^8.1",
-    "drupal/core": "^10.0",
+    "drupal/core": "^10.3",
     "tripal/tripal": "^4.0-alpha1",
     "tripalcultivate/base": "*"
   }

--- a/trpcultivate_phenocollect/trpcultivate_phenocollect.info.yml
+++ b/trpcultivate_phenocollect/trpcultivate_phenocollect.info.yml
@@ -2,8 +2,8 @@ name: Phenotypic Data Collection
 type: module
 description: Provides tools to backup and upload phenotypic data while it is being collected in a access controlled environment.
 package: "TripalCultivate: Phenotypes"
-core_version_requirement: ^10
+core_version_requirement: ^10 | ^11
 dependencies:
-  - tripal
-  - tripal_chado
-  - trpcultivate_phenotypes
+  - tripal:tripal
+  - tripal:tripal_chado
+  - tripalcultivate:trpcultivate

--- a/trpcultivate_phenoshare/trpcultivate_phenoshare.info.yml
+++ b/trpcultivate_phenoshare/trpcultivate_phenoshare.info.yml
@@ -2,8 +2,8 @@ name: Phenotypic Data Sharing
 type: module
 description: Provides trait pages, downloads and visualization tools to facilitates sharing published phenotypic data with the public.
 package: "TripalCultivate: Phenotypes"
-core_version_requirement: ^10
+core_version_requirement: ^10 | ^11
 dependencies:
-  - tripal
-  - tripal_chado
-  - trpcultivate_phenotypes
+  - tripal:tripal
+  - tripal:tripal_chado
+  - tripalcultivate:trpcultivate

--- a/trpcultivate_phenotypes/tests/src/Unit/ConfigRRulesFormTest.php
+++ b/trpcultivate_phenotypes/tests/src/Unit/ConfigRRulesFormTest.php
@@ -1,33 +1,28 @@
 <?php
 
-/**
- * @file
- * Unit test of R Transfomration rules configuration page.
- */
-
 namespace Drupal\Tests\trpcultivate_phenotypes\Unit;
 
-use Drupal\trpcultivate_phenotypes\Form\TripalCultivatePhenotypesRSettingsForm;
 use Drupal\Core\Config\Config;
-use Drupal\Core\Form\FormState;
-use Drupal\Tests\UnitTestCase;
 use Drupal\Core\Config\ConfigFactoryInterface;
-use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\Core\Config\TypedConfigManagerInterface;
 use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Core\Form\FormState;
+use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\Tests\UnitTestCase;
+use Drupal\trpcultivate_phenotypes\Form\TripalCultivatePhenotypesRSettingsForm;
 
- /**
-  *  Class definition ConfigRRulesFormTest.
-  *
-  * @coversDefaultClass Drupal\trpcultivate_phenotypes\Form\TripalCultivatePhenotypesRSettingsForm
-  * @group trpcultivate_phenotypes
-  */
+/**
+ * Class definition ConfigRRulesFormTest.
+ *
+ * @coversDefaultClass Drupal\trpcultivate_phenotypes\Form\TripalCultivatePhenotypesRSettingsForm
+ * @group trpcultivate_phenotypes
+ */
 class ConfigRRulesFormTest extends UnitTestCase {
 
   private $rrulesform;
 
   /**
-   * Initialization of container, configurations, service
-   * and service class required by the test.
+   * {@inheritdoc}
    */
   protected function setUp(): void {
     parent::setUp();
@@ -41,15 +36,15 @@ class ConfigRRulesFormTest extends UnitTestCase {
     $r_config_mock = $this->prophesize(Config::class);
 
     $r_config_mock->get('trpcultivate.phenotypes.r_config.chars')->willReturn([
-      '(', ')', '/', '-', ':', ';', '%'
+      '(', ')', '/', '-', ':', ';', '%',
     ]);
 
     $r_config_mock->get('trpcultivate.phenotypes.r_config.words')->willReturn([
-      'of', 'to', 'have', 'on', 'at'
+      'of', 'to', 'have', 'on', 'at',
     ]);
 
     $r_config_mock->get('trpcultivate.phenotypes.r_config.replace')->willReturn([
-      '# = num', '/ = div', '? = unsure', '- = to'
+      '# = num', '/ = div', '? = unsure', '- = to',
     ]);
 
     // When RRules form rebuilds calling the module settings, return
@@ -61,12 +56,16 @@ class ConfigRRulesFormTest extends UnitTestCase {
     // Isolated configuration for R Rules.
     $r_config = $all_config_mock->reveal();
 
-    // Translation requirement of the container
+    // Translation requirement of the container.
     $translation_mock = $this->prophesize(TranslationInterface::class);
     $translation = $translation_mock->reveal();
 
+    // Typed Config Manager requirement for ConfigForm dependancy injection.
+    $typed_config_mock = $this->prophesize(TypedConfigManagerInterface::class);
+    $typed_config = $typed_config_mock->reveal();
+
     // Class RRulesForm class instance.
-    $rrules_form = new TripalCultivatePhenotypesRSettingsForm($r_config);
+    $rrules_form = new TripalCultivatePhenotypesRSettingsForm($r_config, $typed_config);
     $rrules_form->setStringTranslation($translation);
 
     $container->set('rrules.config', $rrules_form);
@@ -77,15 +76,15 @@ class ConfigRRulesFormTest extends UnitTestCase {
    * Test submit form functionality of RRulesForm class.
    */
   /*
-   public function testSubmitForm() {
-    $form = [];
-    $form_state = new FormState();
+  public function testSubmitForm() {
+  $form = [];
+  $form_state = new FormState();
 
-    $form_state->setValue('words', 'num,log');
-    $form_state->setValue('chars', '#,*');
-    $form_state->setValue('words', 'num,log');
+  $form_state->setValue('words', 'num,log');
+  $form_state->setValue('chars', '#,*');
+  $form_state->setValue('words', 'num,log');
 
-    $this->rrulesform->submitForm($form, $form_state);
+  $this->rrulesform->submitForm($form, $form_state);
   }*/
 
   /**
@@ -112,7 +111,6 @@ class ConfigRRulesFormTest extends UnitTestCase {
     $this->assertEquals('textarea', $config_form['replace']['#type']);
   }
 
-
   /**
    * Test validate functionality of RRulesForm class.
    */
@@ -125,9 +123,9 @@ class ConfigRRulesFormTest extends UnitTestCase {
     // words - any words at least 2 characters long and not and empty string.
     // Failed, Has validation error:
     $field = 'words';
-    foreach(['R', 'r', '.', '~', '1', '       ', ' '] as $rule) {
-      // Ensure we reset the form state after each iteration
-      // so that we are not accidentally keeping errors from previous iterations.
+    foreach (['R', 'r', '.', '~', '1', '       ', ' '] as $rule) {
+      // Ensure we reset the form state after each iteration so tha
+      // we are not accidentally keeping errors from previous iterations.
       $form_state->clearErrors();
 
       // Set the value in the form state -expecting an error.
@@ -140,9 +138,9 @@ class ConfigRRulesFormTest extends UnitTestCase {
     }
 
     // Valid words:
-    foreach(['Hello', 'hello', 'plant', 'seeds', 'this', 'that', 'no'] as $rule) {
-      // Ensure we reset the form state after each iteration
-      // so that we are not accidentally keeping errors from previous iterations.
+    foreach (['Hello', 'hello', 'plant', 'seeds', 'this', 'that', 'no'] as $rule) {
+      // Ensure we reset the form state after each iteration so that
+      // we are not accidentally keeping errors from previous iterations.
       $form_state->clearErrors();
 
       $form_state->setValue($field, $rule);
@@ -152,14 +150,13 @@ class ConfigRRulesFormTest extends UnitTestCase {
         "The word '$rule' should be valid but there are form errors for some reason.");
     }
 
-
     // Validation: SPECIAL CHARACTERS Rule
     // chars - any special characters 1 character long.
     // Failed, Has validation error:
     $field = 'chars';
-    foreach(['hello', ',', 'A', 'a', '1'] as $rule) {
-      // Ensure we reset the form state after each iteration
-      // so that we are not accidentally keeping errors from previous iterations.
+    foreach (['hello', ',', 'A', 'a', '1'] as $rule) {
+      // Ensure we reset the form state after each iteration so that
+      // we are not accidentally keeping errors from previous iterations.
       $form_state->clearErrors();
 
       $form_state->setValue($field, $rule);
@@ -170,9 +167,9 @@ class ConfigRRulesFormTest extends UnitTestCase {
     }
 
     // Valid char:
-    foreach(['~', '@', '>', '+', '-', '$', ':'] as $rule) {
-      // Ensure we reset the form state after each iteration
-      // so that we are not accidentally keeping errors from previous iterations.
+    foreach (['~', '@', '>', '+', '-', '$', ':'] as $rule) {
+      // Ensure we reset the form state after each iteration so that
+      // we are not accidentally keeping errors from previous iterations.
       $form_state->clearErrors();
 
       $form_state->setValue($field, $rule);
@@ -182,15 +179,14 @@ class ConfigRRulesFormTest extends UnitTestCase {
         "The char '$rule' should be valid but there are form errors for some reason.");
     }
 
-
     // Validation: MATCH AND REPLACE Rule
     // match = replace - any non-whitespace value for match or replace and
     // must follow match = replace pattern.
     // Failed, Has validation error:
     $field = 'replace';
-    foreach([' ',', = a', 'hi=hello', 'hi= hello', 'hi => hello'] as $rule) {
-      // Ensure we reset the form state after each iteration
-      // so that we are not accidentally keeping errors from previous iterations.
+    foreach ([' ', ', = a', 'hi=hello', 'hi= hello', 'hi => hello'] as $rule) {
+      // Ensure we reset the form state after each iteration so that
+      // we are not accidentally keeping errors from previous iterations.
       $form_state->clearErrors();
 
       $form_state->setValue($field, $rule);
@@ -200,11 +196,10 @@ class ConfigRRulesFormTest extends UnitTestCase {
         "We expected errors for '$rule' but there were not any.");
     }
 
-
     // Valid words:
-    foreach(['hi = hello', 'yes = no', 'a = b'] as $rule) {
-      // Ensure we reset the form state after each iteration
-      // so that we are not accidentally keeping errors from previous iterations.
+    foreach (['hi = hello', 'yes = no', 'a = b'] as $rule) {
+      // Ensure we reset the form state after each iteration so that
+      // we are not accidentally keeping errors from previous iterations.
       $form_state->clearErrors();
 
       $form_state->setValue($field, $rule);
@@ -214,6 +209,5 @@ class ConfigRRulesFormTest extends UnitTestCase {
         "The replacement '$rule' should be valid but there are form errors for some reason.");
     }
   }
-
 
 }

--- a/trpcultivate_phenotypes/tests/src/Unit/ConfigWatermarkFormTest.php
+++ b/trpcultivate_phenotypes/tests/src/Unit/ConfigWatermarkFormTest.php
@@ -1,32 +1,28 @@
 <?php
 
-/**
- * @file
- * Unit test of Watermark configuration page.
- */
-
 namespace Drupal\Tests\trpcultivate_phenotypes\Unit;
 
-use Drupal\trpcultivate_phenotypes\Form\TripalCultivatePhenotypesWatermarkSettingsForm;
 use Drupal\Core\Config\Config;
-use Drupal\Core\Form\FormState;
-use Drupal\Tests\UnitTestCase;
 use Drupal\Core\Config\ConfigFactoryInterface;
-use Drupal\Core\StringTranslation\TranslationInterface;
-use Drupal\Core\Messenger\MessengerInterface;
-use \Drupal\Core\File\FileUrlGeneratorInterface;
+use Drupal\Core\Config\TypedConfigManagerInterface;
 use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Core\File\FileUrlGeneratorInterface;
+use Drupal\Core\Form\FormState;
+use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\Tests\UnitTestCase;
+use Drupal\trpcultivate_phenotypes\Form\TripalCultivatePhenotypesWatermarkSettingsForm;
 
 /**
-  *  Class definition ConfigWatermarkFormTest.
-  *
-  * @coversDefaultClass Drupal\trpcultivate_phenotypes\Form\TripalCultivatePhenotypesWatermarkSettingsForm
-  * @group trpcultivate_phenotypes
-  */
+ * Class definition ConfigWatermarkFormTest.
+ *
+ * @coversDefaultClass Drupal\trpcultivate_phenotypes\Form\TripalCultivatePhenotypesWatermarkSettingsForm
+ * @group trpcultivate_phenotypes
+ */
 class ConfigWatermarkFormTest extends UnitTestCase {
+
   /**
-   * Initialization of container, configurations, service
-   * and service class required by the test.
+   * {@inheritdoc}
    */
   protected function setUp(): void {
     parent::setUp();
@@ -39,9 +35,9 @@ class ConfigWatermarkFormTest extends UnitTestCase {
     // a configuration settings. Called in validateForm().
     $watermark_config_mock = $this->prophesize(Config::class);
     $watermark_config_mock->get('trpcultivate.phenotypes.watermark')->willReturn([
-      'charts' => false,
-      'image' => null,
-      'file_ext' => ['png', 'gif']
+      'charts' => FALSE,
+      'image' => NULL,
+      'file_ext' => ['png', 'gif'],
     ]);
     $watermark_config_mock->get('trpcultivate.phenotypes.directory.watermark')
       ->willReturn('public://TripalCultivatePhenotypes/watermark/');
@@ -55,19 +51,23 @@ class ConfigWatermarkFormTest extends UnitTestCase {
     // Isolated configuration for watermark configuration.
     $watermark_config = $all_config_mock->reveal();
 
-    // Class WatermarkForm class instance.
-    $watermark_form = new TripalCultivatePhenotypesWatermarkSettingsForm($watermark_config);
+    // Typed Config Manager requirement for ConfigForm dependancy injection.
+    $typed_config_mock = $this->prophesize(TypedConfigManagerInterface::class);
+    $typed_config = $typed_config_mock->reveal();
 
-    // Requirement of the container
-    //  -- Translation
+    // Class WatermarkForm class instance.
+    $watermark_form = new TripalCultivatePhenotypesWatermarkSettingsForm($watermark_config, $typed_config);
+
+    // Requirement of the container.
+    // -- Translation.
     $mock = $this->prophesize(TranslationInterface::class);
     $translation = $mock->reveal();
     $watermark_form->setStringTranslation($translation);
-    //  -- Messenger.
+    // -- Messenger.
     $mock = $this->prophesize(MessengerInterface::class);
     $messenger = $mock->reveal();
     $watermark_form->setMessenger($messenger);
-    //  -- File URL Generator.
+    // -- File URL Generator.
     $mock = $this->prophesize(FileUrlGeneratorInterface::class);
     $fileGenerator = $mock->reveal();
     $container->set('file_url_generator', $fileGenerator);
@@ -112,10 +112,12 @@ class ConfigWatermarkFormTest extends UnitTestCase {
 
     $form_state->clearErrors();
 
-    // Validate that when choosing not to watermark, an image file is not required.
+    // Validate that when choosing not to watermark,
+    // an image file is not required.
     $form_state->setValue('charts', 0);
     $form_state->setValue('file', []);
     $watermark->validateForm($form, $form_state);
     $this->assertFalse($form_state->hasAnyErrors());
   }
+
 }

--- a/trpcultivate_phenotypes/trpcultivate_phenotypes.info.yml
+++ b/trpcultivate_phenotypes/trpcultivate_phenotypes.info.yml
@@ -2,8 +2,8 @@ name: Phenotypic Data API
 type: module
 description: Provides services and plugins to support common functionality within this package.
 package: "TripalCultivate: Phenotypes"
-core_version_requirement: ^10
+core_version_requirement: ^10 | ^11
 dependencies:
-  - tripal
-  - tripal_chado
-  - trpcultivate
+  - tripal:tripal
+  - tripal:tripal_chado
+  - tripalcultivate:trpcultivate


### PR DESCRIPTION
**Issue #125**

## Motivation

<!-- This can usually be copied from the issue. Please do not just say, go see issue but instead copy the relevant details here. -->

We need to update the automated testing grid to test these versions and fix any issues that crop up. We also need to add these versions to our automated docker builds. It may be worth separating our current image into a base and module just like I did in Tripal core for faster build times and easier testing.

## What does this PR do?
<!-- Please describe each things this PR does.
     For example, a PR may 1) solve a specific bug,
     2) create an automated test to ensure it doesn't return. -->

- [x] Update GitHub workflows to include Drupal 10.5, 11.0, + 11.1 and remove 10.2.
- [x] Fix any issues that the automated tests reveal.
- [x] Update devcontainer to run on Drupal 11.1 and to use the new base image.
- [x] Update README testing grid and associated workflows.

## Testing

### Automated Testing
<!-- Please describe each automated test this PR creates
     and provide a list of the assertions it makes using casual language.
     Do not just say things like "asserts the array is not empty"
     but rather say "Ensures that the return value of method X
     with these parameters is not an empty array". -->

This PR does not add any additional automated tests. Instead it simply expands the versions these tests are ran on. 

### Manual Testing
<!-- Describe in detail how someone should manually test this functionality.
     Make sure to include whether they need to build a docker from scratch,
     create any records, configure anything, etc. -->

1. Checkout this branch locally, open it in VSCode and "Reopen in Container".
2. Confirm that devcontainer builds properly (i.e. no screaming error 😉) and open the webpage in the browser to confirm versions. Note it is now building Drupal 11.1
<img width="1178" alt="Screenshot 2024-11-21 at 4 10 40 PM" src="https://github.com/user-attachments/assets/8d892f07-803b-478a-8bf8-48ea1dbabdc9">

3. Also check the README on this branch by going to the following link and confirm the testing grid renders properly with it's badges. 
https://github.com/TripalCultivate/TripalCultivate-Phenotypes/tree/g5.125-supportD11?tab=readme-ov-file#automated-testing
<img width="1114" alt="Screenshot 2024-11-21 at 4 49 52 PM" src="https://github.com/user-attachments/assets/9f7fb691-a226-4afc-9160-832f0acca688">


4. Configure the module for use and confirm no errors pop-up while you do so:
    a) Create an organism
    b) Go to configure ontologies (admin/tripal/extension/tripal-cultivate/phenotypes/ontology) and configure the organism
    c) Go to the trait importer and ensure it looks right

