### PR TITLE
g2.134 Add tests for remaining validation processing methods

### DIFF
--- a/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
+++ b/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
@@ -1275,7 +1275,9 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
       '#items' => [
         [
           [
+            '#prefix' => '<div class="case-message">',
             '#markup' => $table['message'],
+            '#suffix' => '</div>',
           ],
           [
             '#type' => 'table',

--- a/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
+++ b/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
@@ -860,7 +860,7 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
       '#title' => $message,
       '#wrapper_attributes' => [
         'class' => [
-          'genus-exists-failures',
+          'tcp-genus-exists-failures',
         ],
       ],
       'items' => [
@@ -952,7 +952,7 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
       '#title' => $message,
       '#wrapper_attributes' => [
         'class' => [
-          'valid-data-file-failures',
+          'tcp-valid-data-file-failures',
         ],
       ],
       'items' => [
@@ -1007,7 +1007,7 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
       '#type' => 'ul',
       '#attributes' => [
         'class' => [
-          'valid-headers-failures',
+          'tcp-valid-headers-failures',
         ],
       ],
       '#items' => [
@@ -1162,7 +1162,7 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
       '#type' => 'ul',
       '#attributes' => [
         'class' => [
-          'valid-delimited-file-failures',
+          'tcp-valid-delimited-file-failures',
         ],
       ],
       '#items' => $tables,
@@ -1226,7 +1226,7 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
       '#type' => 'ul',
       '#attributes' => [
         'class' => [
-          'empty-cell-failures',
+          'tcp-empty-cell-failures',
         ],
       ],
       '#items' => [
@@ -1332,7 +1332,7 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
       '#type' => 'ul',
       '#attributes' => [
         'class' => [
-          'value-in-list-failures',
+          'tcp-value-in-list-failures',
         ],
       ],
       '#items' => [
@@ -1463,7 +1463,7 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
       '#type' => 'ul',
       '#attributes' => [
         'class' => [
-          'duplicate-traits-failures',
+          'tcp-duplicate-traits-failures',
         ],
       ],
       '#items' => $tables,

--- a/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
+++ b/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
@@ -1051,6 +1051,11 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
    *     - 'failedItems': an array of items that failed:
    *       - 'raw_row': A string indicating the row is empty OR the contents of
    *         the row as it appears in the file.
+   *       - 'expected_columns': The number of columns expected in the input
+   *         file as determined by calling getExpectedColumns().
+   *       - 'strict': A boolean indicating whether the number of expected
+   *         columns by the validator is strict (TRUE) or is the minimum number
+   *         required (FALSE).
    *
    * @return array
    *   A render array of type unordered list which is used to display feedback

--- a/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
+++ b/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
@@ -901,7 +901,6 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
    *   mime type are not compatible.
    */
   public function processValidDataFileFailures(array $validation_result) {
-
     // Get the current user in case we trigger a case that needs to log a
     // message to the administrator.
     $current_user = \Drupal::currentUser();
@@ -918,14 +917,12 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
       // Log a message for the administrator to help with debugging the issue.
       $this->logger->info("The user $username uploaded a file with FID $fid using the Traits Importer, but could not import it as something is wrong with the filename/FID. More specifically, the case message '" . $validation_result['case'] . "' was reported.");
     }
-
     elseif ($validation_result['case'] == 'The file has no data and is an empty file') {
       $message = 'The file provided has no contents in it to import. Please ensure your file has the expected header row and at least one row of data.';
       $items = [
         'Filename: ' . $validation_result['failedItems']['filename'],
       ];
     }
-
     elseif (($validation_result['case'] == 'Unsupported file MIME type') ||
             ($validation_result['case'] == 'Unsupported file mime type and unsupported extension')) {
       $message = "The type of file uploaded is not supported by this importer. Please ensure your file has one of the supported file extensions and was saved using software that supports that type of file. For example, a 'tsv' file should be saved as such by a spreadsheet editor such as Microsoft Excel.";
@@ -938,7 +935,6 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
       ];
       $this->logger->info("The user $username uploaded a file to the Traits Importer with file extension \"$file_extension\" and mime type \"$file_mime\"");
     }
-
     elseif ($validation_result['case'] == 'Data file cannot be opened') {
       $message = 'The file provided could not be opened. Please contact your administrator for help.';
       $filename = $validation_result['failedItems']['filename'];
@@ -1099,7 +1095,6 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
       // Keeps track of which table this one line's validation result gets added
       // to based on the case it triggered.
       $table_case = '';
-
       if (($validation_result['case'] == 'Raw row is empty') ||
           ($validation_result['case'] == 'None of the delimiters supported by the file type was used')) {
         $table_case = 'unsupported';
@@ -1291,11 +1286,10 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
 
     foreach ($failures as $line_no => $validation_result) {
       if ($validation_result['case'] == 'Invalid value(s) in required column(s)') {
-        $table['message'] = 'The following line number and column combinations did not contain one of the following allowed values: "' . implode('", "', $expected_values) . '". Note that values should be case sensitive. <strong>Empty cells indicate the value given was one of the allowed values.</strong>';
+        $table['message'] = 'The following line number and column combinations did not contain one of the following allowed values: "' . implode('", "', $expected_values) . '". Note that values should be case sensitive. <strong>If any cell in the table below is empty, then the value given in the file for that cell was one of the allowed values.</strong>';
 
         // Define a new row in our table for this line number.
         $table['rows'][$line_no][-1] = $line_no;
-
         // For each index with an invalid value, grab the column name from our
         // $headers property and add it to our table header.
         foreach ($validation_result['failedItems'] as $index => $failed_value) {

--- a/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
+++ b/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
@@ -1116,15 +1116,22 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
 
     // Finally, loop through our tables and build our render array.
     $tables = [];
-    foreach ($table as $table_case) {
+    foreach ($table as $table_key => $table_case) {
       array_push($tables, [
         [
+          '#prefix' => '<div class="case-message case-' . $table_key . '">',
           '#markup' => $table_case['message'],
+          '#suffix' => '</div>',
         ],
         [
           '#type' => 'table',
           '#header' => $table_header,
-          '#attributes' => ['class' => ['tcp-raw-row']],
+          '#attributes' => [
+            'class' => [
+              'tcp-raw-row',
+              'table-case-' . $table_key,
+            ],
+          ],
           '#rows' => $table_case['rows'],
         ],
       ]);

--- a/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
+++ b/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
@@ -858,6 +858,11 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
     $render_array = [
       '#type' => 'item',
       '#title' => $message,
+      '#wrapper_attributes' => [
+        'class' => [
+          'genus-exists-failures',
+        ],
+      ],
       'items' => [
         '#theme' => 'item_list',
         '#type' => 'ul',
@@ -949,6 +954,11 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
     $render_array = [
       '#type' => 'item',
       '#title' => $message,
+      '#wrapper_attributes' => [
+        'class' => [
+          'valid-data-file-failures',
+        ],
+      ],
       'items' => [
         '#theme' => 'item_list',
         '#type' => 'ul',
@@ -999,6 +1009,11 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
     $render_array = [
       '#theme' => 'item_list',
       '#type' => 'ul',
+      '#attributes' => [
+        'class' => [
+          'valid-headers-failures',
+        ],
+      ],
       '#items' => [
         [
           [
@@ -1150,6 +1165,11 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
     $render_array = [
       '#theme' => 'item_list',
       '#type' => 'ul',
+      '#attributes' => [
+        'class' => [
+          'valid-delimited-file-failures',
+        ],
+      ],
       '#items' => $tables,
     ];
 
@@ -1209,6 +1229,11 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
     $render_array = [
       '#theme' => 'item_list',
       '#type' => 'ul',
+      '#attributes' => [
+        'class' => [
+          'empty-cell-failures',
+        ],
+      ],
       '#items' => [
         [
           [
@@ -1311,6 +1336,11 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
     $render_array = [
       '#theme' => 'item_list',
       '#type' => 'ul',
+      '#attributes' => [
+        'class' => [
+          'value-in-list-failures',
+        ],
+      ],
       '#items' => [
         [
           [
@@ -1437,6 +1467,11 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
     $render_array = [
       '#theme' => 'item_list',
       '#type' => 'ul',
+      '#attributes' => [
+        'class' => [
+          'duplicate-traits-failures',
+        ],
+      ],
       '#items' => $tables,
     ];
 

--- a/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
+++ b/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
@@ -901,6 +901,8 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
     // message to the administrator.
     $current_user = \Drupal::currentUser();
     $username = $current_user->getAccountName();
+    // Define our items array.
+    $items = [];
 
     if (($validation_result['case'] == 'Invalid file id number') ||
         ($validation_result['case'] == 'File id failed to load a file object')) {

--- a/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
+++ b/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
@@ -1229,8 +1229,7 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
    *   and column combinations with an invalid value. It has the following
    *   headers:
    *   - 'Line Number'
-   *   - 'Column Header'
-   *   - 'Invalid Value'
+   *   - Column Header(s) of the cell(s) that has/have an invalid value
    */
   public function processValueInListFailures(array $failures, array $expected_values) {
     // Define our table header.

--- a/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
+++ b/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
@@ -1268,6 +1268,18 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
       }
     }
 
+    // If our table has more than 2 columns with failed values, then iterate
+    // through and pad the table with empty strings where necessary.
+    if (count($table_header) > 2) {
+      foreach (array_keys($table['rows']) as $line_no) {
+        foreach (array_keys($table_header) as $column_name) {
+          if (!array_key_exists($column_name, $table['rows'][$line_no])) {
+            $table['rows'][$line_no][$column_name] = '';
+          }
+        }
+      }
+    }
+
     // Build the render array for our table.
     $render_array = [
       '#theme' => 'item_list',

--- a/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
+++ b/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
@@ -896,24 +896,19 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
    *   mime type are not compatible.
    */
   public function processValidDataFileFailures(array $validation_result) {
-    if (($validation_result['case'] == 'Filename is empty string') ||
-        ($validation_result['case'] == 'Invalid file id number') ||
-        ($validation_result['case'] == 'Filename failed to load a file object') ||
+
+    // Get the current user in case we trigger a case that needs to log a
+    // message to the administrator.
+    $current_user = \Drupal::currentUser();
+    $username = $current_user->getAccountName();
+
+    if (($validation_result['case'] == 'Invalid file id number') ||
         ($validation_result['case'] == 'File id failed to load a file object')) {
       $message = 'A problem occurred in between uploading the file and submitting it for validation. Please try uploading and submitting it again, or contact your administrator if the problem persists.';
-      // All but one case returns the filename, so check that it exists before
-      // assigning it to items.
-      if (array_key_exists('filename', $validation_result['failedItems'])) {
-        $items = [
-          'Filename: ' . $validation_result['failedItems']['filename'],
-        ];
-      }
-      // Log a message for the administrator to help with debugging the issue.
-      // Get the current user.
-      $current_user = \Drupal::currentUser();
-      $username = $current_user->getAccountName();
+
       // Get the fid of the uploaded file.
       $fid = $validation_result['failedItems']['fid'];
+      // Log a message for the administrator to help with debugging the issue.
       $this->logger->info("The user $username uploaded a file with FID $fid using the Traits Importer, but could not import it as something is wrong with the filename/FID. More specifically, the case message '" . $validation_result['case'] . "' was reported.");
     }
 
@@ -936,6 +931,7 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
       ];
       $this->logger->info("The user $username uploaded a file to the Traits Importer with file extension \"$file_extension\" and mime type \"$file_mime\"");
     }
+
     elseif ($validation_result['case'] == 'Data file cannot be opened') {
       $message = 'The file provided could not be opened. Please contact your administrator for help.';
       $filename = $validation_result['failedItems']['filename'];

--- a/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
+++ b/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
@@ -1188,7 +1188,9 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
       '#items' => [
         [
           [
+            '#prefix' => '<div class="case-message">',
             '#markup' => $table['message'],
+            '#suffix' => '</div>',
           ],
           [
             '#type' => 'table',

--- a/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
+++ b/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
@@ -1092,9 +1092,10 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
       elseif (($validation_result['case'] == 'Raw row exceeds number of strict columns') ||
             ($validation_result['case'] == 'Raw row has insufficient number of columns')) {
         $table_case = 'delimited';
-        // @todo Wrap in an if
-        $num_expected_columns = $validation_result['failedItems']['expected_columns'];
-        $strict = $validation_result['failedItems']['strict'];
+        if (!isset($num_expected_columns)) {
+          $num_expected_columns = $validation_result['failedItems']['expected_columns'];
+          $strict = $validation_result['failedItems']['strict'];
+        }
       }
 
       // Checked all cases, now add a row to our appropriate table.

--- a/trpcultivate_phenotypes/src/Plugin/Validators/ValidDelimitedFile.php
+++ b/trpcultivate_phenotypes/src/Plugin/Validators/ValidDelimitedFile.php
@@ -45,6 +45,11 @@ class ValidDelimitedFile extends TripalCultivatePhenotypesValidatorBase {
    *   - 'failedItems': an array of items that failed with any of the following
    *      keys. This is an empty array if row is properly delimited.
    *      - 'raw_row': The raw row or a string indicating the row is empty.
+   *      - 'expected_columns': The number of columns expected in the input file
+   *        as determined by calling getExpectedColumns().
+   *      - 'strict': A boolean indicating whether the number of expected
+   *        columns by the validator is strict (TRUE) or is the minimum number
+   *        required (FALSE).
    */
   public function validateRawRow(string $raw_row) {
 

--- a/trpcultivate_phenotypes/src/Plugin/Validators/ValidDelimitedFile.php
+++ b/trpcultivate_phenotypes/src/Plugin/Validators/ValidDelimitedFile.php
@@ -44,7 +44,7 @@ class ValidDelimitedFile extends TripalCultivatePhenotypesValidatorBase {
    *   - 'valid': TRUE if the raw row is properly delimited, FALSE otherwise.
    *   - 'failedItems': an array of items that failed with any of the following
    *      keys. This is an empty array if row is properly delimited.
-   *      - 'raw_row': The raw row or a string indicating the row is empty.
+   *      - 'raw_row': The raw row as it was provided.
    *      - 'expected_columns': The number of columns expected in the input file
    *        as determined by calling getExpectedColumns().
    *      - 'strict': A boolean indicating whether the number of expected
@@ -59,7 +59,7 @@ class ValidDelimitedFile extends TripalCultivatePhenotypesValidatorBase {
         'case' => 'Raw row is empty',
         'valid' => FALSE,
         'failedItems' => [
-          'raw_row' => 'is an empty string value',
+          'raw_row' => $raw_row,
         ],
       ];
     }

--- a/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterFormValidateTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterFormValidateTest.php
@@ -346,7 +346,7 @@ class TraitImporterFormValidateTest extends ChadoTestKernelBase {
         'valid_data_type' => [
           'title' => 'Values in required cells are valid',
           'status' => 'fail',
-          'details' => 'The following line number and column combinations did not contain one of the following allowed values: "Quantitative", "Qualitative". Note that values should be case sensitive. <strong>Empty cells indicate the value given was one of the allowed values.</strong>',
+          'details' => 'The following line number and column combinations did not contain one of the following allowed values: "Quantitative", "Qualitative". Note that values should be case sensitive. <strong>If any cell in the table below is empty, then the value given in the file for that cell was one of the allowed values.</strong>',
         ],
         'duplicate_traits' => ['status' => 'pass'],
       ],

--- a/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterProcessValidationTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterProcessValidationTest.php
@@ -555,6 +555,27 @@ class TraitImporterProcessValidationTest extends ChadoTestKernelBase {
     ];
 
     // #1: No supported delimiters were used.
+    $raw_row = "This is one very long string without any supported delimiters in it.";
+    $scenarios[] = [
+      [
+        1 => [
+          'case' => 'None of the delimiters supported by the file type was used',
+          'valid' => FALSE,
+          'failedItems' => [
+            'raw_row' => $raw_row,
+          ],
+        ],
+      ],
+      [
+        'unsupported' => [
+          'expected_message' => 'The following lines in the input file do not contain a valid delimiter supported by this importer.',
+          1 => [
+            'line_contents' => $raw_row,
+          ],
+        ],
+      ],
+    ];
+
     // #2: The delimited row contains too few columns.
     // #3: The delimited row contains too many columns (strict = TRUE).
     // #4: A mix of unsupported delimiters and insufficient columns.
@@ -596,8 +617,7 @@ class TraitImporterProcessValidationTest extends ChadoTestKernelBase {
     $rendered_markup = $this->renderer->renderRoot($render_array);
     $this->setRawContent($rendered_markup);
 
-    //print_r($rendered_markup);
-
+    // print_r($rendered_markup);
     // Check the rendered output.
     // Loop through expectations one table at a time.
     foreach ($expectations as $table_case => $table) {

--- a/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterProcessValidationTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterProcessValidationTest.php
@@ -558,7 +558,7 @@ class TraitImporterProcessValidationTest extends ChadoTestKernelBase {
     $raw_row = "This is one very long string without any supported delimiters in it.";
     $scenarios[] = [
       [
-        1 => [
+        2 => [
           'case' => 'None of the delimiters supported by the file type was used',
           'valid' => FALSE,
           'failedItems' => [
@@ -569,16 +569,89 @@ class TraitImporterProcessValidationTest extends ChadoTestKernelBase {
       [
         'unsupported' => [
           'expected_message' => 'The following lines in the input file do not contain a valid delimiter supported by this importer.',
-          1 => [
+          2 => [
             'line_contents' => $raw_row,
           ],
         ],
       ],
     ];
 
-    // #2: The delimited row contains too few columns.
-    // #3: The delimited row contains too many columns (strict = TRUE).
-    // #4: A mix of unsupported delimiters and insufficient columns.
+    // #2: 1 row with too few columns, 1 row with too many columns.
+    $raw_row_3 = "Column 1\tColumn 2\tColumn 3\tColumn 4";
+    $raw_row_5 = "Column 1\tColumn 2\tColumn 3\tColumn 4\tColumn 5\tColumn 6\tColumn 7\tColumn 8";
+    $scenarios[] = [
+      [
+        3 => [
+          'case' => 'Raw row has insufficient number of columns',
+          'valid' => FALSE,
+          'failedItems' => [
+            'raw_row' => $raw_row_3,
+            'expected_columns' => 6,
+            'strict' => TRUE,
+          ],
+        ],
+        5 => [
+          'case' => 'Raw row exceeds number of strict columns',
+          'valid' => FALSE,
+          'failedItems' => [
+            'raw_row' => $raw_row_5,
+            'expected_columns' => 6,
+            'strict' => TRUE,
+          ],
+        ],
+      ],
+      [
+        'delimited' => [
+          'expected_message' => 'This importer requires a strict number of 6 columns for each line. The following lines do not contain the expected number of columns.',
+          3 => [
+            'line_contents' => $raw_row_3,
+          ],
+          5 => [
+            'line_contents' => $raw_row_5,
+          ],
+        ],
+      ],
+    ];
+
+    // #3: A mix of unsupported delimiters and insufficient columns.
+    $raw_row_4 = "Column 1 Column 2 Column 3 Column 4";
+    $raw_row_6 = "Column 1\tColumn 2\tColumn 3\tColumn 4\tColumn 5\tColumn 6\tColumn 7";
+    $scenarios[] = [
+      [
+        4 => [
+          'case' => 'None of the delimiters supported by the file type was used',
+          'valid' => FALSE,
+          'failedItems' => [
+            'raw_row' => $raw_row_4,
+            'expected_columns' => 6,
+            'strict' => TRUE,
+          ],
+        ],
+        6 => [
+          'case' => 'Raw row exceeds number of strict columns',
+          'valid' => FALSE,
+          'failedItems' => [
+            'raw_row' => $raw_row_6,
+            'expected_columns' => 6,
+            'strict' => TRUE,
+          ],
+        ],
+      ],
+      [
+        'unsupported' => [
+          'expected_message' => 'The following lines in the input file do not contain a valid delimiter supported by this importer.',
+          4 => [
+            'line_contents' => $raw_row_4,
+          ],
+        ],
+        'delimited' => [
+          'expected_message' => 'This importer requires a strict number of 6 columns for each line. The following lines do not contain the expected number of columns.',
+          6 => [
+            'line_contents' => $raw_row_6,
+          ],
+        ],
+      ],
+    ];
     return $scenarios;
   }
 
@@ -624,7 +697,11 @@ class TraitImporterProcessValidationTest extends ChadoTestKernelBase {
       // Check the message above this table is correct.
       $selected_message_markup = $this->cssSelect("ul li div.case-message.case-$table_case");
       $table_message = (string) $selected_message_markup[0];
-      $this->assertStringContainsString($expectations[$table_case]['expected_message'], $table_message, 'The message expected for this scenario did not match the message in the render array.');
+      $this->assertStringContainsString(
+        $expectations[$table_case]['expected_message'],
+        $table_message,
+        'The message expected for this scenario did not match the message in the render array.'
+      );
 
       // Pull out the table rows for this table case.
       $selected_rows = $this->cssSelect("table.table-case-$table_case tbody tr");

--- a/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterProcessValidationTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterProcessValidationTest.php
@@ -576,7 +576,44 @@ class TraitImporterProcessValidationTest extends ChadoTestKernelBase {
       ],
     ];
 
-    // #2: 1 row with too few columns, 1 row with too many columns.
+    // #2: Multiple rows with too few columns and strict = FALSE
+    $raw_row_2 = "Column 1\tColumn 2";
+    $raw_row_4 = "Column 1\tColumn 2\tColumn 3";
+    $scenarios[] = [
+      [
+        2 => [
+          'case' => 'Raw row has insufficient number of columns',
+          'valid' => FALSE,
+          'failedItems' => [
+            'raw_row' => $raw_row_2,
+            'expected_columns' => 4,
+            'strict' => FALSE,
+          ],
+        ],
+        4 => [
+          'case' => 'Raw row has insufficient number of columns',
+          'valid' => FALSE,
+          'failedItems' => [
+            'raw_row' => $raw_row_4,
+            'expected_columns' => 4,
+            'strict' => FALSE,
+          ],
+        ],
+      ],
+      [
+        'delimited' => [
+          'expected_message' => 'This importer requires a minimum number of 4 columns for each line. The following lines do not contain the expected number of columns.',
+          2 => [
+            'line_contents' => $raw_row_2,
+          ],
+          4 => [
+            'line_contents' => $raw_row_4,
+          ],
+        ],
+      ],
+    ];
+
+    // #3: 1 row with too few columns, 1 with too many columns, strict = TRUE
     $raw_row_3 = "Column 1\tColumn 2\tColumn 3\tColumn 4";
     $raw_row_5 = "Column 1\tColumn 2\tColumn 3\tColumn 4\tColumn 5\tColumn 6\tColumn 7\tColumn 8";
     $scenarios[] = [
@@ -613,25 +650,25 @@ class TraitImporterProcessValidationTest extends ChadoTestKernelBase {
       ],
     ];
 
-    // #3: A mix of unsupported delimiters and insufficient columns.
-    $raw_row_4 = "Column 1 Column 2 Column 3 Column 4";
-    $raw_row_6 = "Column 1\tColumn 2\tColumn 3\tColumn 4\tColumn 5\tColumn 6\tColumn 7";
+    // #4: A mix of unsupported delimiters and insufficient columns.
+    $raw_row_6 = "Column 1 Column 2 Column 3 Column 4";
+    $raw_row_7 = "Column 1\tColumn 2\tColumn 3\tColumn 4\tColumn 5\tColumn 6\tColumn 7";
     $scenarios[] = [
       [
-        4 => [
+        6 => [
           'case' => 'None of the delimiters supported by the file type was used',
           'valid' => FALSE,
           'failedItems' => [
-            'raw_row' => $raw_row_4,
+            'raw_row' => $raw_row_6,
             'expected_columns' => 6,
             'strict' => TRUE,
           ],
         ],
-        6 => [
+        7 => [
           'case' => 'Raw row exceeds number of strict columns',
           'valid' => FALSE,
           'failedItems' => [
-            'raw_row' => $raw_row_6,
+            'raw_row' => $raw_row_7,
             'expected_columns' => 6,
             'strict' => TRUE,
           ],
@@ -640,14 +677,14 @@ class TraitImporterProcessValidationTest extends ChadoTestKernelBase {
       [
         'unsupported' => [
           'expected_message' => 'The following lines in the input file do not contain a valid delimiter supported by this importer.',
-          4 => [
-            'line_contents' => $raw_row_4,
+          6 => [
+            'line_contents' => $raw_row_6,
           ],
         ],
         'delimited' => [
           'expected_message' => 'This importer requires a strict number of 6 columns for each line. The following lines do not contain the expected number of columns.',
-          6 => [
-            'line_contents' => $raw_row_6,
+          7 => [
+            'line_contents' => $raw_row_7,
           ],
         ],
       ],
@@ -705,6 +742,14 @@ class TraitImporterProcessValidationTest extends ChadoTestKernelBase {
 
       // Pull out the table rows for this table case.
       $selected_rows = $this->cssSelect("table.table-case-$table_case tbody tr");
+      // Assert that the number of rows matches what we expect.
+      $expected_row_count = (count($table) - 1);
+      $this->assertCount(
+        $expected_row_count,
+        $selected_rows,
+        'We expected ' . $expected_row_count . 'rows in the rendered table for ValueInList failures for this scenario, but there are ' . count($selected_rows) . '.'
+      );
+
       $current_row_index = 0;
       foreach ($table as $expected_line_no => $expected_values) {
         if ($expected_line_no == 'expected_message') {

--- a/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterProcessValidationTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterProcessValidationTest.php
@@ -477,7 +477,6 @@ class TraitImporterProcessValidationTest extends ChadoTestKernelBase {
    * @dataProvider provideValidHeadersFailedCases
    */
   public function testProcessValidHeadersFailures(array $validation_result, array $expectations) {
-
     // Call the process method on our validation result.
     $render_array = $this->importer->processValidHeadersFailures($validation_result);
     // Render the array we were returned.
@@ -1125,7 +1124,6 @@ class TraitImporterProcessValidationTest extends ChadoTestKernelBase {
    * @dataProvider provideValueInListFailedCases
    */
   public function testProcessValueInListFailures(array $failures, array $valid_values, array $expectations) {
-
     // Process our test failures array for this scenario.
     $render_array = $this->importer->processValueInListFailures($failures, $valid_values);
     $rendered_markup = $this->renderer->renderRoot($render_array);
@@ -1425,7 +1423,6 @@ class TraitImporterProcessValidationTest extends ChadoTestKernelBase {
    * @dataProvider provideDuplicateTraitsFailedCases
    */
   public function testProcessDuplicateTraitsFailures(array $failures, array $expectations) {
-
     // Process our test failures array.
     $render_array = $this->importer->processDuplicateTraitsFailures($failures);
     $rendered_markup = $this->renderer->renderRoot($render_array);

--- a/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterProcessValidationTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterProcessValidationTest.php
@@ -223,11 +223,11 @@ class TraitImporterProcessValidationTest extends ChadoTestKernelBase {
     $this->setRawContent($rendered_markup);
 
     // Check the render array here.
-    $selected_message_title = $this->cssSelect('div.form-item label');
+    $selected_message_title = $this->cssSelect('div.tcp-genus-exists-failures label');
     $provided_message = (string) $selected_message_title[0];
     $this->assertStringContainsString($expectations['expected_message'], $provided_message, 'The message expected from processing GenusExists failures for this scenario did not match the one in the rendered output.');
     // Check for an unordered list with one item in it - the genus provided.
-    $selected_list_items = $this->cssSelect('div.form-item ul li');
+    $selected_list_items = $this->cssSelect('div.tcp-genus-exists-failures ul li');
     $this->assertCount(1, $selected_list_items, 'We expect only one list item in the render array from processing GenusExists failures.');
     // Grab the contents of 'SimpleXMLElement Object' and assert it is our
     // genus.
@@ -364,7 +364,7 @@ class TraitImporterProcessValidationTest extends ChadoTestKernelBase {
 
     // Check the rendered output.
     // First check that we were given the correct message.
-    $selected_message_title = $this->cssSelect('div.form-item label');
+    $selected_message_title = $this->cssSelect('div.tcp-valid-data-file-failures label');
     $provided_message = (string) $selected_message_title[0];
     $this->assertStringContainsString(
       $expectations['expected_message'],
@@ -373,7 +373,7 @@ class TraitImporterProcessValidationTest extends ChadoTestKernelBase {
     );
 
     // Next, check for expected items.
-    $selected_list_items = $this->cssSelect('div.form-item ul li');
+    $selected_list_items = $this->cssSelect('div.tcp-valid-data-file-failures ul li');
     $list_item_count = count($selected_list_items);
     $this->assertEquals($expectations['expected_item_count'], $list_item_count, 'We expected ' . $expectations['expected_item_count'] . ' list items in the render array from processing ValidDataFile failures, but instead found ' . $list_item_count . '.');
     // If this is a case where we expect an item, grab the contents of

--- a/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterProcessValidationTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterProcessValidationTest.php
@@ -236,6 +236,90 @@ class TraitImporterProcessValidationTest extends ChadoTestKernelBase {
   }
 
   /**
+   * Data Provider for testProcessValidDataFileFailures().
+   *
+   * @return array
+   *   Each scenario is an array with the following:
+   *   - The validation result array that gets passed to the process method. It
+   *     contains the following keys:
+   *     - 'case': a developer-focused string describing the case checked.
+   *     - 'valid': FALSE to indicate that validation failed.
+   *     - 'failedItems': an array of items that failed with the following keys.
+   *       - 'filename': The provided name of the file.
+   *       - 'fid': The fid of the provided file.
+   *       - 'mime': The mime type of the input file if it is not supported.
+   *       - 'extension': The extension of the input file if not supported.
+   *   - An array of expectations in the rendered output which has the following
+   *     keys:
+   *     - 'expected_message': The message expected in the return value of the
+   *       process method for this scenario.
+   */
+  public function provideValidDataFileFailedCases() {
+    $scenarios = [];
+
+    // #0: An invalid file ID is provided.
+    $scenarios[] = [
+      [
+        'case' => 'Invalid file id number',
+        'valid' => FALSE,
+        'failedItems' => [
+          'fid' => 'wrongid',
+        ],
+      ],
+      [
+        'expected_message' => 'A problem occurred in between uploading the file and submitting it for validation.',
+      ],
+    ];
+
+    // #1: An empty file was provided.
+    $scenarios[] = [
+      [
+        'case' => 'The file has no data and is an empty file',
+        'valid' => FALSE,
+        'failedItems' => [
+          'filename' => 'empty_file.txt',
+          'fid' => 123,
+        ],
+      ],
+      [
+        'expected_message' => 'The file provided has no contents in it to import. Please ensure your file has the expected header row and at least one row of data.',
+      ],
+    ];
+
+    // #2: The file MIME type is unsupported.
+    $scenarios[] = [
+      [
+        'case' => 'Unsupported file MIME type',
+        'valid' => FALSE,
+        'failedItems' => [
+          'mime' => 'application/pdf',
+          'extension' => 'tsv',
+        ],
+      ],
+      [
+        'expected_message' => 'The type of file uploaded is not supported by this importer. Please ensure your file has one of the supported file extensions and was saved using software that supports that type of file.',
+      ],
+    ];
+
+    // #3: The data file couldn't be opened.
+    $scenarios[] = [
+      [
+        'case' => 'Data file cannot be opened',
+        'valid' => FALSE,
+        'failedItems' => [
+          'filename' => 'unopenable.tsv',
+          'fid' => 456,
+        ],
+      ],
+      [
+        'expected_message' => 'The file provided could not be opened. Please contact your administrator for help.',
+      ],
+    ];
+
+    return $scenarios;
+  }
+
+  /**
    * Data Provider for testProcessValidHeadersFailures().
    *
    * @return array

--- a/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterProcessValidationTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterProcessValidationTest.php
@@ -271,7 +271,6 @@ class TraitImporterProcessValidationTest extends ChadoTestKernelBase {
       [
         'expected_message' => 'A problem occurred in between uploading the file and submitting it for validation.',
         'expected_item_count' => 0,
-        'expected_item' => '',
       ],
     ];
 
@@ -371,11 +370,14 @@ class TraitImporterProcessValidationTest extends ChadoTestKernelBase {
 
     // Next, check for expected items.
     $selected_list_items = $this->cssSelect('div.form-item ul li');
-    $this->assertCount($expectations['expected_item_count'], $selected_list_items, 'We expect only one list item in the render array from processing ValidDataFile failures.');
-    // Grab the contents of 'SimpleXMLElement Object' and assert it matches
-    // what we expect.
-    $provided_item = (string) $selected_list_items[0];
-    $this->assertEquals($expectations['expected_item'], $provided_item, 'The render array from processing ValidDataFile failures did not contain the expected failed item.');
+    $list_item_count = count($selected_list_items);
+    $this->assertEquals($expectations['expected_item_count'], $list_item_count, 'We expected ' . $expectations['expected_item_count'] . ' list items in the render array from processing ValidDataFile failures, but instead found ' . $list_item_count . '.');
+    // If this is a case where we expect an item, grab the contents of
+    // 'SimpleXMLElement Object' and assert it matches what we expect.
+    if (array_key_exists('expected_item', $expectations)) {
+      $provided_item = (string) $selected_list_items[0];
+      $this->assertEquals($expectations['expected_item'], $provided_item, 'The render array from processing ValidDataFile failures did not contain the expected failed item.');
+    }
   }
 
   /**
@@ -499,6 +501,34 @@ class TraitImporterProcessValidationTest extends ChadoTestKernelBase {
       // rendered provided headers row.
       $this->assertEquals($validation_result['failedItems'], $selected_provided_headers_td, "The header row provided does not match the second row (the \'provided headers\' row) of the rendered table.");
     }
+  }
+
+  /**
+   * Data Provider for testProcessEmptyCellFailures().
+   *
+   * @return array
+   *   Each scenario is an array with the following:
+   *   - The failures array that gets passed to the process method. It contains
+   *     the following keys:
+   *     - The line number that triggered this failed validation status.
+   *       - 'case': a developer-focused string describing the case checked.
+   *       - 'valid': FALSE to indicate that validation failed.
+   *       - 'failedItems': array of items that failed with the following keys:
+   *         - 'empty_indices': A list of column indices in the line which were
+   *           checked and found to be empty.
+   *   - An array of expectations that we want to find in the resulting rendered
+   *     output which has the following keys:
+   *     - 'expected_message': The message expected in the return value of the
+   *       process method for this scenario.
+   *     - 1+ arrays keyed by the line number in the input file that triggered
+   *       the failed validation status, further keyed by:
+   *       - 'expected_columns': A comma-separated list of column headers that
+   *         map to the expected columns with empty values.
+   */
+  public function provideEmptyCellFailedCases() {
+    $scenarios = [];
+
+    return $scenarios;
   }
 
   /**

--- a/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterProcessValidationTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterProcessValidationTest.php
@@ -719,6 +719,82 @@ class TraitImporterProcessValidationTest extends ChadoTestKernelBase {
       ],
     ];
 
+    $valid_values = [
+      'cm',
+      'days',
+      'scale',
+    ];
+    // #1: An invalid value on multiple rows (1 column)
+    $scenarios[] = [
+      [
+        2 => [
+          'case' => 'Invalid value(s) in required column(s)',
+          'valid' => FALSE,
+          'failedItems' => [
+            // Column 'Unit' is at index 4.
+            4 => 'Amy',
+          ],
+        ],
+        5 => [
+          'case' => 'Invalid value(s) in required column(s)',
+          'valid' => FALSE,
+          'failedItems' => [
+            4 => 'Sam',
+          ],
+        ],
+      ],
+      $valid_values,
+      [
+        'expected_message' => 'The following line number and column combinations did not contain one of the following allowed values: "' . implode('", "', $valid_values) . '".',
+        'expected_column_count' => 2,
+        'expected_table_rows' => [
+          2 => [
+            'Unit' => 'Amy',
+          ],
+          5 => [
+            'Unit' => 'Sam',
+          ],
+        ],
+      ],
+    ];
+
+    // #2: Multiple different invalid values in different columns.
+    $scenarios[] = [
+      [
+        2 => [
+          'case' => 'Invalid value(s) in required column(s)',
+          'valid' => FALSE,
+          'failedItems' => [
+            // Column 'Unit' is at index 4.
+            4 => 'Amy',
+          ],
+        ],
+        5 => [
+          'case' => 'Invalid value(s) in required column(s)',
+          'valid' => FALSE,
+          'failedItems' => [
+            4 => 'Sam',
+            // Column 'Type' is at index 5.
+            5 => 'Ben',
+          ],
+        ],
+      ],
+      $valid_values,
+      [
+        'expected_message' => 'The following line number and column combinations did not contain one of the following allowed values: "' . implode('", "', $valid_values) . '".',
+        'expected_column_count' => 3,
+        'expected_table_rows' => [
+          2 => [
+            'Type' => 'Amy',
+          ],
+          5 => [
+            'Unit' => 'Sam',
+            'Type' => 'Ben',
+          ],
+        ],
+      ],
+    ];
+
     return $scenarios;
   }
 
@@ -758,7 +834,8 @@ class TraitImporterProcessValidationTest extends ChadoTestKernelBase {
     $rendered_markup = $this->renderer->renderRoot($render_array);
     $this->setRawContent($rendered_markup);
 
-    // print_r($rendered_markup);
+    //print_r($rendered_markup);
+
     // Check the rendered output.
     // Check the message above this table is correct.
     $selected_message_markup = $this->cssSelect("ul li div.case-message");

--- a/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterProcessValidationTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterProcessValidationTest.php
@@ -664,6 +664,60 @@ class TraitImporterProcessValidationTest extends ChadoTestKernelBase {
   }
 
   /**
+   * Data Provider for testProcessValueInListFailures().
+   *
+   * @return array
+   *   Each scenario is an array with the following:
+   *   - The failures array that gets passed to the process method. It contains
+   *     the following keys:
+   *     - The line number that triggered this failed validation status.
+   *       - 'case': a developer-focused string describing the case checked.
+   *       - 'valid': FALSE to indicate that validation failed.
+   *       - 'failedItems': array of items that failed, where the key => value
+   *         pairs map to the index => cell value(s) that failed validation.
+   *       - 'valid_values': the list of values that are considered valid by
+   *         this validator.
+   *   - An array of expectations that we want to find in the resulting rendered
+   *     output which has the following keys:
+   *     - 'expected_message': The message expected in the return value of the
+   *       process method for this scenario.
+   *     - 1+ arrays keyed by the line number in the input file that triggered
+   *       the failed validation status, further keyed by the column header name
+   *       of a cell in this row and its value is the invalid value. For
+   *       example:
+   *       - 2 => [ 'Type' => 'Invalid Value' ]
+   */
+  public function provideValueInListFailedCases() {
+    $scenarios = [];
+
+    // #0: An invalid value in a required column on one row.
+    $scenarios[] = [
+      [
+        3 => [
+          'case' => 'Invalid value(s) in required column(s)',
+          'valid' => FALSE,
+          'failedItems' => [
+            // Column 'Type' is at index 5.
+            5 => 'Invalid Type',
+          ],
+          'valid_values' => [
+            'Quantitative',
+            'Qualitative',
+          ],
+        ],
+      ],
+      [
+        'expected_message' => 'The following line number and column combinations did not contain one of the following allowed values: "Quantitative", "Qualitative".',
+        3 => [
+          'Type' => 'Invalid Type',
+        ],
+      ],
+    ];
+
+    return $scenarios;
+  }
+
+  /**
    * Data Provider for testProcessDuplicateTraitsFailures().
    *
    * @return array

--- a/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterProcessValidationTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterProcessValidationTest.php
@@ -727,7 +727,6 @@ class TraitImporterProcessValidationTest extends ChadoTestKernelBase {
     $rendered_markup = $this->renderer->renderRoot($render_array);
     $this->setRawContent($rendered_markup);
 
-    // print_r($rendered_markup);
     // Check the rendered output.
     // Loop through expectations one table at a time.
     foreach ($expectations as $table_case => $table) {
@@ -747,14 +746,16 @@ class TraitImporterProcessValidationTest extends ChadoTestKernelBase {
       $this->assertCount(
         $expected_row_count,
         $selected_rows,
-        'We expected ' . $expected_row_count . 'rows in the rendered table for ValueInList failures for this scenario, but there are ' . count($selected_rows) . '.'
+        'We expected ' . $expected_row_count . 'rows in the rendered table for ValidDelimitedFile failures for this scenario, but there are ' . count($selected_rows) . '.'
       );
 
       $current_row_index = 0;
+      // Loop through expectations for each row of a table.
       foreach ($table as $expected_line_no => $expected_values) {
         if ($expected_line_no == 'expected_message') {
           continue;
         }
+        // Select our current row as an array.
         $select_row_cells = (array) $selected_rows[$current_row_index]->td;
         // 1st Column: Line Number
         $line_number = $select_row_cells[0];
@@ -911,11 +912,21 @@ class TraitImporterProcessValidationTest extends ChadoTestKernelBase {
 
     // Select the table rows and check for our expected values.
     $selected_rows = $this->cssSelect("tbody tr");
+    // Assert that the number of rows matches what we expect.
+    $expected_row_count = (count($expectations) - 1);
+    $this->assertCount(
+      $expected_row_count,
+      $selected_rows,
+      'We expected ' . $expected_row_count . 'rows in the rendered table for EmptyCell failures for this scenario, but there are ' . count($selected_rows) . '.'
+    );
+
     $current_row_index = 0;
+    // Loop through expectations for each row in the table.
     foreach ($expectations as $expected_line_no => $expected_values) {
       if ($expected_line_no == 'expected_message') {
         continue;
       }
+      // Select our current row as an array.
       $select_row_cells = (array) $selected_rows[$current_row_index]->td;
       // 1st Column: Line Number
       $line_number = $select_row_cells[0];
@@ -1136,6 +1147,7 @@ class TraitImporterProcessValidationTest extends ChadoTestKernelBase {
 
     // Now check the cell values.
     $current_row_index = 0;
+    // Loop through expectations for each row in the table.
     foreach ($expectations['expected_table_rows'] as $expected_line_no => $expected_values) {
       $select_row_cells = (array) $selected_rows[$current_row_index]->td;
       // 1st Column: Line Number
@@ -1151,13 +1163,13 @@ class TraitImporterProcessValidationTest extends ChadoTestKernelBase {
         $this->assertEquals(
           $column_header,
           $select_column_headers[$current_column_index],
-          "We expected the column header $column_header to be present in the rendered table's header at index $current_column_index but it was not."
+          "We expected the column header $column_header to be present in the rendered table's header for ValueInList failures at index $current_column_index but it was not."
         );
         // Check that the invalid value in the table matches what we expect.
         $this->assertEquals(
           $invalid_value,
           (string) $select_row_cells[$current_column_index],
-          "We expected an invalid value to be listed for $column_header at line #$expected_line_no."
+          "We expected an invalid value to be listed for $column_header at line #$expected_line_no in the rendered table for ValueInList failures."
         );
         $current_column_index++;
       }
@@ -1411,35 +1423,38 @@ class TraitImporterProcessValidationTest extends ChadoTestKernelBase {
       $this->assertStringContainsString($expectations[$table_case]['expected_message'], $table_message, 'The message expected for this scenario did not match the message in the render array.');
 
       // Pull out the table rows for this table case.
-      $selected_table_rows = $this->cssSelect("table.table-case-$table_case tbody tr td");
-      // Keep track of the index in $selected_table_rows. This is necessary
-      // since there's no way to distinguish different rows in a table.
-      // ie:
-      // Row 1: $selected_table_rows[0], ..[1], ..[2], ..[3]
-      // Row 2: $selected_table_rows[4], ..[5], ..[6], ..[7]
-      // etc...
-      $str_index = 0;
+      $selected_rows = $this->cssSelect("table.table-case-$table_case tbody tr");
+      // Assert that the number of rows matches what we expect.
+      $expected_row_count = (count($table) - 1);
+      $this->assertCount(
+        $expected_row_count,
+        $selected_rows,
+        'We expected ' . $expected_row_count . 'rows in the rendered table for DuplicateTraits failures for this scenario, but there are ' . count($selected_rows) . '.'
+      );
+
+      $current_row_index = 0;
       // Loop through expectations for each row of a table.
-      foreach ($table as $expected_line_no => $validation_status) {
+      foreach ($table as $expected_line_no => $expected_values) {
         if ($expected_line_no == 'expected_message') {
           continue;
         }
-        // Line Number.
-        $line_number = (string) $selected_table_rows[$str_index];
+        // Select our current row as an array.
+        $select_row_cells = (array) $selected_rows[$current_row_index]->td;
+        // 1st Column: Line Number
+        $line_number = (string) $select_row_cells[0];
         $this->assertEquals($expected_line_no, $line_number, "Did not get the expected line number in the rendered $table_case table from processing DuplicateTraits failures.");
-        // Trait Name.
-        $trait_name = (string) $selected_table_rows[$str_index + 1];
-        $this->assertEquals($table[$expected_line_no]['expected_trait'], $trait_name, "Did not get the expected trait name in the rendered $table_case table from processing DuplicateTraits failures.");
-        // Method Short Name.
-        $method_name = (string) $selected_table_rows[$str_index + 2];
-        $this->assertEquals($table[$expected_line_no]['expected_method'], $method_name, "Did not get the expected method name in the rendered $table_case table from processing DuplicateTraits failures.");
-        // Unit.
-        $unit_name = (string) $selected_table_rows[$str_index + 3];
-        $this->assertEquals($table[$expected_line_no]['expected_unit'], $unit_name, "Did not get the expected unit in the rendered $table_case table from processing DuplicateTraits failures.");
+        // 2nd Column: Trait Name
+        $trait_name = (string) $select_row_cells[1];
+        $this->assertEquals($expected_values['expected_trait'], $trait_name, "Did not get the expected trait name in the rendered $table_case table from processing DuplicateTraits failures.");
+        // 3rd Column: Method Short Name
+        $method_name = (string) $select_row_cells[2];
+        $this->assertEquals($expected_values['expected_method'], $method_name, "Did not get the expected method name in the rendered $table_case table from processing DuplicateTraits failures.");
+        // 4th Column: Unit
+        $unit_name = (string) $select_row_cells[3];
+        $this->assertEquals($expected_values['expected_unit'], $unit_name, "Did not get the expected unit in the rendered $table_case table from processing DuplicateTraits failures.");
 
-        // Increase the selected_table_rows count by 4 so that we can pull
-        // values for the next row.
-        $str_index = $str_index + 4;
+        // Move onto the next row.
+        $current_row_index++;
       }
     }
   }

--- a/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterProcessValidationTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterProcessValidationTest.php
@@ -504,6 +504,66 @@ class TraitImporterProcessValidationTest extends ChadoTestKernelBase {
   }
 
   /**
+   * Data Provider for testProcessValidDelimitedFileFailures().
+   *
+   * @return array
+   *   Each scenario is an array with the following:
+   *   - The failures array that gets passed to the process method. It contains
+   *     the following keys:
+   *     - The line number that triggered this failed validation status.
+   *       - 'case': a developer-focused string describing the case checked.
+   *       - 'valid': FALSE to indicate that validation failed.
+   *       - 'failedItems': array of items that failed with the following keys:
+   *         - 'raw_row': The raw row or a string indicating the row is empty.
+   *         - 'expected_columns': The number of columns expected in the input
+   *           file as determined by calling getExpectedColumns().
+   *         - 'strict': A boolean indicating whether the number of expected
+   *           columns by the validator is strict (TRUE) or is the minimum
+   *           number required (FALSE).
+   *   - An array of expectations that we want to find in the resulting rendered
+   *     output. This array is nested by the tables expected (keyed by type -
+   *     'unsupported' or 'delimited'), in the order they are expected to show
+   *     up on the page (1 array per table). Each array has the following keys:
+   *     - 'expected_message': The message expected in the return value of the
+   *       process method for this scenario.
+   *     - 1+ arrays keyed by the line number in the input file that triggered
+   *       the failed validation status, further keyed by:
+   *       - 'line_contents': The raw contents of this line that failed.
+   */
+  public function provideValidDelimitedFileFailedCases() {
+    $scenarios = [];
+
+    // #0: The first row is empty.
+    $scenarios[] = [
+      [
+        1 => [
+          'case' => 'Raw row is empty',
+          'valid' => FALSE,
+          'failedItems' => [
+            'raw_row' => 'is an empty string value',
+          ],
+        ],
+      ],
+      [
+        'unsupported' => [
+          'expected_message' => 'The following lines in the input file do not contain a valid delimiter supported by this importer.',
+          1 => [
+            'line_contents' => '',
+          ],
+        ],
+      ],
+    ];
+
+    // #1: No supported delimiters were used.
+
+    // #2: The delimited row contains too few columns.
+
+    // #3: The delimited row contains too many columns (strict = TRUE).
+
+    return $scenarios;
+  }
+
+  /**
    * Data Provider for testProcessEmptyCellFailures().
    *
    * @return array

--- a/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterProcessValidationTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterProcessValidationTest.php
@@ -366,7 +366,11 @@ class TraitImporterProcessValidationTest extends ChadoTestKernelBase {
     // First check that we were given the correct message.
     $selected_message_title = $this->cssSelect('div.form-item label');
     $provided_message = (string) $selected_message_title[0];
-    $this->assertStringContainsString($expectations['expected_message'], $provided_message, 'The message expected from processing ValidDataFile failures for this scenario did not match the one in the rendered output.');
+    $this->assertStringContainsString(
+      $expectations['expected_message'],
+      $provided_message,
+      'The message expected from processing ValidDataFile failures for this scenario did not match the one in the rendered output.'
+    );
 
     // Next, check for expected items.
     $selected_list_items = $this->cssSelect('div.form-item ul li');
@@ -483,13 +487,21 @@ class TraitImporterProcessValidationTest extends ChadoTestKernelBase {
     // Check the rendered output.
     // First check that we were given the correct message.
     $selected_message_markup = $this->cssSelect('ul li div.case-message');
-    $this->assertStringContainsString($expectations['expected_message'], (string) $selected_message_markup[0], 'The message expected for this scenario for ProcessValidHeadersFailures did not match the message in the render array.');
+    $this->assertStringContainsString(
+      $expectations['expected_message'],
+      (string) $selected_message_markup[0],
+      'The message expected from processing ValidHeaders failures for this scenario did not match the message in the render array.'
+    );
     // Check that we have a table that contains the expected 2 rows.
     $selected_table_rows = $this->cssSelect('tbody tr');
     $this->assertCount(2, $selected_table_rows, 'The rendered table by processValidHeadersFailures does not contain the expected 2 rows for this scenario.');
     // Check for the "Provided Headers" heading on the 2nd row.
     $selected_provided_headers_th = $this->cssSelect('tbody tr.provided-headers th');
-    $this->assertEquals('Provided Headers', (string) $selected_provided_headers_th[0], 'The second row of the rendered table does not contain the "Provided Headers" table header for this scenario.');
+    $this->assertEquals(
+      'Provided Headers',
+      (string) $selected_provided_headers_th[0],
+      'The second row of the rendered table does not contain the "Provided Headers" table header for this scenario.'
+    );
     // Check that the row values are the same as what we provided.
     $selected_provided_headers_td = $this->cssSelect('tbody tr.provided-headers td');
     // If the headers row was empty, check that we have no values in row 2.
@@ -736,7 +748,7 @@ class TraitImporterProcessValidationTest extends ChadoTestKernelBase {
       $this->assertStringContainsString(
         $expectations[$table_case]['expected_message'],
         $table_message,
-        'The message expected for this scenario did not match the message in the render array.'
+        'The message expected from processing ValidDelimitedFile failures for this scenario did not match the message in the render array.'
       );
 
       // Pull out the table rows for this table case.
@@ -908,7 +920,11 @@ class TraitImporterProcessValidationTest extends ChadoTestKernelBase {
     // Check the message above this table is correct.
     $selected_message_markup = $this->cssSelect("ul li div.case-message");
     $table_message = (string) $selected_message_markup[0];
-    $this->assertStringContainsString($expectations['expected_message'], $table_message, 'The message expected for this scenario did not match the message in the render array.');
+    $this->assertStringContainsString(
+      $expectations['expected_message'],
+      $table_message,
+      'The message expected from processing EmptyCell failures for this scenario did not match the message in the render array.'
+    );
 
     // Select the table rows and check for our expected values.
     $selected_rows = $this->cssSelect("tbody tr");
@@ -1122,7 +1138,7 @@ class TraitImporterProcessValidationTest extends ChadoTestKernelBase {
     $this->assertStringContainsString(
       $expectations['expected_message'],
       $table_message,
-      'The message expected for this scenario did not match the message in the render array.'
+      'The message expected from processing ValueInList failures for this scenario did not match the message in the render array.'
     );
 
     // Select and save the table header.
@@ -1155,7 +1171,8 @@ class TraitImporterProcessValidationTest extends ChadoTestKernelBase {
       $this->assertEquals(
         $expected_line_no,
         $line_number,
-        "Did not get the expected line number in the rendered table from processing ValueInList failures.");
+        "Did not get the expected line number in the rendered table from processing ValueInList failures."
+      );
       // 2nd Column and up: Column(s) with invalid value
       $current_column_index = 1;
       foreach ($expected_values as $column_header => $invalid_value) {
@@ -1420,7 +1437,11 @@ class TraitImporterProcessValidationTest extends ChadoTestKernelBase {
       // Check the message above this table is correct.
       $selected_message_markup = $this->cssSelect("ul li div.case-message.case-$table_case");
       $table_message = (string) $selected_message_markup[0];
-      $this->assertStringContainsString($expectations[$table_case]['expected_message'], $table_message, 'The message expected for this scenario did not match the message in the render array.');
+      $this->assertStringContainsString(
+        $expectations[$table_case]['expected_message'],
+        $table_message,
+        'The message expected from processing DuplicateTraits failures for this scenario did not match the message in the render array.'
+      );
 
       // Pull out the table rows for this table case.
       $selected_rows = $this->cssSelect("table.table-case-$table_case tbody tr");

--- a/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterProcessValidationTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterProcessValidationTest.php
@@ -843,24 +843,42 @@ class TraitImporterProcessValidationTest extends ChadoTestKernelBase {
     // Check the message above this table is correct.
     $selected_message_markup = $this->cssSelect("ul li div.case-message");
     $table_message = (string) $selected_message_markup[0];
-    $this->assertStringContainsString($expectations['expected_message'], $table_message, 'The message expected for this scenario did not match the message in the render array.');
+    $this->assertStringContainsString(
+      $expectations['expected_message'],
+      $table_message,
+      'The message expected for this scenario did not match the message in the render array.'
+    );
 
     // Select and save the table header.
     $selected_table_header = $this->cssSelect("thead tr");
     $select_column_headers = (array) $selected_table_header[0]->th;
     // Assert that the number of columns matches the number of we expect.
-    $this->assertCount($expectations['expected_column_count'], $select_column_headers, 'We expected ' . $expectations['expected_column_count'] . 'columns to be in the rendered table for ValueInList failures for this scenario, but instead there are ' . count($select_column_headers) . '.');
+    $this->assertCount(
+      $expectations['expected_column_count'],
+      $select_column_headers,
+      'We expected ' . $expectations['expected_column_count'] . 'columns to be in the rendered table for ValueInList failures for this scenario, but instead there are ' . count($select_column_headers) . '.'
+    );
 
-    // @todo Assert that the number of rows matches what we expect.
-
-    // Select the table rows and check for our expected values.
+    // Select the table rows.
     $selected_rows = $this->cssSelect("tbody tr");
+    // Assert that the number of rows matches what we expect.
+    $expected_row_count = count($expectations['expected_table_rows']);
+    $this->assertCount(
+      $expected_row_count,
+      $selected_rows,
+      'We expected ' . $expected_row_count . 'rows in the rendered table for ValueInList failures for this scenario, but there are ' . count($selected_rows) . '.'
+    );
+
+    // Now check the cell values.
     $current_row_index = 0;
     foreach ($expectations['expected_table_rows'] as $expected_line_no => $expected_values) {
       $select_row_cells = (array) $selected_rows[$current_row_index]->td;
       // 1st Column: Line Number
       $line_number = $select_row_cells[0];
-      $this->assertEquals($expected_line_no, $line_number, "Did not get the expected line number in the rendered table from processing ValueInList failures.");
+      $this->assertEquals(
+        $expected_line_no,
+        $line_number,
+        "Did not get the expected line number in the rendered table from processing ValueInList failures.");
       // 2nd Column and up: Column(s) with invalid value
       $current_column_index = 1;
       foreach ($expected_values as $column_header => $invalid_value) {

--- a/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterProcessValidationTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterProcessValidationTest.php
@@ -765,16 +765,16 @@ class TraitImporterProcessValidationTest extends ChadoTestKernelBase {
           'case' => 'Invalid value(s) in required column(s)',
           'valid' => FALSE,
           'failedItems' => [
-            // Column 'Unit' is at index 4.
-            4 => 'Amy',
+            // Column 'Type' is at index 5.
+            5 => 'Amy',
           ],
         ],
         5 => [
           'case' => 'Invalid value(s) in required column(s)',
           'valid' => FALSE,
           'failedItems' => [
+            // Column 'Unit' is at index 4.
             4 => 'Sam',
-            // Column 'Type' is at index 5.
             5 => 'Ben',
           ],
         ],
@@ -831,6 +831,9 @@ class TraitImporterProcessValidationTest extends ChadoTestKernelBase {
 
     // Process our test failures array for this scenario.
     $render_array = $this->importer->processValueInListFailures($failures, $valid_values);
+
+    //print_r($render_array);
+
     $rendered_markup = $this->renderer->renderRoot($render_array);
     $this->setRawContent($rendered_markup);
 

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorValidDelimitedFileTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorValidDelimitedFileTest.php
@@ -87,7 +87,7 @@ class ValidatorValidDelimitedFileTest extends ChadoTestKernelBase {
         [
           'case' => 'Raw row is empty',
           'valid' => FALSE,
-          'failedItems' => ['raw_row' => 'is an empty string value'],
+          'failedItems' => ['raw_row' => ''],
 
         ],
       ],


### PR DESCRIPTION
**Issue #134**

## Motivation

Finish creating new tests in TraitImporterProcessValidationTest to trigger every case from each processing method implemented in PR #127 and render the output to compare with expectations. Each test will have its own data provider.

## What does this PR do?
Implements the following test methods and their associated data provider:
   - [x] `testProcessValidDataFileFailures()`
   - [x] `testProcessValidDelimitedFileFailures()`
   - [x] `testProcessEmptyCellFailures()`
   - [x] `testProcessValueInListFailures()`

Updates were also made to the process methods themselves (in `TripalCultivatePhenotypesTraitsImporter.php`) to further simplify, make consistent with eachother, and add html classes to the render arrays.

One update to the `ValidDelimitedFile` validator was made to return the `$raw_row` parameter as it was provided in the case of it being empty. This was made to simplify testing (no separate check for a "raw row is empty" returned value) but also may help troubleshoot future edge cases where perhaps the line contains "gremlins" that show up as empty.

## Testing
### Automated Testing
Adds 4 tests and data providers to: `/tests/src/Kernel/TripalImporter/TraitImporterProcessValidationTest.php` (See checklist above)

These tests bring coverage of the Traits Importer back up to 100% 🎉 

### Manual Testing
To verify the changes that have been made to the process methods, you can add a `print_r($rendered_markup);` under the line:

> `$this->setRawContent($rendered_markup);`

in each of the test methods. Run the test, then copy the printed output from any of the data provider scenarios and paste using PHP Execute in a TripalCultivate Phenotypes docker container, or more simply, in an online HTML renderer such as https://htmledit.squarefree.com/

You can also check the class of each render array to make sure each process method produces a uniquely-classed rendered object and, when multiple tables appear for a single scenario (should only happen for `ValidDelimitedFile` and `DuplicateTraits`), that each table is distinguishable. 