### PR TITLE
Fixes empty row bug

### DIFF
--- a/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
+++ b/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
@@ -590,10 +590,35 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
     $storage[$this->validation_result] = $validation_feedback;
     $form_state->setStorage($storage);
 
-    if ($failed_validator === TRUE) {
+    // Check if the $validation_feedback contains 'fail' or 'todo' status.
+    // If either is found, prevent form submission.
+    $submit_form = TRUE;
+
+    foreach ($validation_feedback as $feedback_item) {
+      if ($feedback_item['status'] == 'todo' || $feedback_item['status'] == 'fail') {
+        $submit_form = FALSE;
+
+        // No need to inspect other validators, a single instance of fail/todo
+        // is sufficient to prevent form submission.
+        break;
+      }
+    }
+
+    if ($submit_form === FALSE) {
+      // Provide a general error message indicating that input values and/or the
+      // data file may contain one or more errors.
+      \Drupal::messenger()
+        ->addError('Your file import was not successful. Please check the Validation Result Window for errors and try again.');
+
       // Prevent this form from submitting and reload form with all the
       // validation failures in the storage system.
       $form_state->setRebuild(TRUE);
+    }
+    else {
+      // Display a successful message to user when file import was
+      // without any error.
+      \Drupal::messenger()
+        ->addStatus('<b>Your file import was successful and a Job Process Request has been created to securely save your data.</b>');
     }
   }
 

--- a/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
+++ b/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
@@ -3,6 +3,7 @@
 namespace Drupal\trpcultivate_phenotypes\Plugin\TripalImporter;
 
 use Drupal\Core\Entity\EntityTypeManager;
+use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Render\Renderer;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
@@ -144,6 +145,13 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
   protected Renderer $service_Renderer;
 
   /**
+   * The Drupal Messenger Service.
+   *
+   * @var \Drupal\Core\Messenger\MessengerInterface
+   */
+  protected $service_Messenger;
+
+  /**
    * Used to reference the validation result summary in the form.
    *
    * @var string
@@ -173,6 +181,8 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
    *   The service used to generate the termplate file.
    * @param Drupal\Core\Render\Renderer $renderer
    *   The Drupal renderer service.
+   * @param \Drupal\Core\Messenger\MessengerInterface $messenger
+   *   The Drupal messenger service.
    */
   public function __construct(
     array $configuration,
@@ -185,6 +195,7 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
     EntityTypeManager $service_entityTypeManager,
     TripalCultivatePhenotypesFileTemplateService $service_FileTemplate,
     Renderer $renderer,
+    MessengerInterface $messenger,
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition, $chado_connection);
 
@@ -196,6 +207,7 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
     $this->service_entityTypeManager = $service_entityTypeManager;
     $this->service_FileTemplate = $service_FileTemplate;
     $this->service_Renderer = $renderer;
