### PR TITLE
Add cases to valid file delimiter validator

### DIFF
--- a/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
+++ b/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
@@ -1086,7 +1086,8 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
           ($validation_result['case'] == 'None of the delimiters supported by the file type was used')) {
         $table_case = 'unsupported';
       }
-      elseif ($validation_result['case'] == 'Raw row is not delimited') {
+      elseif (($validation_result['case'] == 'Raw row exceeds number of strict columns') ||
+            ($validation_result['case'] == 'Raw row has insufficient number of columns')) {
         $table_case = 'delimited';
       }
 

--- a/trpcultivate_phenotypes/src/Plugin/Validators/ValidDelimitedFile.php
+++ b/trpcultivate_phenotypes/src/Plugin/Validators/ValidDelimitedFile.php
@@ -97,36 +97,33 @@ class ValidDelimitedFile extends TripalCultivatePhenotypesValidatorBase {
       ];
     }
 
-    // With the list of delimiters identified in the raw row, try each delimiter
-    // separately to see if number of values is the expected number of columns.
-    // Store every delimiter that failed into the failed delimiters array.
-    $delimiters_failed = [];
+    $columns = TripalCultivatePhenotypesValidatorBase::splitRowIntoColumns($raw_row, $input_file_mime_type);
+    $no_cols = count($columns);
 
