### PR TITLE
Make importer share form interface support dark mode

### DIFF
--- a/trpcultivate_phenotypes/css/trpcultivate-phenotypes-style-stage-accordion.css
+++ b/trpcultivate_phenotypes/css/trpcultivate-phenotypes-style-stage-accordion.css
@@ -5,14 +5,20 @@
 
 /* Stage Title Panel */
 .tcp-stage-title {
-  background-color: #EAEAEA;
-  border: 0;
-  color: #333333;
+  background-color: light-dark(#EAEAEA, #4A4A4C);
+  color: light-dark(#333333, #FFFFFF);
   cursor: pointer;
   margin: 1px 0 0 0;
   padding: 20px;
   text-align: left;
   width: auto;
+
+  border-top-left-radius: 10px;
+  border-top-right-radius: 10px;
+  -webkit-border-top-left-radius: 10px;
+  -webkit-border-top-right-radius: 10px;
+  -moz-border-radius-topleft: 10px;
+  -moz-border-radius-topright: 10px;
 }
 
 /* Stage Content Panel */
@@ -23,7 +29,7 @@ div.tcp-stage-title + div {
 }
 
 .tcp-stage-title:hover {
-  background-color: #DADADA;
+  background-color: light-dark(#DADADA, #3B3B3D);
 }
 
 /* Iconography - stage indicators */

--- a/trpcultivate_phenotypes/css/trpcultivate-phenotypes-style-stage-accordion.css
+++ b/trpcultivate_phenotypes/css/trpcultivate-phenotypes-style-stage-accordion.css
@@ -17,7 +17,7 @@
 
 /* Stage Content Panel */
 div.tcp-stage-title + div {
-  background-color: #FFFFFF;
+  background-color: inherit;
   display: none;
   padding: 10px;
 }


### PR DESCRIPTION
**Issue #147 Support Dark Mode**

## Motivation

<!-- This can usually be copied from the issue. Please do not just say, go see issue but instead copy the relevant details here. -->

## What does this PR do?
*Please describe each things this PR does. For example, a PR may 1) solve a specific bug, 2) create an automated test to ensure it doesn't return.*

1. Adjust the background CSS rule of stage container so that it will support light and dark modes.

## Testing

### Automated Testing
*Please describe each automated test this PR creates and provide a list of the assertions it makes using casual language.*
*Do not just say things like "asserts the array is not empty" but rather say "Ensures that the return value of method X with these parameters is not an empty array".*

### Manual Testing
*Describe in detail how someone should manually test this functionality.*
*Make sure to include whether they need to build a docker from scratch, create any records, etc.*

1. Switch to branch gBUG.147-ImporterInDarkMode
2. Access Phenotypes Share Importer.
3. In a new tab, go to Appearance > Settings > Gin and set it to dark mode.
4. Refresh the Importer to reload in dark mode
<img width="729" alt="image" src="https://github.com/user-attachments/assets/f46f6c1a-9ec4-48a1-afd0-ca4000c4aec3" />
5. Repeat steps 3 and 4 and select Light mode.