### PR TITLE
Fixes unused variable problem

### DIFF
--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/Traits/ValidatorTraitColumnCountTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/Traits/ValidatorTraitColumnCountTest.php
@@ -82,12 +82,12 @@ class ValidatorTraitColumnCountTest extends ChadoTestKernelBase {
    *     - number_of_columns: the number of columns to expect.
    *     - strict: strict comparison flag.
    *   - Expected exception catch status and message for setter and getter:
-   *     - setter:
-   *       - catch_status: True to indicate an exception is expected.
-   *       - message: The setter exception message if catch_status is true.
-   *     - getter: getter exception message.
-   *       - catch_status: True to indicate an exception is expected.
-   *       - message: The getter exception message if catch_status is true.
+   *     - 'setter':
+   *       - 'catch_status': True to indicate an exception is expected.
+   *       - 'message': The setter exception message if catch_status is true.
+   *     - 'getter': getter exception message.
+   *       - 'catch_status': True to indicate an exception is expected.
+   *       - 'message': The getter exception message if catch_status is true.
    */
   public function provideExpectedColumnsForSetter() {
     return [

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/Traits/ValidatorTraitColumnCountTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/Traits/ValidatorTraitColumnCountTest.php
@@ -81,9 +81,13 @@ class ValidatorTraitColumnCountTest extends ChadoTestKernelBase {
    *   - Expected values set:
    *     - number_of_columns: the number of columns to expect.
    *     - strict: strict comparison flag.
-   *   - Expected exception message for both setter and getter:
-   *     - setter: setter exception message.
+   *   - Expected exception catch status and message for setter and getter:
+   *     - setter:
+   *       - catch_status: True to indicate an exception is expected.
+   *       - message: The setter exception message if catch_status is true.
    *     - getter: getter exception message.
+   *       - catch_status: True to indicate an exception is expected.
+   *       - message: The getter exception message if catch_status is true.
    */
   public function provideExpectedColumnsForSetter() {
     return [
@@ -94,8 +98,14 @@ class ValidatorTraitColumnCountTest extends ChadoTestKernelBase {
         FALSE,
         NULL,
         [
-          'setter' => 'setExpectedColumns() in validator requires an integer value greater than zero.',
-          'getter' => 'Cannot retrieve the number of expected columns as one has not been set by setExpectedColumns().',
+          'setter' => [
+            'catch_status' => TRUE,
+            'message'  => 'setExpectedColumns() in validator requires an integer value greater than zero.',
+          ],
+          'getter' => [
+            'catch_status' => TRUE,
+            'message' => 'Cannot retrieve the number of expected columns as one has not been set by setExpectedColumns().',
+          ],
         ],
       ],
 
@@ -109,8 +119,14 @@ class ValidatorTraitColumnCountTest extends ChadoTestKernelBase {
           'strict' => TRUE,
         ],
         [
-          'setter' => '',
-          'getter' => '',
+          'setter' => [
+            'catch_status' => FALSE,
+            'message' => '',
+          ],
+          'getter' => [
+            'catch_status' => FALSE,
+            'message' => '',
+          ],
         ],
       ],
     ];
@@ -159,9 +175,10 @@ class ValidatorTraitColumnCountTest extends ChadoTestKernelBase {
       $exception_message = $e->getMessage();
     }
 
+    $this->assertEquals($exception_caught, $exception['setter']['catch_status'], 'setExpectedColumns() exception catch status does not match expected status in scenario ' . $scenario);
     $this->assertEquals(
       $exception_message,
-      $exception['setter'],
+      $exception['setter']['message'],
       'Exception message does not match the expected message when trying to call setExpectedColumns() in scenario ' . $scenario
     );
 
@@ -178,9 +195,10 @@ class ValidatorTraitColumnCountTest extends ChadoTestKernelBase {
       $exception_message = $e->getMessage();
     }
 
+    $this->assertEquals($exception_caught, $exception['getter']['catch_status'], 'getExpectedColumns() exception catch status does not match expected status in scenario ' . $scenario);
     $this->assertEquals(
       $exception_message,
-      $exception['getter'],
+      $exception['getter']['message'],
       'Exception message does not match the expected message when trying to call getExpectedColumns() in scenario ' . $scenario
     );
 


### PR DESCRIPTION
**Issue #[#120 ]** Test for Validator Trait ColumnCount is missing checks for exception status

## Motivation
PHP Sniffer shows test method in class ValidatorTraitColumnCountTest.php has unused variable $exception_caught on lines 151, 158, 169, and 177.

Include an expected outcome to the data provider and implement an assert test instead of removing the variable as the proposed fix.

<!-- This can usually be copied from the issue. Please do not just say, go see issue but instead copy the relevant details here. -->

## What does this PR do?
*Please describe each things this PR does. For example, a PR may 1) solve a specific bug, 2) create an automated test to ensure it doesn't return.*

1. It updates the data provider to include expected outcome pertaining to whether a scenario will throw an exception or not.
2. Implement test to compare the variable to the expected value.