-    foreach ($delimiters_used as $delimiter) {
-      $columns = TripalCultivatePhenotypesValidatorBase::splitRowIntoColumns($raw_row, $input_file_mime_type);
-
+    if ($no_cols > $expected_columns['number_of_columns']) {
+      // The line has more columns than expected.
       if ($expected_columns['strict']) {
-        // A strict comparison - exact match only.
-        if (count($columns) != $expected_columns['number_of_columns']) {
-          array_push($delimiters_failed, $delimiter);
-        }
-      }
-      else {
-        // Not a strict comparison - at least x number of columns.
-        if (count($columns) < $expected_columns['number_of_columns']) {
-          array_push($delimiters_failed, $delimiter);
-        }
+        return [
+          'case' => 'Raw row exceeds number of strict columns',
+          'valid' => FALSE,
+          'failedItems' => [
+            'raw_row' => $raw_row,
+            'expected_columns' => $expected_columns['number_of_columns'],
+            'strict' => $expected_columns['strict'],
+          ],
+        ];
       }
     }
 
-    // If the failed delimiters array contains the same number of delimiters
-    // attempted, then every delimiter failed to split the line as required.
-    if ($delimiters_used == $delimiters_failed) {
+    if ($no_cols < $expected_columns['number_of_columns']) {
+      // The line has less column than expected.
       return [
-        'case' => 'Raw row is not delimited',
+        'case' => 'Raw row has insufficient number of columns',
         'valid' => FALSE,
         'failedItems' => [
           'raw_row' => $raw_row,
+          'expected_columns' => $expected_columns['number_of_columns'],
+          'strict' => $expected_columns['strict'],
         ],
       ];
     }

--- a/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterFormValidateTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterFormValidateTest.php
@@ -220,7 +220,7 @@ class TraitImporterFormValidateTest extends ChadoTestKernelBase {
         'valid_delimited_file' => [
           'title' => 'Lines are properly delimited',
           'status' => 'fail',
-          'details' => 'Raw row has insufficient number of columns at row',
+          'details' => 'This importer requires a strict number of 6 columns for each line. The following lines do not contain the expected number of columns.',
         ],
         'valid_header' => ['status' => 'todo'],
         'empty_cell' => ['status' => 'todo'],
@@ -240,7 +240,7 @@ class TraitImporterFormValidateTest extends ChadoTestKernelBase {
         'valid_delimited_file' => [
           'title' => 'Lines are properly delimited',
           'status' => 'fail',
-          'details' => 'Raw row has insufficient number of columns at row',
+          'details' => 'This importer requires a strict number of 6 columns for each line. The following lines do not contain the expected number of columns.',
         ],
         // Since the header row has the correct number of columns, validation
         // for valid_header is expected to pass.

--- a/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterFormValidateTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterFormValidateTest.php
@@ -220,7 +220,7 @@ class TraitImporterFormValidateTest extends ChadoTestKernelBase {
         'valid_delimited_file' => [
           'title' => 'Row is properly delimited',
           'status' => 'fail',
-          'details' => 'Raw row is not delimited',
+          'details' => 'Raw row has insufficient number of columns at row',
         ],
         'valid_header' => ['status' => 'todo'],
         'empty_cell' => ['status' => 'todo'],
@@ -240,7 +240,7 @@ class TraitImporterFormValidateTest extends ChadoTestKernelBase {
         'valid_delimited_file' => [
           'title' => 'Row is properly delimited',
           'status' => 'fail',
-          'details' => 'Raw row is not delimited',
+          'details' => 'Raw row has insufficient number of columns at row',
         ],
         // Since the header row has the correct number of columns, validation
         // for valid_header is expected to pass.

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorValidDelimitedFileTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorValidDelimitedFileTest.php
@@ -107,22 +107,45 @@ class ValidatorValidDelimitedFileTest extends ChadoTestKernelBase {
         ],
       ],
 
-      // #2: Not the expected number of columns (strict comparison).
+      // #2: Not the expected number of columns (more and strict comparison).
       [
-        'column number mismatch',
+        'column number mismatch - more',
+        "Data Value One\tData Value Two\tData Value Three\tData Value Four\tData Value Five",
+        [
+          'number_of_columns' => 4,
+          'strict' => TRUE,
+        ],
+        [
+          'case' => 'Raw row exceeds number of strict columns',
+          'valid' => FALSE,
+          'failedItems' => [
+            'raw_row' => "Data Value One\tData Value Two\tData Value Three\tData Value Four\tData Value Five",
+            'expected_columns' => 4,
+            'strict' => TRUE,
+          ],
+        ],
+      ],
+
+      // #3: Not the expected number of columns (less and strict comparison).
+      [
+        'column number mismatch - less',
         "Data Value One\tData Value Two\tData Value Three",
         [
           'number_of_columns' => 4,
           'strict' => TRUE,
         ],
         [
-          'case' => 'Raw row is not delimited',
+          'case' => 'Raw row has insufficient number of columns',
           'valid' => FALSE,
-          'failedItems' => ['raw_row' => "Data Value One\tData Value Two\tData Value Three"],
+          'failedItems' => [
+            'raw_row' => "Data Value One\tData Value Two\tData Value Three",
+            'expected_columns' => 4,
+            'strict' => TRUE,
+          ],
         ],
       ],
 
-      // #3: Not the expected number of columns (not strict comparison).
+      // #4: Not the expected number of columns (not strict comparison).
       [
         'column number failed minimum',
         "Data Value One\tData Value Two\tData Value Three",
@@ -131,13 +154,17 @@ class ValidatorValidDelimitedFileTest extends ChadoTestKernelBase {
           'strict' => FALSE,
         ],
         [
-          'case' => 'Raw row is not delimited',
+          'case' => 'Raw row has insufficient number of columns',
           'valid' => FALSE,
-          'failedItems' => ['raw_row' => "Data Value One\tData Value Two\tData Value Three"],
+          'failedItems' => [
+            'raw_row' => "Data Value One\tData Value Two\tData Value Three",
+            'expected_columns' => 4,
+            'strict' => FALSE,
+          ],
         ],
       ],
 
-      // #4: Line has 2 different delimiters (tab + comma) where one is used to
+      // #5: Line has 2 different delimiters (tab + comma) where one is used to
       // delimit values and the other exists within the values.
       [
         'two delimiters used',
@@ -153,7 +180,7 @@ class ValidatorValidDelimitedFileTest extends ChadoTestKernelBase {
         ],
       ],
 
-      // #5: Valid raw row and expecting exactly 4 columns.
+      // #6: Valid raw row and expecting exactly 4 columns.
       [
         'valid raw row with exact columns',
         "Data Value One\tData Value Two\tData Value Three\tData Value Four",
@@ -168,7 +195,7 @@ class ValidatorValidDelimitedFileTest extends ChadoTestKernelBase {
         ],
       ],
 
-      // #6: Valid raw row and expecting at least 3 columns.
+      // #7: Valid raw row and expecting at least 3 columns.
       [
         'valid raw row with minimum columns',
         "Data Value One\tData Value Two\tData Value Three\tData Value Four",
@@ -183,7 +210,7 @@ class ValidatorValidDelimitedFileTest extends ChadoTestKernelBase {
         ],
       ],
 
-      // #7: Raw row has one column with strict flag set to FALSE (mininum).
+      // #8: Raw row has one column with strict flag set to FALSE (mininum).
       [
         'one column with strict set to false',
         "Data Value One",
@@ -198,7 +225,7 @@ class ValidatorValidDelimitedFileTest extends ChadoTestKernelBase {
         ],
       ],
 
-      // #8: Raw row has one column with strict flag set to TRUE (exact match).
+      // #9: Raw row has one column with strict flag set to TRUE (exact match).
       [
         'one column with strict flag set to true',
         "Data Value One",


### PR DESCRIPTION
**Issue #115 ** G4.115 Case strings in ValidDelimitedFile validator may need reconsidering

## Motivation
Create a more specific case the valid file validator to report if line has insufficient number of columns or exceeds number of columns expected.

<!-- This can usually be copied from the issue. Please do not just say, go see issue but instead copy the relevant details here. -->

## What does this PR do?
*Please describe each things this PR does. For example, a PR may 1) solve a specific bug, 2) create an automated test to ensure it doesn't return.*

1. Create a case for lines values that exceed expected number of columns.
2. Create a case for line values that is less than the expected number of columns.
3. Add test scenarios to test new cases.

## Automated test
Class: DataFileDelimiterTest - testDataFileRowIsDelimited()

1. Raw row is an empty string.
2. None of the supported delimiters was used.
3. Unexpected number of columns (more columns returned with strict comparison set to true).
4. Unexpected number of columns (less columns returned with strict comparison set to true).
5. Unexpected number of columns (less columns returned with strict comparison set to false).
6. Line has 2 delimiters detected
7. Valid line expecting 4 values and strict comparison.
8. Valid line expecting at least 3 values and not strict comparison.
9. Line has one value and not strict comparison.
10. Line has one value and strict comparison.

## Manual test
```
// Setup
$validator = \Drupal::service('plugin.manager.trpcultivate_validator')
  ->createInstance('valid_delimited_file');

$validator->setSupportedMimeTypes([
  'tsv',
  'txt',
]);

$validator->setFileMimeType('text/tab-separated-values');

// Comparison Flag:

// Adjust values:
// Params: number of columns expected and comparison flag.
$number_of_columns = 4;
$comparison_flag = TRUE;


$validator->setExpectedColumns($number_of_columns, $comparison_flag);

// Test
$data_values = [
  'Value 1',
  'Value 2',
  'Value 3',
  'Value 4'
];

$raw_row_input = implode("\t", $data_values);
$validation_status = $validator->validateRawRow($raw_row_input);
dpm($validation_status);
```

Paste this code into a fully setup Tripal site with phenotypes modules installed and activated.

Comparison Flag:
If set to true, the delimiter validator must match the exact number of columns.
If set to false, the delimiter validator must match at least the number of columns.