### PR TITLE
Updates file template generator service

### DIFF
--- a/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
+++ b/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
@@ -1483,6 +1483,10 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
    * notes are laid out using the theme 'importer_header'. This is rendered
    * using the referenced TWIG file below.
    *
+   * @return string
+   *   The fully rendered HTML string produced by the 'importer_header' theme
+   *   with the pertinent variables supplied by this method.
+   *
    * A template geneartor service is utilized to provide a downloadable file
    * template, pre-configured to contain all headers required. The link to
    * this template file is also formatted using the theme 'importer_header'.

--- a/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
+++ b/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
@@ -1484,7 +1484,7 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
    * service is utilized to provide a downloadable file template, pre-configured
    * to contain all headers required.
    *
-   * @see Tripal\src\TripalImporter\TripalImporterBase.php
+   * @see Drupal\tripal\TripalImporter\TripalImporterBase::describeUploadFileFormat()
    * @see templates\trpcultivate-phenotypes-template-importer-header.html.twig
    */
   public function describeUploadFileFormat() {

--- a/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
+++ b/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
@@ -831,12 +831,24 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
   public function describeUploadFileFormat() {
     // A template file has been generated and is ready for download.
     $importer_id = $this->pluginDefinition['id'];
+    // The file extension of the template file.
+    // Define file properties of the template file.
+    $file_properties = [];
+    // Select the first item in the file type plugin definition list and use it
+    // as the primary file extension of the template file.
+    $file_extension = $this->plugin_definition['file_types'][0];
+    $file_properties['extension'] = $file_extension;
+    // Mime type to extension mapping.
+    $file_properties['mime'] = file_mime_type($file_extension);
+    // Delimiter.
+    $file_properties['delimiter'] = self::$mime_to_delimiter_mapping[$file_properties['mime']];
+
     // Only the header names are needed for making the template file, so pull
     // them out into a new array.
     $column_headers = array_column($this->headers, 'name');
 
     $file_link = $this->service_FileTemplate
-      ->generateFile($importer_id, $column_headers);
+      ->generateFile($importer_id, $column_headers, $file_properties);
 
     // Additional notes to the headers.
     $notes = $this->t('The order of the above columns is important and your file must include a header!

--- a/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
+++ b/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
@@ -1480,9 +1480,12 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
    * NOTE: This method supports full HTML markup output.
    *
    * All relevant information relating to expected column headers and usage
-   * notes are laid out using the theme 'importer_header'. A template geneartor
-   * service is utilized to provide a downloadable file template, pre-configured
-   * to contain all headers required.
+   * notes are laid out using the theme 'importer_header'. This is rendered
+   * using the referenced TWIG file below.
+   *
+   * A template geneartor service is utilized to provide a downloadable file
+   * template, pre-configured to contain all headers required. The link to
+   * this template file is also formatted using the theme 'importer_header'.
    *
    * @see Drupal\tripal\TripalImporter\TripalImporterBase::describeUploadFileFormat()
    * @see templates\trpcultivate-phenotypes-template-importer-header.html.twig

--- a/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
+++ b/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
@@ -1472,10 +1472,20 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
   }
 
   /**
-   * {@inheritdoc}
+   * Provide a more informative description about the template file.
    *
-   * @see src/TripalCultivateValidator/TripalCultivatePhenotypesValidatorBase.php
-   * @see src/TripalCultivateValidator/ValidatorTraits/FileTypes.php
+   * Class TripalImporterBase is the parent class of this method and additional
+   * documentation is available in reference link below.
+   *
+   * NOTE: This method supports full HTML markup output.
+   *
+   * All relevant information relating to expected column headers and usage
+   * notes are laid out using the theme 'importer_header'. A template geneartor
+   * service is utilized to provide a downloadable file template, pre-configured
+   * to contain all headers required.
+   *
+   * @see Tripal\src\TripalImporter\TripalImporterBase.php
+   * @see templates\trpcultivate-phenotypes-template-importer-header.html.twig
    */
   public function describeUploadFileFormat() {
     // A template file has been generated and is ready for download.

--- a/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
+++ b/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
@@ -1483,13 +1483,13 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
    * notes are laid out using the theme 'importer_header'. This is rendered
    * using the referenced TWIG file below.
    *
-   * @return string
-   *   The fully rendered HTML string produced by the 'importer_header' theme
-   *   with the pertinent variables supplied by this method.
-   *
    * A template geneartor service is utilized to provide a downloadable file
    * template, pre-configured to contain all headers required. The link to
    * this template file is also formatted using the theme 'importer_header'.
+   *
+   * @return string
+   *   The fully rendered HTML string produced by the 'importer_header' theme
+   *   with the pertinent variables supplied by this method.
    *
    * @see Drupal\tripal\TripalImporter\TripalImporterBase::describeUploadFileFormat()
    * @see templates\trpcultivate-phenotypes-template-importer-header.html.twig
@@ -1519,7 +1519,6 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
 
     // Render the header and notes/lists in a template and use the file link as
     // the value to href attribute of the link to download a template file.
-
     $supported_file_extensions = implode(', ', $file_extensions);
 
     $build = [

--- a/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
+++ b/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
@@ -26,7 +26,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *   label = @Translation("Tripal Cultivate: Phenotypic Trait Importer"),
  *   description = @Translation("Loads Traits for phenotypic data into the system. This is useful for large phenotypic datasets to ease the upload process."),
  *   file_types = {"tsv"},
- *   upload_description = @Translation("Please provide a txt or tsv data file."),
+ *   upload_description = @Translation("Please provide a data file."),
  *   upload_title = @Translation("Phenotypic Trait Data File*"),
  *   use_analysis = FALSE,
  *   require_analysis = FALSE,
@@ -1512,10 +1512,14 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
 
     // Render the header and notes/lists in a template and use the file link as
     // the value to href attribute of the link to download a template file.
+
+    $supported_file_extensions = implode(', ', $file_extensions);
+
     $build = [
       '#theme' => 'importer_header',
       '#data' => [
         'headers' => $this->headers,
+        'file_extensions' => $supported_file_extensions,
         'notes' => $notes,
         'template_file' => $file_link,
       ],

--- a/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
+++ b/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
@@ -827,35 +827,34 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
 
   /**
    * {@inheritdoc}
+   *
+   * @see src/TripalCultivateValidator/TripalCultivatePhenotypesValidatorBase.php
+   * @see src/TripalCultivateValidator/ValidatorTraits/FileTypes.php
    */
   public function describeUploadFileFormat() {
     // A template file has been generated and is ready for download.
     $importer_id = $this->pluginDefinition['id'];
-    // The file extension of the template file.
-    // Define file properties of the template file.
-    $file_properties = [];
-    // Select the first item in the file type plugin definition list and use it
-    // as the primary file extension of the template file.
-    $file_extension = $this->plugin_definition['file_types'][0];
-    $file_properties['extension'] = $file_extension;
-    // Mime type to extension mapping.
-    $file_properties['mime'] = file_mime_type($file_extension);
-    // Delimiter.
-    $file_properties['delimiter'] = self::$mime_to_delimiter_mapping[$file_properties['mime']];
 
     // Only the header names are needed for making the template file, so pull
     // them out into a new array.
     $column_headers = array_column($this->headers, 'name');
 
+    // File types 'file_types' annotation definition of this importer.
+    // The first item in the definition list will be used as the primary
+    // file extension of the template file.
+    // File MIME type and delimiter are based on mapping information defined
+    // in the validator base and file types validator trait.
+    $file_extensions = $this->plugin_definition['file_types'];
+
     $file_link = $this->service_FileTemplate
-      ->generateFile($importer_id, $column_headers, $file_properties);
+      ->generateFile($importer_id, $column_headers, $file_extensions);
 
     // Additional notes to the headers.
     $notes = $this->t('The order of the above columns is important and your file must include a header!
     If you have a single trait measured in more than one way (i.e. with multiple collection
     methods), then you should have one line per collection method with the trait repeated.');
 
-    // Render the header notes/lists template and use the file link as
+    // Render the header and notes/lists in a template and use the file link as
     // the value to href attribute of the link to download a template file.
     $build = [
       '#theme' => 'importer_header',

--- a/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
+++ b/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
@@ -1498,7 +1498,7 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
     // Additional notes to the headers.
     $notes = $this->t('The order of the above columns is important and your file must include a header!
     If you have a single trait measured in more than one way (i.e. with multiple collection
-    methods), then you should have one line per collection method with the trait repeated.');
+    methods), then you should have one line per collection method with the trait name/description repeated.');
 
     // Render the header and notes/lists in a template and use the file link as
     // the value to href attribute of the link to download a template file.

--- a/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
+++ b/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
@@ -1472,7 +1472,7 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
   }
 
   /**
-   * Provide a more informative description about the template file.
+   * Describe the upload format including column descriptions + template file.
    *
    * Class TripalImporterBase is the parent class of this method and additional
    * documentation is available in reference link below.

--- a/trpcultivate_phenotypes/src/Service/TripalCultivatePhenotypesFileTemplateService.php
+++ b/trpcultivate_phenotypes/src/Service/TripalCultivatePhenotypesFileTemplateService.php
@@ -6,6 +6,7 @@ use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\file\Entity\File;
 use Drupal\trpcultivate_phenotypes\TripalCultivateValidator\ValidatorTraits\FileTypes;
+use Drupal\trpcultivate_phenotypes\TripalCultivateValidator\TripalCultivatePhenotypesValidatorBase;
 
 /**
  * Generate data collection template file used in the importer.
@@ -58,7 +59,7 @@ class TripalCultivatePhenotypesFileTemplateService {
    * @param array $column_headers
    *   An array of column headers to be written into the template file as the
    *   column header row.
-   * @param array $file_properties
+   * @param array $file_extensions
    *   The file extension of the template file. This is taken from the the
    *   'file_type' plugin annotation definition of the Importer.
    *
@@ -68,7 +69,8 @@ class TripalCultivatePhenotypesFileTemplateService {
    * @return string
    *   Abosolute path to the template file.
    */
-  public function generateFile($importer_id, $column_headers, $file_properties) {
+  public function generateFile($importer_id, $column_headers, $file_extensions) {
+
     // Fetch the configuration relating to directory for housing data collection
     // template file. This directory had been setup during install and had / at
     // the end as defined. @see config install and schema.
@@ -76,9 +78,11 @@ class TripalCultivatePhenotypesFileTemplateService {
 
     // About the template file:
     // File extension.
-    $file_extension = $file_properties['extension'];
+    $file_extension = $file_extensions[0];
     // File MIME type.
-    $file_mime_type = $file_properties['mime'];
+    $file_mime_type = FileTypes::$extension_to_mime_mapping[$file_extension];
+    // File delimiter.
+    $file_delimiter = TripalCultivatePhenotypesValidatorBase::$mime_to_delimiter_mapping[$file_mime_type[0]];
 
     // Personalize the filename by appending display name of the current user,
     // but first sanitize it by replacing all spaces into a dash character.
@@ -111,8 +115,7 @@ class TripalCultivatePhenotypesFileTemplateService {
 
     // Convert the headers array into a tsv string value and post into the first
     // line of the file.
-    $file_delimiter = ($file_properties['extension'] == 'tsv') ? "\t" : $file_properties['delimiter'];
-    $fileheaders = implode($file_delimiter, $column_headers) . "\n# DELETE THIS LINE --- START DATA HERE AND USE TAB KEY #";
+    $fileheaders = implode($file_delimiter[0], $column_headers) . "\n# DELETE THIS LINE --- START DATA HERE AND USE TAB KEY #";
     file_put_contents($fileuri, $fileheaders);
 
     // Save.

--- a/trpcultivate_phenotypes/src/Service/TripalCultivatePhenotypesFileTemplateService.php
+++ b/trpcultivate_phenotypes/src/Service/TripalCultivatePhenotypesFileTemplateService.php
@@ -111,14 +111,14 @@ class TripalCultivatePhenotypesFileTemplateService {
     // download a template file. File uri of the created file.
     $fileuri = $file->getFileUri();
 
-    // Before we can write contents, we need to ensure the upper level folders
-    // exist.
+    // Before we can write contents, we need to ensure the upper level
+    // folders exist.
     if (!file_exists($dir_template_file)) {
       mkdir($dir_template_file, 0777, TRUE);
     }
 
-    // Convert the headers array into a tsv string value and post into the first
-    // line of the file.
+    // Convert the headers array into a delimited string value and post into the
+    // first line of the file.
     $fileheaders = implode($file_delimiter[0], $column_headers) . "\n# DELETE THIS LINE --- START DATA HERE AND USE APPROPRIATE DELIMITER/VALUE SEPARATOR KEY #";
     file_put_contents($fileuri, $fileheaders);
 

--- a/trpcultivate_phenotypes/src/Service/TripalCultivatePhenotypesFileTemplateService.php
+++ b/trpcultivate_phenotypes/src/Service/TripalCultivatePhenotypesFileTemplateService.php
@@ -67,7 +67,7 @@ class TripalCultivatePhenotypesFileTemplateService {
    *   of multiple file type values were provided.
    *
    * @return string
-   *   Relative path to the generated template file.
+   *   The relative path to the generated template file.
    *
    * @see src/TripalCultivateValidator/TripalCultivatePhenotypesValidatorBase.php
    * @see src/TripalCultivateValidator/ValidatorTraits/FileTypes.php

--- a/trpcultivate_phenotypes/src/Service/TripalCultivatePhenotypesFileTemplateService.php
+++ b/trpcultivate_phenotypes/src/Service/TripalCultivatePhenotypesFileTemplateService.php
@@ -1,13 +1,7 @@
 <?php
 
-/**
- * @file
- * Tripal Cultivate Phenotypes File Template service definition.
- */
-
 namespace Drupal\trpcultivate_phenotypes\Service;
 
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\file\Entity\File;
@@ -16,39 +10,56 @@ use Drupal\file\Entity\File;
  * Class TripalCultivatePhenotypesFileTemplateService.
  */
 class TripalCultivatePhenotypesFileTemplateService {
-  // Module configuration.
+
+  /**
+   * Module configuration.
+   *
+   * @var Drupal\Core\Config\ConfigFactoryInterface
+   */
   protected $config;
 
-  // Drupal current user.
+  /**
+   * Drupal user account.
+   *
+   * @var Drupal\Core\Session\AccountInterface
+   */
   protected $user;
 
   /**
    * Constructor.
+   *
+   * @param Drupal\Core\Config\ConfigFactoryInterface $config
+   *   Configuration interface.
+   * @param Drupal\Core\Session\AccountInterface $user
+   *   Account interface.
    */
-  public function __construct(ConfigFactoryInterface $config, AccountInterface $current_user) {
+  public function __construct(ConfigFactoryInterface $config, AccountInterface $user) {
+    // Set the configuration.
     $this->config = $config->get('trpcultivate_phenotypes.settings');
-    $this->user   = $current_user;
+
+    // Set the current user.
+    $this->user = $user;
   }
 
   /**
    * Generate template file.
    *
    * @param string $importer_id
-   *   String, The plugin ID annotation definition.
+   *   String, The plugin ID annotation definition used to prefix the filename.
    * @param array $column_headers
-   *   Array keys (column headers) as defined by the header property in the importer.
+   *   An array of column headers to be written into the template file as the
+   *   column header row.
    *
-   * @return path
-   *   Path to the template file.
+   * @return string
+   *   Abosolute path to the template file.
    */
   public function generateFile($importer_id, $column_headers) {
-    // Fetch the configuration relating to directory for housing data collection template file.
-    // This directory had been setup during install and had / at the end as defined.
-    // @see config install and schema.
+    // Fetch the configuration relating to directory for housing data collection
+    // template file. This directory had been setup during install and had / at
+    // the end as defined. @see config install and schema.
     $dir_template_file = $this->config->get('trpcultivate.phenotypes.directory.template_file');
 
     // About the template file:
-
     // File extension.
     $fileextension = 'tsv';
     // MIME: TSV type file.
@@ -66,7 +77,7 @@ class TripalCultivatePhenotypesFileTemplateService {
     $file = File::create([
       'filename' => $filename,
       'filemime' => $filemime,
-      'uri' => $dir_template_file . $filename
+      'uri' => $dir_template_file . $filename,
     ]);
 
     // Mark file for deletion during a Drupal maintenance.
@@ -76,13 +87,12 @@ class TripalCultivatePhenotypesFileTemplateService {
 
     // Write the contents: headers into the file created and serve the path back
     // to the calling Importer as value to the href attribute of link to download a template file.
-
     // File uri of the created file.
     $fileuri = $file->getFileUri();
 
     // Before we can write contents, we need to ensure the upper level folders exist.
     if (!file_exists($dir_template_file)) {
-      mkdir($dir_template_file, 0777, true);
+      mkdir($dir_template_file, 0777, TRUE);
     }
 
     // Convert the headers array into a tsv string value and post into the first line of the file.
@@ -91,4 +101,5 @@ class TripalCultivatePhenotypesFileTemplateService {
 
     return $file->createFileUrl();
   }
+
 }

--- a/trpcultivate_phenotypes/src/Service/TripalCultivatePhenotypesFileTemplateService.php
+++ b/trpcultivate_phenotypes/src/Service/TripalCultivatePhenotypesFileTemplateService.php
@@ -60,7 +60,7 @@ class TripalCultivatePhenotypesFileTemplateService {
    *   An array of column headers to be written into the template file as the
    *   column header row.
    * @param array $file_extensions
-   *   The file extension of the template file. This is taken from the the
+   *   The file extension of the template file. This is taken from the
    *   'file_type' plugin annotation definition of the Importer.
    *
    *   NOTE: Only the first item is used as the primary file extension, in case

--- a/trpcultivate_phenotypes/src/Service/TripalCultivatePhenotypesFileTemplateService.php
+++ b/trpcultivate_phenotypes/src/Service/TripalCultivatePhenotypesFileTemplateService.php
@@ -58,22 +58,27 @@ class TripalCultivatePhenotypesFileTemplateService {
    * @param array $column_headers
    *   An array of column headers to be written into the template file as the
    *   column header row.
+   * @param array $file_properties
+   *   The file extension of the template file. This is taken from the the
+   *   'file_type' plugin annotation definition of the Importer.
+   *
+   *   Only the first item is used as the primary file extension, in case of
+   *   multiple file type values were provided.
    *
    * @return string
    *   Abosolute path to the template file.
    */
-  public function generateFile($importer_id, $column_headers) {
+  public function generateFile($importer_id, $column_headers, $file_properties) {
     // Fetch the configuration relating to directory for housing data collection
     // template file. This directory had been setup during install and had / at
     // the end as defined. @see config install and schema.
     $dir_template_file = $this->config->get('trpcultivate.phenotypes.directory.template_file');
 
-    // @TODO: support for multiple file types.
     // About the template file:
     // File extension.
-    $file_extension = 'tsv';
-    // MIME: TSV type file.
-    $filemime = 'text/tab-separated-values';
+    $file_extension = $file_properties['extension'];
+    // File MIME type.
+    $file_mime_type = $file_properties['mime'];
 
     // Personalize the filename by appending display name of the current user,
     // but first sanitize it by replacing all spaces into a dash character.
@@ -86,7 +91,7 @@ class TripalCultivatePhenotypesFileTemplateService {
     // Create the file.
     $file = File::create([
       'filename' => $filename,
-      'filemime' => $filemime,
+      'filemime' => $file_mime_type,
       'uri' => $dir_template_file . $filename,
     ]);
 
@@ -106,7 +111,8 @@ class TripalCultivatePhenotypesFileTemplateService {
 
     // Convert the headers array into a tsv string value and post into the first
     // line of the file.
-    $fileheaders = implode("\t", $column_headers) . "\n# DELETE THIS LINE --- START DATA HERE AND USE TAB KEY #";
+    $file_delimiter = ($file_properties['extension'] == 'tsv') ? "\t" : $file_properties['delimiter'];
+    $fileheaders = implode($file_delimiter, $column_headers) . "\n# DELETE THIS LINE --- START DATA HERE AND USE TAB KEY #";
     file_put_contents($fileuri, $fileheaders);
 
     // Save.

--- a/trpcultivate_phenotypes/src/Service/TripalCultivatePhenotypesFileTemplateService.php
+++ b/trpcultivate_phenotypes/src/Service/TripalCultivatePhenotypesFileTemplateService.php
@@ -18,6 +18,9 @@ class TripalCultivatePhenotypesFileTemplateService {
    *
    * - FileTypes: Gets an array of all supported MIME types the importer is
    *   configured to process.
+   *
+   * @todo Update when/if $extension_to_mime_mapping is moved to a more generic
+   * class (ie. not validator specific).
    */
   use FileTypes;
 
@@ -84,7 +87,10 @@ class TripalCultivatePhenotypesFileTemplateService {
     $file_extension = $file_extensions[0];
     // See referenced file in the doc block about the mapping variables used.
     // File MIME type.
-    $file_mime_type = FileTypes::$extension_to_mime_mapping[$file_extension];
+    // @todo Should move the following 2 methods to a more generic class
+    // instead of keeping them in FileTypes and ValidatorBase which are meant
+    // for validators.
+    $file_mime_type = self::$extension_to_mime_mapping[$file_extension];
     // File delimiter.
     $file_delimiter = TripalCultivatePhenotypesValidatorBase::$mime_to_delimiter_mapping[$file_mime_type[0]];
 

--- a/trpcultivate_phenotypes/src/Service/TripalCultivatePhenotypesFileTemplateService.php
+++ b/trpcultivate_phenotypes/src/Service/TripalCultivatePhenotypesFileTemplateService.php
@@ -67,7 +67,10 @@ class TripalCultivatePhenotypesFileTemplateService {
    *   of multiple file type values were provided.
    *
    * @return string
-   *   Abosolute path to the template file.
+   *   Relative path to the generated template file.
+   *
+   * @see src/TripalCultivateValidator/TripalCultivatePhenotypesValidatorBase.php
+   * @see src/TripalCultivateValidator/ValidatorTraits/FileTypes.php
    */
   public function generateFile($importer_id, $column_headers, $file_extensions) {
 
@@ -79,6 +82,7 @@ class TripalCultivatePhenotypesFileTemplateService {
     // About the template file:
     // File extension.
     $file_extension = $file_extensions[0];
+    // See referenced file in the doc block about the mapping variables used.
     // File MIME type.
     $file_mime_type = FileTypes::$extension_to_mime_mapping[$file_extension];
     // File delimiter.
@@ -115,7 +119,7 @@ class TripalCultivatePhenotypesFileTemplateService {
 
     // Convert the headers array into a tsv string value and post into the first
     // line of the file.
-    $fileheaders = implode($file_delimiter[0], $column_headers) . "\n# DELETE THIS LINE --- START DATA HERE AND USE TAB KEY #";
+    $fileheaders = implode($file_delimiter[0], $column_headers) . "\n# DELETE THIS LINE --- START DATA HERE AND USE APPROPRIATE DELIMITER/VALUE SEPARATOR KEY #";
     file_put_contents($fileuri, $fileheaders);
 
     // Save.

--- a/trpcultivate_phenotypes/src/Service/TripalCultivatePhenotypesFileTemplateService.php
+++ b/trpcultivate_phenotypes/src/Service/TripalCultivatePhenotypesFileTemplateService.php
@@ -125,7 +125,7 @@ class TripalCultivatePhenotypesFileTemplateService {
 
     // Convert the headers array into a delimited string value and post into the
     // first line of the file.
-    $fileheaders = implode($file_delimiter[0], $column_headers) . "\n# DELETE THIS LINE --- START DATA HERE AND USE APPROPRIATE DELIMITER/VALUE SEPARATOR KEY #";
+    $fileheaders = implode($file_delimiter[0], $column_headers) . "\n# DELETE THIS LINE --- START DATA HERE AND USE APPROPRIATE DELIMITER/VALUE SEPARATOR #";
     file_put_contents($fileuri, $fileheaders);
 
     // Save.

--- a/trpcultivate_phenotypes/src/Service/TripalCultivatePhenotypesFileTemplateService.php
+++ b/trpcultivate_phenotypes/src/Service/TripalCultivatePhenotypesFileTemplateService.php
@@ -63,8 +63,8 @@ class TripalCultivatePhenotypesFileTemplateService {
    *   The file extension of the template file. This is taken from the the
    *   'file_type' plugin annotation definition of the Importer.
    *
-   *   Only the first item is used as the primary file extension, in case of
-   *   multiple file type values were provided.
+   *   NOTE: Only the first item is used as the primary file extension, in case
+   *   of multiple file type values were provided.
    *
    * @return string
    *   Abosolute path to the template file.

--- a/trpcultivate_phenotypes/templates/trpcultivate-phenotypes-template-importer-header.html.twig
+++ b/trpcultivate_phenotypes/templates/trpcultivate-phenotypes-template-importer-header.html.twig
@@ -12,7 +12,7 @@
 {{ attach_library('trpcultivate_phenotypes/trpcultivate-phenotypes-style-importer-header') }}
 
 <div id="tcp-header-notes">
-  <p>This should be a tab-separated file with the following columns:</p>
+  <p>This should be a [{{data.file_extensions}}] file with the following columns:</p>
 
   <ol id="tcp-header-notes">
     {% for header in data.headers %}

--- a/trpcultivate_phenotypes/templates/trpcultivate-phenotypes-template-importer-header.html.twig
+++ b/trpcultivate_phenotypes/templates/trpcultivate-phenotypes-template-importer-header.html.twig
@@ -21,6 +21,8 @@
     </li>
     {% endfor %}
   </ol>
+
+  <p><em>{{data.notes}}</em></p>
 </div>
 
 <div id="tcp-template-file">

--- a/trpcultivate_phenotypes/tests/src/Kernel/ServiceTemplateGeneratorTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/ServiceTemplateGeneratorTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Kernel test of Template Generator service.
- */
-
 namespace Drupal\Tests\trpcultivate_phenotypes\Kernel;
 
 use Drupal\Tests\tripal_chado\Kernel\ChadoTestKernelBase;
@@ -13,17 +8,30 @@ use Drupal\Tests\tripal_chado\Kernel\ChadoTestKernelBase;
  * Tests associated with the template file generator service.
  *
  * @group trpcultivate_phenotypes
+ * @group template_generate
  */
 class ServiceTemplateGeneratorTest extends ChadoTestKernelBase {
+
   /**
    * Modules to enable.
+   *
+   * @var array
    */
   protected static $modules = [
-    'user',
     'file',
+    'user',
     'system',
-    'trpcultivate_phenotypes'
+    'tripal',
+    'tripal_chado',
+    'trpcultivate_phenotypes',
   ];
+
+  /**
+   * Undocumented variable
+   *
+   * @var [type]
+   */
+  protected $config;
 
   /**
    * {@inheritdoc}
@@ -37,15 +45,14 @@ class ServiceTemplateGeneratorTest extends ChadoTestKernelBase {
     // Setup file configuration and schema.
     $this->installConfig(['file', 'trpcultivate_phenotypes']);
     $this->installEntitySchema('file');
+
+    $this->config = \Drupal::service('config.factory');
   }
 
+  /**
+   * Test template generator.
+   */
   public function testTemplateGeneratorService() {
-    // This is a bare-bones test of the service as it is sooo complicated
-    // to setup a test environment for reading and writing a file.
-    // @TODO: revisit when with good understanding of Drupal file system in a Kernel test.
-
-    // As is, this automated test, tests that the template generator creates a file
-    // and that the generated file has some content in it by inspecting the file size.
     $template_generator = \Drupal::service('trpcultivate_phenotypes.template_generator');
 
     // Generate a template file.
@@ -56,7 +63,34 @@ class ServiceTemplateGeneratorTest extends ChadoTestKernelBase {
     // Assert a link has been created.
     $this->assertNotNull($link, 'Failed to generate template file link.');
 
-    // Works locally but fails in actions. Importer share functional test implements the same file size check.
-    // $this->assertGreaterThanOrEqual(1, filesize($link), 'The template file generated is empty.');
+    // Assert that a file has been created in the the configured directory
+    // for template files.
+    $dir_templates = $this->config->get('trpcultivate_phenotypes.settings')
+      ->get('trpcultivate.phenotypes.directory.template_file');
+
+    $file_system = \Drupal::service('file_system')
+      ->realpath($dir_templates);
+
+    $template_file = reset(array_diff(scandir($file_system), ['..', '.']));
+
+    $this->assertStringContainsString(
+      $plugin_id,
+      $template_file,
+      'Test could not find a template file in the directory configured for template files'
+    );
+
+    // Assert that the headers were inserted into the file as the header row.
+    $file_contents = fopen($file_system . '/' . $template_file, 'r');
+    if ($file_contents) {
+      $header_row = trim(fgets($file_contents), "\n");
+      fclose($file_contents);
+    }
+
+    $this->assertEquals(
+      $header_row,
+      implode("\t", $column_headers),
+      'The template file does not contain the expected column headers'
+    );
   }
+
 }

--- a/trpcultivate_phenotypes/tests/src/Kernel/ServiceTemplateGeneratorTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/ServiceTemplateGeneratorTest.php
@@ -181,7 +181,7 @@ class ServiceTemplateGeneratorTest extends ChadoTestKernelBase {
     // Assert a link has been created.
     $this->assertNotNull($link, 'Failed to generate template file link in scenario ' . $scenario);
 
-    // Assert that a file has been created in the the configured directory
+    // Assert that a file has been created in the configured directory
     // for template files.
     $dir_templates = $this->config->get('trpcultivate_phenotypes.settings')
       ->get('trpcultivate.phenotypes.directory.template_file');

--- a/trpcultivate_phenotypes/tests/src/Kernel/ServiceTemplateGeneratorTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/ServiceTemplateGeneratorTest.php
@@ -185,8 +185,8 @@ class ServiceTemplateGeneratorTest extends ChadoTestKernelBase {
       ->get('trpcultivate.phenotypes.directory.template_file');
 
     $file_system = $this->file_system->realpath($dir_templates);
-
-    $template_file = (string) reset(array_diff(scandir($file_system), ['..', '.']));
+    $files_in_dir = array_diff(scandir($file_system), ['..', '.']);
+    $template_file = (string) reset($files_in_dir);
 
     // Filename is the expected file name.
     $this->assertEquals(

--- a/trpcultivate_phenotypes/tests/src/Kernel/ServiceTemplateGeneratorTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/ServiceTemplateGeneratorTest.php
@@ -3,6 +3,7 @@
 namespace Drupal\Tests\trpcultivate_phenotypes\Kernel;
 
 use Drupal\Tests\tripal_chado\Kernel\ChadoTestKernelBase;
+use Drupal\user\Entity\User;
 
 /**
  * Tests associated with the template file generator service.
@@ -27,11 +28,33 @@ class ServiceTemplateGeneratorTest extends ChadoTestKernelBase {
   ];
 
   /**
-   * Undocumented variable
+   * Configuration entity.
    *
-   * @var [type]
+   * @var object
    */
   protected $config;
+
+
+  /**
+   * The TripalCultivatePhenotypes File Template Service.
+   *
+   * @var Drupal\trpcultivate_phenotypes\Service\TripalCultivatePhenotypesFileTemplateService
+   */
+  protected $service_FileTemplate;
+
+  /**
+   * A test user.
+   *
+   * @var Drupal\user\Entity\User
+   */
+  protected $user;
+
+  /**
+   * File system interface.
+   *
+   * @var Drupal\Core\File\FileSystemInterface
+   */
+  protected $file_system;
 
   /**
    * {@inheritdoc}
@@ -45,20 +68,115 @@ class ServiceTemplateGeneratorTest extends ChadoTestKernelBase {
     // Setup file configuration and schema.
     $this->installConfig(['file', 'trpcultivate_phenotypes']);
     $this->installEntitySchema('file');
+    $this->installEntitySchema('user');
 
+    $this->file_system = \Drupal::service('file_system');
     $this->config = \Drupal::service('config.factory');
+    $this->service_FileTemplate = \Drupal::service('trpcultivate_phenotypes.template_generator');
+
+    // Create a user.
+    $this->user = User::create([
+      'name' => 'user-collector',
+      'roles' => ['authenticated user'],
+    ]);
+    $this->user->save();
+
+    \Drupal::currentUser()->setAccount($this->user);
   }
 
   /**
-   * Test template generator.
+   * Data Provider: provide various test scenarios of file format and headers.
+   *
+   * @return array
+   *   Each test file scenario is an array with the following values:
+   *   - A string, humnan-readable short description of the test scenario.
+   *   - A string, the importer plugin id.
+   *   - An array, the list of headers that will become the header row in file.
+   *   - An array, file properties with the following keys:
+   *     - 'extension': the file extension of the template file.
+   *     - 'mime': the MIME type of template file.
+   *     - 'delimiter': the delimiter used to separate values (ie. headers).
+   *   - An array of expected values, with the following keys:
+   *     - 'file_filename': the expected filename of the template file.
+   *     - 'file_content': the expected content (header row) of the file.
    */
-  public function testTemplateGeneratorService() {
-    $template_generator = \Drupal::service('trpcultivate_phenotypes.template_generator');
+  public function provideParametersForFileTemplateGenerator() {
+    return [
+      // #0: A tsv file.
+      [
+        'a tsv file',
+        'my-importer',
+        ['Header A', 'Header B', 'Header C'],
+        [
+          'extension' => 'tsv',
+          'mime' => 'text/tab-separated-values',
+          'delimiter' => "\t",
+        ],
+        [
+          'file_filename' => "my-importer-data-collection-template-file-user-collector.tsv",
+          'file_content' => implode("\t", ['Header A', 'Header B', 'Header C']),
+        ],
+      ],
 
-    // Generate a template file.
-    $plugin_id = 'doesnt-nned-to-be-real';
-    $column_headers = ['Header A', 'Header B', 'Header C'];
-    $link = $template_generator->generateFile($plugin_id, $column_headers);
+      // #1: A csv file.
+      [
+        'a csv file',
+        'another-importer',
+        ['Header E', 'Header F', 'Header G'],
+        [
+          'extension' => 'csv',
+          'mime' => 'text/csv',
+          'delimiter' => ",",
+        ],
+        [
+          'file_filename' => "another-importer-data-collection-template-file-user-collector.csv",
+          'file_content' => "Header E,Header F,Header G",
+        ],
+      ],
+
+      // #2: A txt file.
+      [
+        'a txt file',
+        'basic-importer',
+        ['Header X', 'Header Y', 'Header Z'],
+        [
+          'extension' => 'txt',
+          'mime' => 'text/txt',
+          'delimiter' => "<delimiter>",
+        ],
+        [
+          'file_filename' => "basic-importer-data-collection-template-file-user-collector.txt",
+          'file_content' => "Header X<delimiter>Header Y<delimiter>Header Z",
+        ],
+      ],
+    ];
+  }
+
+  /**
+   * Test file template generator service.
+   *
+   * @param string $scenario
+   *   Humnan-readable short description of the test scenario.
+   * @param string $importer_id
+   *   The importer plugin id.
+   * @param array $column_headers
+   *   The list of headers that will become the header row in file.
+   * @param array $file_properties
+   *   File properties with the following keys:
+   *     - 'extension': the file extension of the template file.
+   *     - 'mime': the MIME type of template file.
+   *     - 'delimiter': the delimiter used to separate values (ie. headers).
+   * @param array $expected
+   *   An array of expected values, with the following keys:
+   *     - 'file_filename': the expected filename of the template file.
+   *     - 'file_content': the expected content (header row) of the file.
+   *
+   * @dataProvider provideParametersForFileTemplateGenerator
+   */
+  public function testTemplateGeneratorService($scenario, $importer_id, $column_headers, $file_properties, $expected) {
+
+    // Generate the template file.
+    $link = $this->service_FileTemplate->generateFile($importer_id, $column_headers, $file_properties);
 
     // Assert a link has been created.
     $this->assertNotNull($link, 'Failed to generate template file link.');
@@ -68,17 +186,31 @@ class ServiceTemplateGeneratorTest extends ChadoTestKernelBase {
     $dir_templates = $this->config->get('trpcultivate_phenotypes.settings')
       ->get('trpcultivate.phenotypes.directory.template_file');
 
-    $file_system = \Drupal::service('file_system')
-      ->realpath($dir_templates);
+    $file_system = $this->file_system->realpath($dir_templates);
 
-    $template_file = reset(array_diff(scandir($file_system), ['..', '.']));
+    $template_file = (string) reset(array_diff(scandir($file_system), ['..', '.']));
 
-    $this->assertStringContainsString(
-      $plugin_id,
+    // Filename is the expected file name.
+    $this->assertEquals(
+      $expected['file_filename'],
       $template_file,
-      'Test could not find a template file in the directory configured for template files'
+      'The filename of the template file does not match expected file name in scenario ' . $scenario
     );
 
+    // The filename contains the importer id and username.
+    $this->assertStringContainsString(
+      $importer_id,
+      $template_file,
+      'The filename of the template file is expected to contain the importer id in scenario ' . $scenario
+    );
+
+    $this->assertStringContainsString(
+      $this->user->getAccountName(),
+      $template_file,
+      'The filename of the template file is expected to contain the importer id in scenario ' . $scenario
+    );
+
+    // The template file has the headers.
     // Assert that the headers were inserted into the file as the header row.
     $file_contents = fopen($file_system . '/' . $template_file, 'r');
     if ($file_contents) {
@@ -87,9 +219,9 @@ class ServiceTemplateGeneratorTest extends ChadoTestKernelBase {
     }
 
     $this->assertEquals(
+      $expected['file_content'],
       $header_row,
-      implode("\t", $column_headers),
-      'The template file does not contain the expected column headers'
+      'The template file does not contain the expected column headers in scenario' . $scenario
     );
   }
 

--- a/trpcultivate_phenotypes/tests/src/Kernel/ServiceTemplateGeneratorTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/ServiceTemplateGeneratorTest.php
@@ -6,7 +6,7 @@ use Drupal\Tests\tripal_chado\Kernel\ChadoTestKernelBase;
 use Drupal\user\Entity\User;
 
 /**
- * Tests associated with the template file generator service.
+ * Test file template generator service.
  *
  * @group trpcultivate_phenotypes
  * @group template_generate
@@ -33,7 +33,6 @@ class ServiceTemplateGeneratorTest extends ChadoTestKernelBase {
    * @var object
    */
   protected $config;
-
 
   /**
    * The TripalCultivatePhenotypes File Template Service.
@@ -92,13 +91,12 @@ class ServiceTemplateGeneratorTest extends ChadoTestKernelBase {
    *   - A string, humnan-readable short description of the test scenario.
    *   - A string, the importer plugin id.
    *   - An array, the list of headers that will become the header row in file.
-   *   - An array, file properties with the following keys:
-   *     - 'extension': the file extension of the template file.
-   *     - 'mime': the MIME type of template file.
-   *     - 'delimiter': the delimiter used to separate values (ie. headers).
+   *   - An array, the 'file_types' plugin annotation definition of importer.
    *   - An array of expected values, with the following keys:
-   *     - 'file_filename': the expected filename of the template file.
-   *     - 'file_content': the expected content (header row) of the file.
+   *     - 'filename': the expected filename of the template file.
+   *     - 'extension': the expected file extension of the template file.
+   *     - 'delimiter': the expected delimiter used to encode the header row.
+   *     - 'header_row': the expected content (header row) of the file.
    */
   public function provideParametersForFileTemplateGenerator() {
     return [
@@ -108,13 +106,13 @@ class ServiceTemplateGeneratorTest extends ChadoTestKernelBase {
         'my-importer',
         ['Header A', 'Header B', 'Header C'],
         [
-          'extension' => 'tsv',
-          'mime' => 'text/tab-separated-values',
-          'delimiter' => "\t",
+          'tsv',
         ],
         [
-          'file_filename' => "my-importer-data-collection-template-file-user-collector.tsv",
-          'file_content' => implode("\t", ['Header A', 'Header B', 'Header C']),
+          'filename' => "my-importer-data-collection-template-file-user-collector.tsv",
+          'extension' => 'tsv',
+          'delimiter' => "\t",
+          'header_row' => implode("\t", ['Header A', 'Header B', 'Header C']),
         ],
       ],
 
@@ -124,29 +122,32 @@ class ServiceTemplateGeneratorTest extends ChadoTestKernelBase {
         'another-importer',
         ['Header E', 'Header F', 'Header G'],
         [
-          'extension' => 'csv',
-          'mime' => 'text/csv',
-          'delimiter' => ",",
+          'csv',
+          'tsv',
+          'txt',
         ],
         [
-          'file_filename' => "another-importer-data-collection-template-file-user-collector.csv",
-          'file_content' => "Header E,Header F,Header G",
+          'filename' => "another-importer-data-collection-template-file-user-collector.csv",
+          'extension' => 'csv',
+          'delimiter' => ",",
+          'header_row' => "Header E,Header F,Header G",
         ],
       ],
 
-      // #2: A txt file.
+      // #2: A txt file - multiple items in the 'file_types' definition.
       [
         'a txt file',
         'basic-importer',
         ['Header X', 'Header Y', 'Header Z'],
         [
-          'extension' => 'txt',
-          'mime' => 'text/txt',
-          'delimiter' => "<delimiter>",
+          'txt',
+          'csv',
         ],
         [
-          'file_filename' => "basic-importer-data-collection-template-file-user-collector.txt",
-          'file_content' => "Header X<delimiter>Header Y<delimiter>Header Z",
+          'filename' => "basic-importer-data-collection-template-file-user-collector.txt",
+          'extension' => 'txt',
+          'delimiter' => "\t",
+          'header_row' => implode("\t", ['Header X', 'Header Y', 'Header Z']),
         ],
       ],
     ];
@@ -161,11 +162,8 @@ class ServiceTemplateGeneratorTest extends ChadoTestKernelBase {
    *   The importer plugin id.
    * @param array $column_headers
    *   The list of headers that will become the header row in file.
-   * @param array $file_properties
-   *   File properties with the following keys:
-   *     - 'extension': the file extension of the template file.
-   *     - 'mime': the MIME type of template file.
-   *     - 'delimiter': the delimiter used to separate values (ie. headers).
+   * @param array $file_extensions
+   *   The 'file_types' plugin annotation definition of the importer.
    * @param array $expected
    *   An array of expected values, with the following keys:
    *     - 'file_filename': the expected filename of the template file.
@@ -173,13 +171,13 @@ class ServiceTemplateGeneratorTest extends ChadoTestKernelBase {
    *
    * @dataProvider provideParametersForFileTemplateGenerator
    */
-  public function testTemplateGeneratorService($scenario, $importer_id, $column_headers, $file_properties, $expected) {
+  public function testTemplateGeneratorService($scenario, $importer_id, $column_headers, $file_extensions, $expected) {
 
     // Generate the template file.
-    $link = $this->service_FileTemplate->generateFile($importer_id, $column_headers, $file_properties);
+    $link = $this->service_FileTemplate->generateFile($importer_id, $column_headers, $file_extensions);
 
     // Assert a link has been created.
-    $this->assertNotNull($link, 'Failed to generate template file link.');
+    $this->assertNotNull($link, 'Failed to generate template file link in scenario ' . $scenario);
 
     // Assert that a file has been created in the the configured directory
     // for template files.
@@ -192,9 +190,16 @@ class ServiceTemplateGeneratorTest extends ChadoTestKernelBase {
 
     // Filename is the expected file name.
     $this->assertEquals(
-      $expected['file_filename'],
+      $expected['filename'],
       $template_file,
-      'The filename of the template file does not match expected file name in scenario ' . $scenario
+      'The filename of the template file does not match expected filename in scenario ' . $scenario
+    );
+
+    // File is of the expected file extension.
+    $this->assertEquals(
+      $expected['extension'],
+      pathinfo($template_file, PATHINFO_EXTENSION),
+      'The file extension of the template file does not match expected file extension in scenario ' . $scenario
     );
 
     // The filename contains the importer id and username.
@@ -207,11 +212,12 @@ class ServiceTemplateGeneratorTest extends ChadoTestKernelBase {
     $this->assertStringContainsString(
       $this->user->getAccountName(),
       $template_file,
-      'The filename of the template file is expected to contain the importer id in scenario ' . $scenario
+      'The filename of the template file is expected to contain the username in scenario ' . $scenario
     );
 
     // The template file has the headers.
-    // Assert that the headers were inserted into the file as the header row.
+    // Assert that the headers were inserted into the file as the header row
+    // using the delimiter.
     $file_contents = fopen($file_system . '/' . $template_file, 'r');
     if ($file_contents) {
       $header_row = trim(fgets($file_contents), "\n");
@@ -219,9 +225,17 @@ class ServiceTemplateGeneratorTest extends ChadoTestKernelBase {
     }
 
     $this->assertEquals(
-      $expected['file_content'],
+      $expected['header_row'],
       $header_row,
-      'The template file does not contain the expected column headers in scenario' . $scenario
+      'The template file does not contain the expected column headers in scenario ' . $scenario
+    );
+
+    // Using the delimiter to separate the header values, the result should
+    // match the headers array provided.
+    $this->assertEquals(
+      $column_headers,
+      explode($expected['delimiter'], $header_row),
+      'The header row in the template file does not match expected column headers in scenario ' . $scenario
     );
   }
 

--- a/trpcultivate_phenotypes/tests/src/Kernel/ServiceTemplateGeneratorTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/ServiceTemplateGeneratorTest.php
@@ -166,8 +166,10 @@ class ServiceTemplateGeneratorTest extends ChadoTestKernelBase {
    *   The 'file_types' plugin annotation definition of the importer.
    * @param array $expected
    *   An array of expected values, with the following keys:
-   *     - 'file_filename': the expected filename of the template file.
-   *     - 'file_content': the expected content (header row) of the file.
+   *     - 'filename': the expected filename of the template file.
+   *     - 'extension': the expected file extension of the template file.
+   *     - 'delimiter': the expected delimiter used to encode the header row.
+   *     - 'header_row': the expected content (header row) of the file.
    *
    * @dataProvider provideParametersForFileTemplateGenerator
    */


### PR DESCRIPTION
**Issue #124** Automated test needed for describeUploadFileFormat().

## Motivation
This PR updates the template generator service and automated test to accommodate customization of file extension of the generated template file. The previous version supports a single file extension and is hard-coded into the logic of the class. In addition, an unused variable $notes in https://github.com/TripalCultivate/TripalCultivate-Phenotypes/blob/3d934ca9215e046bd890e00cce6f2388cd19445f/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php#L1488 was not implemented but is now added into the header information section (see image below).

<img width="944" alt="image" src="https://github.com/user-attachments/assets/2e8821ad-282e-41db-b806-3da47cd23cd0" />


<!-- This can usually be copied from the issue. Please do not just say, go see issue but instead copy the relevant details here. -->

## What does this PR do?
*Please describe each things this PR does. For example, a PR may 1) solve a specific bug, 2) create an automated test to ensure it doesn't return.*

1. Display additional notes in the headers information section of the Importer form.
2. Replace the static file extension by improving the logic of determining the supported file types.
3. Reference static variables in validator base and validator file types to establish MIME type and delimiter.
4. Upgrade automated test.

## Testing

### Automated Testing
*Please describe each automated test this PR creates and provide a list of the assertions it makes using casual language.*
*Do not just say things like "asserts the array is not empty" but rather say "Ensures that the return value of method X with these parameters is not an empty array".*

ClassName->testTemplateGeneratorService()
- file_types annotation definition with single item - tsv.
- file_types annotation definition with multiple items but only the first item is preferred.
- A file type (txt - text/plain) where the mapping of delimiter contains multiple characters but only the first item is selected.

For every test case, the template generator is check to:
1. It creates the file uri to the template file.
2. The template file is stored in the configured directory for template files.
3. Filename is a combination of the plugin id, a string, current user username.
4. Filename contains the plugin id.
5. Filename contains the username.
6. File extension is the expected file extension.
7. The header row matches the headers array if it was encoded as string using the delimiter.
8. Separating the header row string should match the raw headers array.

### Manual Testing
*Describe in detail how someone should manually test this functionality.*
*Make sure to include whether they need to build a docker from scratch, create any records, etc.*

1. Switch to g2.124-describeUploadFileFormat
2. In a fully setup site, paste the code below in your site/devel/php
```
$template_generator = \Drupal::service('trpcultivate_phenotypes.template_generator');

$column_headers = [
  'Header A',
  'Header B',
  'Header C'
];

$importer_id = 'my-importer';

$file_extensions = [
  'tsv',
  'csv'
];

$l = $template_generator->generateFile($importer_id, $column_headers, $file_extensions);

dpm($l);

```
3. Copy the link and paste in the location bar in another browser window.
<img width="723" alt="image" src="https://github.com/user-attachments/assets/ed4256e2-2c2d-48ff-a56a-0801db5d3a64" />
4. Append the uri with the host.
localhost/site/default/file....
5. Click enter and save file when prompted. Adjust parameters to test.