+    $this->service_Messenger = $messenger;
   }
 
   /**
@@ -213,6 +225,7 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
       $container->get('entity_type.manager'),
       $container->get('trpcultivate_phenotypes.template_generator'),
       $container->get('renderer'),
+      $container->get('messenger'),
     );
   }
 
@@ -353,7 +366,7 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
     // This is a reminder to user about expected trait data.
     $phenotypes_minder = $this->t('This importer allows for the upload of phenotypic trait dictionaries in preparation
       for uploading phenotypic data. <br /><strong>This importer Does NOT upload phenotypic measurements.</strong>');
-    \Drupal::messenger()->addWarning($phenotypes_minder);
+    $this->service_Messenger->addWarning($phenotypes_minder);
 
     // Field Genus:
     // Prepare select options with only active genus.
@@ -362,7 +375,7 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
 
     if (!$active_genus) {
       $phenotypes_minder = $this->t('This module is <strong>NOT configured</strong> to import Traits for analyzed phenotypes.');
-      \Drupal::messenger()->addWarning($phenotypes_minder);
+      $this->service_Messenger->addWarning($phenotypes_minder);
     }
 
     // If there is only one genus, it should be the default.
@@ -398,6 +411,9 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
    * {@inheritdoc}
    */
   public function formSubmit($form, &$form_state) {
+    // Display successful message to user if file import was without any error.
+    $this->service_Messenger
+      ->addStatus($this->t('<b>Your file import was successful and a Job Process Request has been created to securely save your data.</b>'));
   }
 
   /**
@@ -607,18 +623,12 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
     if ($submit_form === FALSE) {
       // Provide a general error message indicating that input values and/or the
       // data file may contain one or more errors.
-      \Drupal::messenger()
-        ->addError('Your file import was not successful. Please check the Validation Result Window for errors and try again.');
+      $this->service_Messenger
+        ->addError($this->t('Your file import was not successful. Please check the Validation Result Window for errors and try again.'));
 
       // Prevent this form from submitting and reload form with all the
       // validation failures in the storage system.
       $form_state->setRebuild(TRUE);
-    }
-    else {
-      // Display a successful message to user when file import was
-      // without any error.
-      \Drupal::messenger()
-        ->addStatus('<b>Your file import was successful and a Job Process Request has been created to securely save your data.</b>');
     }
   }
 

--- a/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterFormValidateTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterFormValidateTest.php
@@ -491,6 +491,27 @@ class TraitImporterFormValidateTest extends ChadoTestKernelBase {
         );
       }
     }
+
+    // Assert that the default value of genus field is the genus
+    // entered/selected, indicating that on form validate error, the form was
+    // not submitted and reloaded with the genus value as default.
+    $this->assertEquals(
+      $form_state->getValue('genus'),
+      $submitted_genus,
+      'The import form should set the default value of genus to the genus entered if the form was not submitted due to validation error.'
+    );
+
+    // If the form was not submitted due to validation error, check to ensure
+    // that no Tripal Job was created in the process.
+    $tripal_jobs = $this->chado_connection->query(
+      'SELECT job_id FROM {tripal_jobs} ORDER BY job_id DESC LIMIT 1'
+    )
+      ->fetchField();
+
+    $this->assertFalse(
+      $tripal_jobs,
+      'A failed import due to validation error that did not submit should not create a job request.'
+    );
   }
 
 }

--- a/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterRunTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterRunTest.php
@@ -159,6 +159,7 @@ class TraitImporterRunTest extends ChadoTestKernelBase {
       $this->container->get('entity_type.manager'),
       $this->container->get('trpcultivate_phenotypes.template_generator'),
       $this->container->get('renderer'),
+      $this->container->get('messenger'),
     );
 
   }


### PR DESCRIPTION
**Issue #117 - File with only a header row and empty row pass validation and submit a Tripal Job.

## Motivation

A bug has been confirmed that when importing a data file with just a column header, the form will get submitted. In addition to form being submitted, A Tripal Jobs is created. 


<!-- This can usually be copied from the issue. Please do not just say, go see issue but instead copy the relevant details here. -->

## What does this PR do?
*Please describe each things this PR does. For example, a PR may 1) solve a specific bug, 2) create an automated test to ensure it doesn't return.*

This PR:
1. solves both issues of form being submitted and Tripal job being created.
2. displays an error message when import has validation error and if the import was successful.
3. adds assert cases to check that form was not submitted and job was not created.

<img width="544" alt="image" src="https://github.com/user-attachments/assets/7f127cd5-5b9f-4312-8c84-f37926eb65ea" />

<img width="549" alt="image" src="https://github.com/user-attachments/assets/4b4bacd6-1e3d-41b8-97d8-532016ef60de" />

## Testing

### Manual Testing
*Describe in detail how someone should manually test this functionality.*
*Make sure to include whether they need to build a docker from scratch, create any records, etc.*

1. Fully setup a clone site with the phenotypes module installed and activated.
4. Create an organism and configure the genus accordingly.
5. Prepare 2 data files where one has error and the other is valid data file.
6. Upload each file and compare the status messages as shown in the screenshots above.
7. Upload a file with just the header row, alternatively under test/fixtures a test file with the same setup is also available.
8. Test the the form did not submit and no job was initiated.
