### PR TITLE
G4.161 - Allow multiple genus to be set to a project

### DIFF
--- a/trpcultivate_phenoshare/src/Plugin/TripalImporter/TripalCultivatePhenoShareImporter.php
+++ b/trpcultivate_phenoshare/src/Plugin/TripalImporter/TripalCultivatePhenoShareImporter.php
@@ -2,15 +2,12 @@
 
 namespace Drupal\trpcultivate_phenoshare\Plugin\TripalImporter;
 
-use Drupal\Core\Ajax\AjaxResponse;
-use Drupal\Core\Ajax\InvokeCommand;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\EntityTypeManager;
 use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Render\Renderer;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
-use Drupal\tripal_chado\Controller\ChadoProjectAutocompleteController;
 use Drupal\tripal_chado\Database\ChadoConnection;
 use Drupal\tripal_chado\TripalImporter\ChadoImporterBase;
 use Drupal\trpcultivate_phenotypes\Service\TripalCultivatePhenotypesGenusOntologyService;
@@ -508,20 +505,6 @@ class TripalCultivatePhenoShareImporter extends ChadoImporterBase implements Con
         'type_column' => 'x',
         'property_table' => 'project',
       ],
-      // Used by script to pre-select genus paired to project entered.
-      '#id' => 'trpcultivate-fld-project',
-
-      // AJAX.
-      '#ajax' => [
-        'callback' => [self::class, 'ajaxLoadGenusOfProject'],
-        'disable-refocus' => TRUE,
-        'event' => 'blur',
-        'progress' => [
-          'type' => 'throbber',
-          'message' => '',
-        ],
-        'wrapper' => 'trpcultivate-field-genus-wrapper',
-      ],
     ];
 
     // Field Genus:
@@ -535,7 +518,8 @@ class TripalCultivatePhenoShareImporter extends ChadoImporterBase implements Con
       '#options' => $active_genus,
       '#weight' => -90,
       '#required' => TRUE,
-      '#description' => $this->t('Select the genus for the germplasm represented within the data being uploaded. This genus must be configured for the selected Research Experiment.'),
+      '#description' => $this->t('Select the genus for the germplasm represented within the data being uploaded.
+        This genus must be configured for the selected Research Experiment. Please contact us if you do not see the intended genus.'),
       '#description_display' => 'after',
 
       // States.
@@ -1767,51 +1751,6 @@ class TripalCultivatePhenoShareImporter extends ChadoImporterBase implements Con
     }
 
     return $has_fail;
-  }
-
-  /**
-   * Load genus of project.
-   *
-   * @param array $form
-   *   Drupal form array.
-   * @param object $form_state
-   *   Drupal form state object.
-   *
-   * @return Drupal\Core\Ajax\AjaxResponse
-   *   Drupal AJAX Response.
-   */
-  public static function ajaxLoadGenusOfProject($form, &$form_state) {
-    // Project name.
-    $project = $form_state->getValue('project');
-
-    $response = new AjaxResponse();
-
-    if (!empty($project)) {
-      // The project entered through the auto-complete project field
-      // returns a string, the project name. Additional step of resolving
-      // the name to its project id is required to determine the genus.
-      // T4 - this values is from autocomplete field which seems to contain the
-      // project id (id) part.
-      $project = preg_replace('/\([0-9]\)$/', '', $project);
-      $project_name = trim($project);
-      $project_id = ChadoProjectAutocompleteController::getProjectId($project_name);
-
-      // Get genus of project.
-      $genus_of_project = \Drupal::service('trpcultivate_phenotypes.genus_project')
-        ->getGenusOfProject($project_id);
-
-      // Set the value of genus field to default (- Select -) when genus
-      // is not set for the project.
-      $genus_of_project = ($genus_of_project['genus']) ?? '';
-    }
-    else {
-      // Set the value of genus to default.
-      $genus_of_project = '';
-    }
-
-    $response->addCommand(new InvokeCommand('#trpcultivate-fld-genus', 'val', [$genus_of_project]));
-
-    return $response;
   }
 
 }

--- a/trpcultivate_phenoshare/tests/src/Kernel/TripalImporter/ShareImporterFormTest.php
+++ b/trpcultivate_phenoshare/tests/src/Kernel/TripalImporter/ShareImporterFormTest.php
@@ -735,23 +735,4 @@ class ShareImporterFormTest extends ChadoTestKernelBase {
     }
   }
 
-  /**
-   * Test ajaxLoadGenusOfProject() method in the importer.
-   */
-  public function testAjaxLoadGenusOfProject() {
-
-    $form = $this->form_importer;
-    $form_state = new FormState();
-    $form_state->setValue('project', 'Awesome Project');
-
-    $http_response = $this->phenoshare_importer->ajaxLoadGenusOfProject($form, $form_state)
-      ->getStatusCode();
-
-    $this->assertEquals(
-      200,
-      $http_response,
-      'The method ajaxLoadGenusOfProject is expected to return a 200 (ok) response status code'
-    );
-  }
-
 }

--- a/trpcultivate_phenotypes/src/Plugin/Validators/ProjectGenusMatch.php
+++ b/trpcultivate_phenotypes/src/Plugin/Validators/ProjectGenusMatch.php
@@ -138,17 +138,7 @@ class ProjectGenusMatch extends TripalCultivatePhenotypesValidatorBase implement
         $failed_items = ['genus_provided' => $genus];
       }
       else {
-        $genus_match = FALSE;
-
-        foreach ($project_genus as $value) {
-          // Project genus has one or more genus set.
-          $g = (is_array($value)) ? $value['genus'] : $value;
-
-          if ($g == $genus) {
-            $genus_match = TRUE;
-            break;
-          }
-        }
+        $genus_match = in_array($genus, $project_genus);
 
         if (!$genus_match) {
           // Genus does not match the genus paired to the project.

--- a/trpcultivate_phenotypes/src/Plugin/Validators/ProjectGenusMatch.php
+++ b/trpcultivate_phenotypes/src/Plugin/Validators/ProjectGenusMatch.php
@@ -141,7 +141,9 @@ class ProjectGenusMatch extends TripalCultivatePhenotypesValidatorBase implement
         $genus_match = FALSE;
 
         foreach ($project_genus as $value) {
-          if ((is_array($value) && $value['genus'] == $genus) || $value == $genus) {
+          $g = (is_array($value)) ? $value['genus'] : $value;
+
+          if ($g == $genus) {
             $genus_match = TRUE;
             break;
           }

--- a/trpcultivate_phenotypes/src/Plugin/Validators/ProjectGenusMatch.php
+++ b/trpcultivate_phenotypes/src/Plugin/Validators/ProjectGenusMatch.php
@@ -131,14 +131,23 @@ class ProjectGenusMatch extends TripalCultivatePhenotypesValidatorBase implement
       // the genus provided in the genus field.
       $project_genus = $this->service_PhenoGenusProject->getGenusOfProject($project_id);
 
-      if (!isset($project_genus['genus'])) {
+      if (empty($project_genus)) {
         // Genus does not match the genus paired to the project.
         $case = 'Project has no genus set and could not compare with the genus provided';
         $valid = FALSE;
         $failed_items = ['genus_provided' => $genus];
       }
       else {
-        if ($genus != $project_genus['genus']) {
+        $genus_match = FALSE;
+
+        foreach ($project_genus as $value) {
+          if ((is_array($value) && $value['genus'] == $genus) || $value == $genus) {
+            $genus_match = TRUE;
+            break;
+          }
+        }
+
+        if (!$genus_match) {
           // Genus does not match the genus paired to the project.
           $case = 'Genus does not match the genus set to the project';
           $valid = FALSE;

--- a/trpcultivate_phenotypes/src/Plugin/Validators/ProjectGenusMatch.php
+++ b/trpcultivate_phenotypes/src/Plugin/Validators/ProjectGenusMatch.php
@@ -141,6 +141,7 @@ class ProjectGenusMatch extends TripalCultivatePhenotypesValidatorBase implement
         $genus_match = FALSE;
 
         foreach ($project_genus as $value) {
+          // Project genus has one or more genus set.
           $g = (is_array($value)) ? $value['genus'] : $value;
 
           if ($g == $genus) {

--- a/trpcultivate_phenotypes/src/Plugin/Validators/ProjectGenusMatch.php
+++ b/trpcultivate_phenotypes/src/Plugin/Validators/ProjectGenusMatch.php
@@ -137,15 +137,11 @@ class ProjectGenusMatch extends TripalCultivatePhenotypesValidatorBase implement
         $valid = FALSE;
         $failed_items = ['genus_provided' => $genus];
       }
-      else {
-        $genus_match = in_array($genus, $project_genus);
-
-        if (!$genus_match) {
-          // Genus does not match the genus paired to the project.
-          $case = 'Genus does not match the genus set to the project';
-          $valid = FALSE;
-          $failed_items = ['genus_provided' => $genus];
-        }
+      elseif (!in_array($genus, $project_genus)) {
+        // Genus does not match the genus paired to the project.
+        $case = 'Genus does not match the genus set to the project';
+        $valid = FALSE;
+        $failed_items = ['genus_provided' => $genus];
       }
     }
 

--- a/trpcultivate_phenotypes/src/Service/TripalCultivatePhenotypesGenusProjectService.php
+++ b/trpcultivate_phenotypes/src/Service/TripalCultivatePhenotypesGenusProjectService.php
@@ -103,7 +103,7 @@ class TripalCultivatePhenotypesGenusProjectService {
         foreach ($project_genus as $row) {
           if ($row->value == $genus) {
             $project_has_genus = TRUE;
-            $break;
+            break;
           }
         }
 

--- a/trpcultivate_phenotypes/src/Service/TripalCultivatePhenotypesGenusProjectService.php
+++ b/trpcultivate_phenotypes/src/Service/TripalCultivatePhenotypesGenusProjectService.php
@@ -61,18 +61,17 @@ class TripalCultivatePhenotypesGenusProjectService {
   /**
    * Assign a genus to an experiment/project.
    *
+   * Each genus-project relationship is an entry in projectprop table.
+   *
    * @param int $project
    *   Project (project id number) the parameter $genus will be assigned to.
    * @param string $genus
    *   Genus name/title.
-   * @param bool $replace
-   *   True to replace existing genus of a project with a different genus.
-   *   Default to False.
    *
    * @return bool
    *   True, genus was set successfully or false on error/fail.
    */
-  public function setGenusToProject($project, $genus, $replace = FALSE) {
+  public function setGenusToProject($project, $genus) {
     $error = 0;
 
     if (empty($project) || $project <= 0) {
@@ -135,13 +134,13 @@ class TripalCultivatePhenotypesGenusProjectService {
   }
 
   /**
-   * Get genus of an experiment/project.
+   * Get all genus assigned to a project.
    *
    * @param int $project
    *   Project (project_id number) to search.
    *
    * @return array
-   *   Key is genus/organism id number and value is the genus name/title.
+   *   An array of all the genus assigned to a project.
    */
   public function getGenusOfProject($project) {
     $genus_project = [];
@@ -154,34 +153,15 @@ class TripalCultivatePhenotypesGenusProjectService {
 
       // Fetch genus paired to a project. If multiple genus have been set prior,
       // restrict search to genus that are active/configured using this module.
-      $result = $this->chado_connection->query("
-        SELECT organism_id AS id, genus FROM {1:organism} WHERE genus IN (
-          SELECT value::VARCHAR FROM {1:projectprop} WHERE
-            project_id = :project_id AND
-            type_id = :type_id AND
-            LOWER(value) IN (:active_genus[])
-        ) ORDER BY genus ASC
-        ", [
-          ':project_id' => $project,
-          ':type_id' => $this->sysvar_genus,
-          ':active_genus[]' => $active_genus,
-        ]
-      )
-        ->fetchAllKeyed(0, 1);
+      $result = $this->chado_connection->select('1:projectprop', 'pp')
+        ->fields('pp', ['value'])
+        ->condition('pp.project_id', $project, '=')
+        ->condition('pp.type_id', $this->sysvar_genus, '=')
+        ->where('LOWER(pp.value) IN (:active_genus[])', [':active_genus[]' => $active_genus])
+        ->orderBy('value', 'ASC')
+        ->execute();
 
-      if ($result) {
-        foreach ($result as $organism_id => $genus) {
-          $item = ['id' => $organism_id, 'genus' => $genus];
-
-          if (count($result) == 1) {
-            $genus_project = $item;
-            break;
-          }
-          else {
-            $genus_project[] = $item;
-          }
-        }
-      }
+      $genus_project = $result->fetchCol();
     }
 
     return ($genus_project) ? $genus_project : [];

--- a/trpcultivate_phenotypes/src/Service/TripalCultivatePhenotypesGenusProjectService.php
+++ b/trpcultivate_phenotypes/src/Service/TripalCultivatePhenotypesGenusProjectService.php
@@ -152,7 +152,7 @@ class TripalCultivatePhenotypesGenusProjectService {
         ->condition('pp.project_id', $project, '=')
         ->condition('pp.type_id', $this->sysvar_genus, '=')
         ->where('LOWER(pp.value) IN (:active_genus[])', [':active_genus[]' => $active_genus])
-        ->orderBy('value', 'ASC')
+        ->orderBy('rank', 'ASC')
         ->execute();
 
       $genus_project = $result->fetchCol();

--- a/trpcultivate_phenotypes/src/Service/TripalCultivatePhenotypesGenusProjectService.php
+++ b/trpcultivate_phenotypes/src/Service/TripalCultivatePhenotypesGenusProjectService.php
@@ -151,19 +151,33 @@ class TripalCultivatePhenotypesGenusProjectService {
       // Fetch genus paired to a project. If multiple genus have been set prior,
       // restrict search to genus that are active/configured using this module.
       $result = $this->chado_connection->query("
-        SELECT organism_id AS id, genus FROM {1:organism}
-        WHERE genus IN (SELECT value::VARCHAR FROM {1:projectprop}
-          WHERE project_id = :project_id AND type_id = :type_id AND LOWER(value) IN (:active_genus[]))
-      ", [':project_id' => $project, ':type_id' => $this->sysvar_genus, ':active_genus[]' => $active_genus]);
+        SELECT organism_id AS id, genus FROM {1:organism} WHERE genus IN (
+          SELECT value::VARCHAR FROM {1:projectprop} WHERE
+            project_id = :project_id AND
+            type_id = :type_id AND
+            LOWER(value) IN (:active_genus[])
+        ) ORDER BY genus ASC
+        ", [
+          ':project_id' => $project,
+          ':type_id' => $this->sysvar_genus,
+          ':active_genus[]' => $active_genus,
+        ]
+      )
+        ->fetchAllKeyed(0, 1);
 
-      $genus_project = $result->fetchAll();
-    }
+      if ($result) {
+        foreach ($result as $organism_id => $genus) {
+          $item = ['id' => $organism_id, 'genus' => $genus];
 
-    if (count($genus_project) == 1) {
-      $genus_project = [
-        'id' => $genus_project[0]->id,
-        'genus' => $genus_project[0]->genus,
-      ];
+          if (count($result) == 1) {
+            $genus_project = $item;
+            break;
+          }
+          else {
+            $genus_project[] = $item;
+          }
+        }
+      }
     }
 
     return ($genus_project) ? $genus_project : [];

--- a/trpcultivate_phenotypes/src/Service/TripalCultivatePhenotypesGenusProjectService.php
+++ b/trpcultivate_phenotypes/src/Service/TripalCultivatePhenotypesGenusProjectService.php
@@ -89,36 +89,40 @@ class TripalCultivatePhenotypesGenusProjectService {
       $is_active_genus = (in_array($g, array_keys($this->sysvar_genusontology))) ? TRUE : FALSE;
 
       if ($is_active_genus) {
-        $result = $this->chado_connection->query("
-          SELECT projectprop_id AS id FROM {1:projectprop}
-          WHERE project_id = :project_id AND type_id = :type_id LIMIT 1
-        ", [':project_id' => $project, ':type_id' => $this->sysvar_genus]);
+        // Pull all genus assigned to the project.
+        $result = $this->chado_connection->select('1:projectprop', 'pp')
+          ->fields('pp', ['value', 'rank'])
+          ->condition('pp.project_id', $project, '=')
+          ->condition('pp.type_id', $this->sysvar_genus, '=')
+          ->orderBy('rank', 'DESC')
+          ->execute();
 
-        $projectprop_id = $result->fetchField();
+        $project_genus = $result->fetchAll();
 
-        if ($projectprop_id > 0) {
-          // Has a genus.
-          if ($replace) {
-            // And wishes to replace with another genus.
-            $this->chado_connection->query("
-              UPDATE {1:projectprop} SET value = :new_genus WHERE projectprop_id = :id
-            ", [':new_genus' => $genus, ':id' => $projectprop_id]);
+        $project_has_genus = FALSE;
+        $next_rank = 0;
+
+        // Determine if the project already had the genus.
+        foreach ($project_genus as $i => $g) {
+          if ($i == 0) {
+            $next_rank = $g->rank;
           }
 
-          // Do nothing if maintain the same genus.
+          if ($g->value == $genus) {
+            $project_has_genus = TRUE;
+            $break;
+          }
         }
-        else {
-          // Not set yet, no record in projectprop.
-          // Create a relationship regardless to replace or not.
-          $sql = "INSERT INTO {1:projectprop} (project_id, type_id, value) VALUES (:project, :config_genus, :genus)";
-          $this->chado_connection->query(
-            $sql,
-            [
-              ':project' => $project,
-              ':config_genus' => $this->sysvar_genus,
-              ':genus' => $genus,
-            ],
-          );
+
+        if (!$project_has_genus) {
+          $this->chado_connection->insert('1:projectprop')
+            ->fields([
+              'project_id' => $project,
+              'type_id' => $this->sysvar_genus,
+              'value' => $genus,
+              'rank' => $next_rank + 1,
+            ])
+            ->execute();
         }
       }
       else {

--- a/trpcultivate_phenotypes/src/Service/TripalCultivatePhenotypesGenusProjectService.php
+++ b/trpcultivate_phenotypes/src/Service/TripalCultivatePhenotypesGenusProjectService.php
@@ -89,25 +89,19 @@ class TripalCultivatePhenotypesGenusProjectService {
 
       if ($is_active_genus) {
         // Pull all genus assigned to the project.
-        $result = $this->chado_connection->select('1:projectprop', 'pp')
+        $project_genus = $this->chado_connection->select('1:projectprop', 'pp')
           ->fields('pp', ['value', 'rank'])
           ->condition('pp.project_id', $project, '=')
           ->condition('pp.type_id', $this->sysvar_genus, '=')
           ->orderBy('rank', 'DESC')
-          ->execute();
-
-        $project_genus = $result->fetchAll();
+          ->execute()
+          ->fetchAll();
 
         $project_has_genus = FALSE;
-        $next_rank = 0;
 
         // Determine if the project already had the genus.
-        foreach ($project_genus as $i => $g) {
-          if ($i == 0) {
-            $next_rank = $g->rank;
-          }
-
-          if ($g->value == $genus) {
+        foreach ($project_genus as $row) {
+          if ($row->value == $genus) {
             $project_has_genus = TRUE;
             $break;
           }
@@ -119,7 +113,7 @@ class TripalCultivatePhenotypesGenusProjectService {
               'project_id' => $project,
               'type_id' => $this->sysvar_genus,
               'value' => $genus,
-              'rank' => $next_rank + 1,
+              'rank' => (isset($project_genus[0])) ? $project_genus[0]->rank + 1 : 1,
             ])
             ->execute();
         }

--- a/trpcultivate_phenotypes/src/Service/TripalCultivatePhenotypesGenusProjectService.php
+++ b/trpcultivate_phenotypes/src/Service/TripalCultivatePhenotypesGenusProjectService.php
@@ -140,7 +140,7 @@ class TripalCultivatePhenotypesGenusProjectService {
    *   Key is genus/organism id number and value is the genus name/title.
    */
   public function getGenusOfProject($project) {
-    $genus_project = 0;
+    $genus_project = [];
 
     if ($project > 0) {
       $sysvar_genus = array_keys($this->sysvar_genusontology);
@@ -152,15 +152,21 @@ class TripalCultivatePhenotypesGenusProjectService {
       // restrict search to genus that are active/configured using this module.
       $result = $this->chado_connection->query("
         SELECT organism_id AS id, genus FROM {1:organism}
-        WHERE genus = (SELECT value::VARCHAR FROM {1:projectprop}
-          WHERE project_id = :project_id AND type_id = :type_id AND LOWER(value) IN (:active_genus[]) LIMIT 1)
-        LIMIT 1
+        WHERE genus IN (SELECT value::VARCHAR FROM {1:projectprop}
+          WHERE project_id = :project_id AND type_id = :type_id AND LOWER(value) IN (:active_genus[]))
       ", [':project_id' => $project, ':type_id' => $this->sysvar_genus, ':active_genus[]' => $active_genus]);
 
-      $genus_project = $result->fetchObject();
+      $genus_project = $result->fetchAll();
     }
 
-    return ($genus_project) ? ['id' => $genus_project->id, 'genus' => $genus_project->genus] : 0;
+    if (count($genus_project) == 1) {
+      $genus_project = [
+        'id' => $genus_project[0]->id,
+        'genus' => $genus_project[0]->genus,
+      ];
+    }
+
+    return ($genus_project) ? $genus_project : [];
   }
 
 }

--- a/trpcultivate_phenotypes/src/Service/TripalCultivatePhenotypesGenusProjectService.php
+++ b/trpcultivate_phenotypes/src/Service/TripalCultivatePhenotypesGenusProjectService.php
@@ -134,7 +134,7 @@ class TripalCultivatePhenotypesGenusProjectService {
    *   Project (project_id number) to search.
    *
    * @return array
-   *   An array of all the genus assigned to a project.
+   *   A list of all the genus assigned to a project.
    */
   public function getGenusOfProject($project) {
     $genus_project = [];

--- a/trpcultivate_phenotypes/tests/src/Kernel/ServiceGenusProjectTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/ServiceGenusProjectTest.php
@@ -41,18 +41,27 @@ class ServiceGenusProjectTest extends ChadoTestKernelBase {
   ];
 
   /**
-   * Configuration.
-   *
-   * @var \Drupal\Core\Config\Config
-   */
-  private $config;
-
-  /**
-   * A genus used as an alternative genus to the genus a project has been set.
+   * Configuration terms.genus.
    *
    * @var string
    */
-  private $alt_genus = 'AlternativeGenus';
+  private $sysvar_genus;
+
+  /**
+   * A set of configured and not configured genus as test genus input value.
+   *
+   * @var array
+   */
+  private array $genus = [];
+
+  /**
+   * A test project id number.
+   *
+   * The project id number is obtained after creating a project record.
+   *
+   * @var int
+   */
+  private int $project;
 
   /**
    * {@inheritdoc}
@@ -66,29 +75,60 @@ class ServiceGenusProjectTest extends ChadoTestKernelBase {
     // Install module configuration.
     $this->installConfig(['trpcultivate_phenotypes']);
 
-    // Fetch module settings.
-    $this->config = \Drupal::configFactory()->getEditable('trpcultivate_phenotypes.settings');
-
     // Create a test chado instance and then set it in the container for use by
     // our service.
     $this->chado_connection = $this->createTestSchema(ChadoTestKernelBase::PREPARE_TEST_CHADO);
 
     // Set terms used to create relations.
-    $this->setTermConfig();
+    $terms = $this->setTermConfig();
+    $this->sysvar_genus = $terms['genus'];
 
-    // Create and configure a genus to be used to switch a project genus to
-    // using this genus.
-    $organism_id = $this->chado_connection->insert('1:organism')
+    // Create test genus.
+    $ins_genus = [
+      'configured' => [
+        'Genus1',
+        'Genus2',
+        'Genus3',
+        'Genus4',
+        'Genus5',
+      ],
+      'not-configured' => [
+        'Genus6',
+      ],
+    ];
+
+    foreach ($ins_genus as $type => $genus_set) {
+      foreach ($genus_set as $i => $genus) {
+        $organism_id = $this->chado_connection->insert('1:organism')
+          ->fields([
+            'genus' => $genus,
+            'species' => 'species:' . $i,
+          ])
+          ->execute();
+
+        $this->assertIsNumeric($organism_id, 'Unable to insert genus: ' . $genus);
+
+        $this->genus[$type][$organism_id] = $genus;
+
+        if ($type == 'configured') {
+          $this->setOntologyConfig($genus);
+        }
+      }
+    }
+
+    // Create test project.
+    $project_id = $this->chado_connection->insert('1:project')
       ->fields([
-        'genus' => $this->alt_genus,
-        'species' => 'some species',
+        'name' => 'This is a test project',
+        'description' => 'A project description',
       ])
       ->execute();
 
-    $this->assertIsNumeric($organism_id, 'Unable to create alternative genus');
+    $this->assertIsNumeric($project_id, 'Unable to create project');
+    $this->project = $project_id;
 
-    // Configure the genus.
-    $this->setOntologyConfig($this->alt_genus);
+    $container = \Drupal::getContainer();
+    $this->service_PhenoGenusProject = $container->get('trpcultivate_phenotypes.genus_project');
   }
 
   /**
@@ -97,27 +137,47 @@ class ServiceGenusProjectTest extends ChadoTestKernelBase {
    * @return array
    *   Each genus-project test scenario is an array witht the following values:
    *   - A string, human-readable short description of the test scenario.
-   *   - A string, the name or title of a project.
-   *   - An array, the genus and species of the organism that will be
+   *   - An integer indicating the number of genus to set to the project.
    *     paired with the project. Keyed by 'genus' and 'species'.
    *   - An array of expected values, with the following keys:
    *     - 'project_genus': the expected genus returned by the method
    *     getGenusOfProject().
-   *     - 'alternative_genus': a genus returned after setting a genus.
    */
   public function provideGenusProjectForGenusProjectService() {
     return [
-      // #0: A project with configured genus.
+      // #0: A project with one configured genus.
+      [
+        'A project with a configured genus',
+        1,
+        [
+          'project_genus' => ['Genus1'],
+        ],
+      ],
+
+      // #1: A project with two configured genus.
+      [
+        'A project with two configured genus',
+        2,
+        [
+          'project_genus' => [
+            'Genus1',
+            'Genus2',
+          ],
+        ],
+      ],
+
+      // #3: A project with 5 configured genus.
       [
         'A project with configured genus',
-        'Project - Plant Breeding',
+        5,
         [
-          'genus' => 'a genus',
-          'species' => 'a species',
-        ],
-        [
-          'project_genus' => 'a genus',
-          'alternative_genus' => 'AlternativeGenus',
+          'project_genus' => [
+            'Genus1',
+            'Genus2',
+            'Genus3',
+            'Genus4',
+            'Genus5',
+          ],
         ],
       ],
     ];
@@ -128,75 +188,60 @@ class ServiceGenusProjectTest extends ChadoTestKernelBase {
    *
    * @param string $scenario
    *   Human-readable text description of the test scenario.
-   * @param string $project_name
-   *   A string, the name or title of a project.
-   * @param array $project_genus
-   *   An array, the genus and species of the organism that will be
-   *   paired with the project. Keyed by 'genus' and 'species'.
+   * @param int $genus_count
+   *   An integer indicating the number of genus to set to the project.
    * @param array $expected
    *   An array of expected values, with the following keys:
    *     - 'project_genus': the expected genus returned by the method
    *     getGenusOfProject().
-   *     - 'alternative_genus': a genus returned after setting a genus.
    *
    * @dataProvider provideGenusProjectForGenusProjectService
    */
-  public function testGenusProjectService($scenario, $project_name, $project_genus, $expected) {
-    // Create the project record.
-    $project_id = $this->chado_connection->insert('1:project')
-      ->fields([
-        'name' => $project_name,
-        'description' => 'A project description',
-      ])
-      ->execute();
+  public function testGenusProjectService($scenario, $genus_count, $expected) {
 
-    $this->assertIsNumeric($project_id, 'Unable to create project in scenario ' . $scenario);
+    $project_genus = [];
+    for ($i = 0; $i < $genus_count; $i++) {
+      $project_genus[] = 'Genus' . ($i + 1);
+    }
 
-    // Create the genus record.
-    $organism_id = $this->chado_connection->insert('1:organism')
-      ->fields([
-        'genus' => $project_genus['genus'],
-        'species' => $project_genus['species'],
-      ])
-      ->execute();
+    foreach ($project_genus as $genus) {
+      $is_set = $this->service_PhenoGenusProject->setGenusToProject($this->project, $genus);
+      $this->assertTrue($is_set, 'Project Genus Service failed to set a genus to project in scenario: ' . $scenario);
+    }
 
-    $this->assertIsNumeric($organism_id, 'Unable to create project genus in scenario ' . $scenario);
+    $set_genus = $this->service_PhenoGenusProject->getGenusOfProject($this->project);
 
-    // Configure the genus.
-    $this->setOntologyConfig($project_genus['genus']);
-
-    // Genus Project Service.
-    $this->service_PhenoGenusProject = \Drupal::service('trpcultivate_phenotypes.genus_project');
-    $this->assertNotNull($this->service_PhenoGenusProject, 'Failed to instantiate Genus Project Service in scenario ' . $scenario);
-
-    // Test setGenusToProject().
-    $is_set = $this->service_PhenoGenusProject->setGenusToProject($project_id, $project_genus['genus'], TRUE);
-    $this->assertTrue($is_set, 'Project Genus Service failed to set a genus to project in scenario ' . $scenario);
-
-    // Keep the same project genus by setting the replace flag to FALSE.
-    $is_set = $this->service_PhenoGenusProject->setGenusToProject($project_id, $project_genus['genus'], FALSE);
-    $this->assertTrue($is_set, 'Project Genus Service failed to set a genus to project in scenario ' . $scenario);
-
-    // Test getGenusOfProject().
-    $genus_of_project = $this->service_PhenoGenusProject->getGenusOfProject($project_id);
     $this->assertEquals(
+      count($set_genus),
+      count($expected['project_genus']),
+      'The number of genus set does no match expected genus count in scenario: ' . $scenario
+    );
+
+    $this->assertEquals(
+      $set_genus,
       $expected['project_genus'],
-      $genus_of_project['genus'],
-      'The genus of project does not match expected genus in scenario ' . $scenario
+      'The genus set does no match expected genus in scenario: ' . $scenario
     );
 
-    // Replace the genus with the alternative genus.
-    $is_alt_genus_set = $this->service_PhenoGenusProject->setGenusToProject($project_id, $this->alt_genus, TRUE);
-    $this->assertTrue($is_alt_genus_set, 'Project Genus Service failed to set alternate genus to project in scenario ' . $scenario);
+    // Test the rank assigned is the order of the genus as it appears in the
+    // expected genus array (plus 1 - since zero-based index and rank starts 1).
+    $project_genus = $this->chado_connection->select('1:projectprop', 'pp')
+      ->fields('pp', ['value', 'rank'])
+      ->condition('pp.project_id', $this->project, '=')
+      ->condition('pp.type_id', $this->sysvar_genus, '=')
+      ->orderBy('rank', 'ASC')
+      ->execute()
+      ->fetchAll();
 
-    $new_genus_of_project = $this->service_PhenoGenusProject->getGenusOfProject($project_id);
-    $key = array_search($expected['alternative_genus'], array_column($new_genus_of_project, 'genus'));
+    foreach ($project_genus as $row) {
+      $key = array_search($row->value, $expected['project_genus']);
 
-    $this->assertEquals(
-      $expected['alternative_genus'],
-      $new_genus_of_project[$key]['genus'],
-      'The genus of project does not match expected alternative genus in scenario ' . $scenario
-    );
+      $this->assertEquals(
+        $key + 1,
+        $row->rank,
+        'The rank assigned to the genus does not match expected rank value in scenario: ' . $scenario
+      );
+    }
   }
 
 }

--- a/trpcultivate_phenotypes/tests/src/Kernel/ServiceGenusProjectTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/ServiceGenusProjectTest.php
@@ -190,9 +190,11 @@ class ServiceGenusProjectTest extends ChadoTestKernelBase {
     $this->assertTrue($is_alt_genus_set, 'Project Genus Service failed to set alternate genus to project in scenario ' . $scenario);
 
     $new_genus_of_project = $this->service_PhenoGenusProject->getGenusOfProject($project_id);
+    $key = array_search($expected['alternative_genus'], array_column($new_genus_of_project, 'genus'));
+
     $this->assertEquals(
       $expected['alternative_genus'],
-      $new_genus_of_project['genus'],
+      $new_genus_of_project[$key]['genus'],
       'The genus of project does not match expected alternative genus in scenario ' . $scenario
     );
   }

--- a/trpcultivate_phenotypes/tests/src/Kernel/ServiceGenusProjectTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/ServiceGenusProjectTest.php
@@ -48,7 +48,7 @@ class ServiceGenusProjectTest extends ChadoTestKernelBase {
   private $sysvar_genus;
 
   /**
-   * A set of configured and not configured genus as test genus input value.
+   * A set of configured genus as test genus input value.
    *
    * @var array
    */
@@ -57,7 +57,7 @@ class ServiceGenusProjectTest extends ChadoTestKernelBase {
   /**
    * A test project id number.
    *
-   * The project id number is obtained after creating a project record.
+   * The project id number obtained after creating a project record.
    *
    * @var int
    */
@@ -121,25 +121,24 @@ class ServiceGenusProjectTest extends ChadoTestKernelBase {
    *   Each genus-project test scenario is an array witht the following values:
    *   - A string, human-readable short description of the test scenario.
    *   - An integer indicating the number of genus to set to the project.
-   *     paired with the project. Keyed by 'genus' and 'species'.
    *   - An array of expected values, with the following keys:
    *     - 'project_genus': the expected genus returned by the method
    *     getGenusOfProject().
    */
   public function provideGenusProjectForGenusProjectService() {
     return [
-      // #0: A project with one configured genus.
+      // #0: A project with one genus.
       [
-        'A project with a configured genus',
+        'A project with a genus',
         1,
         [
           'project_genus' => ['Genus1'],
         ],
       ],
 
-      // #1: A project with two configured genus.
+      // #1: A project with two genus.
       [
-        'A project with two configured genus',
+        'A project with two genus',
         2,
         [
           'project_genus' => [
@@ -149,9 +148,9 @@ class ServiceGenusProjectTest extends ChadoTestKernelBase {
         ],
       ],
 
-      // #3: A project with 5 configured genus.
+      // #3: A project with 5 genus.
       [
-        'A project with configured genus',
+        'A project with five genus',
         5,
         [
           'project_genus' => [
@@ -182,12 +181,9 @@ class ServiceGenusProjectTest extends ChadoTestKernelBase {
    */
   public function testGenusProjectService($scenario, $genus_count, $expected) {
 
-    $project_genus = [];
     for ($i = 0; $i < $genus_count; $i++) {
-      $project_genus[] = 'Genus' . ($i + 1);
-    }
+      $genus = 'Genus' . ($i + 1);
 
-    foreach ($project_genus as $genus) {
       $is_set = $this->service_PhenoGenusProject->setGenusToProject($this->project, $genus);
       $this->assertTrue($is_set, 'Project Genus Service failed to set a genus to project in scenario: ' . $scenario);
     }
@@ -206,7 +202,7 @@ class ServiceGenusProjectTest extends ChadoTestKernelBase {
       'The genus set does no match expected genus in scenario: ' . $scenario
     );
 
-    // Test the rank assigned is the order of the genus as it appears in the
+    // Test the rank assigned is the order of each genus as it appears in the
     // expected genus array (plus 1 - since zero-based index and rank starts 1).
     $project_genus = $this->chado_connection->select('1:projectprop', 'pp')
       ->fields('pp', ['value', 'rank'])

--- a/trpcultivate_phenotypes/tests/src/Kernel/ServiceGenusProjectTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/ServiceGenusProjectTest.php
@@ -83,37 +83,20 @@ class ServiceGenusProjectTest extends ChadoTestKernelBase {
     $terms = $this->setTermConfig();
     $this->sysvar_genus = $terms['genus'];
 
-    // Create test genus.
-    $ins_genus = [
-      'configured' => [
-        'Genus1',
-        'Genus2',
-        'Genus3',
-        'Genus4',
-        'Genus5',
-      ],
-      'not-configured' => [
-        'Genus6',
-      ],
-    ];
+    // Create test genus - Genus1, Genus2, Genus3, Genus4 and Genus5.
+    for ($i = 1; $i < 6; $i++) {
+      $genus = 'Genus' . $i;
+      $organism_id = $this->chado_connection->insert('1:organism')
+        ->fields([
+          'genus' => $genus,
+          'species' => 'species:' . $i,
+        ])
+        ->execute();
 
-    foreach ($ins_genus as $type => $genus_set) {
-      foreach ($genus_set as $i => $genus) {
-        $organism_id = $this->chado_connection->insert('1:organism')
-          ->fields([
-            'genus' => $genus,
-            'species' => 'species:' . $i,
-          ])
-          ->execute();
+      $this->assertIsNumeric($organism_id, 'Unable to insert genus: ' . $genus);
 
-        $this->assertIsNumeric($organism_id, 'Unable to insert genus: ' . $genus);
-
-        $this->genus[$type][$organism_id] = $genus;
-
-        if ($type == 'configured') {
-          $this->setOntologyConfig($genus);
-        }
-      }
+      $this->genus[] = $genus;
+      $this->setOntologyConfig($genus);
     }
 
     // Create test project.

--- a/trpcultivate_phenotypes/tests/src/Kernel/ServiceGenusProjectTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/ServiceGenusProjectTest.php
@@ -362,10 +362,11 @@ class ServiceGenusProjectTest extends ChadoTestKernelBase {
   }
 
   /**
-   * Test getGenusOfProject() with a genus that is not configured.
+   * Test getGenusOfProject() method.
    */
-  public function testGetGenusOfProjectWithUnconfiguredGenus() {
+  public function testGetGenusOfProject() {
 
+    // Unconfigured genus.
     foreach ($this->genus as $configured_genus) {
       $this->service_PhenoGenusProject->setGenusToProject($this->project, $configured_genus);
     }
@@ -387,6 +388,31 @@ class ServiceGenusProjectTest extends ChadoTestKernelBase {
       self::UNCONFIGURED_GENUS,
       $project_genus,
       'Unconfigured genus set to a project is not returned by the getGenusOfProject() method.'
+    );
+
+    // Invalid project.
+    foreach (['', 0, 9999] as $project) {
+      $project_genus = $this->service_PhenoGenusProject->getGenusOfProject($project);
+
+      $this->assertEmpty(
+        $project_genus,
+        'The return value of getGenusOfProject() method does not match expected value of empty array when project is invalid.'
+      );
+    }
+
+    // Not set with genus.
+    $project_id = $this->chado_connection->insert('1:project')
+      ->fields([
+        'name' => 'This is another test project',
+        'description' => 'A project description',
+      ])
+      ->execute();
+
+    $project_genus = $this->service_PhenoGenusProject->getGenusOfProject($project_id);
+
+    $this->assertEmpty(
+      $project_genus,
+      'The return value of getGenusOfProject() method does not match expected value of empty array when project has no set genus.'
     );
   }
 

--- a/trpcultivate_phenotypes/tests/src/Kernel/ServiceGenusProjectTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/ServiceGenusProjectTest.php
@@ -21,7 +21,7 @@ class ServiceGenusProjectTest extends ChadoTestKernelBase {
    *
    * @var string
    */
-  private const string UNCONFIGURED_GENUS = 'UnconfiguredGenus';
+  private const UNCONFIGURED_GENUS = 'UnconfiguredGenus';
 
   /**
    * Term Service.

--- a/trpcultivate_phenotypes/tests/src/Kernel/ServiceGenusProjectTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/ServiceGenusProjectTest.php
@@ -5,6 +5,7 @@ namespace Drupal\Tests\trpcultivate_phenotypes\Kernel;
 use Drupal\Tests\tripal_chado\Kernel\ChadoTestKernelBase;
 use Drupal\tripal_chado\Database\ChadoConnection;
 use Drupal\Tests\trpcultivate_phenotypes\Traits\PhenotypeImporterTestTrait;
+use Drupal\tripal\Services\TripalLogger;
 
 /**
  * Test Tripal Cultivate Phenotypes Genus Project service.
@@ -64,6 +65,13 @@ class ServiceGenusProjectTest extends ChadoTestKernelBase {
   private int $project;
 
   /**
+   * Tripal Logger log message.
+   *
+   * @var string
+   */
+  private string $log_message;
+
+  /**
    * {@inheritdoc}
    */
   protected function setUp(): void {
@@ -99,6 +107,14 @@ class ServiceGenusProjectTest extends ChadoTestKernelBase {
       $this->setOntologyConfig($genus);
     }
 
+    // This is not a configured genus.
+    $this->chado_connection->insert('1:organism')
+      ->fields([
+        'genus' => 'NotConfiguredGenus',
+        'species' => 'unconfigured species',
+      ])
+      ->execute();
+
     // Create test project.
     $project_id = $this->chado_connection->insert('1:project')
       ->fields([
@@ -110,7 +126,20 @@ class ServiceGenusProjectTest extends ChadoTestKernelBase {
     $this->assertIsNumeric($project_id, 'Unable to create project');
     $this->project = $project_id;
 
+    // Mock Tripal Logger.
+    $mock_logger = $this->getMockBuilder(TripalLogger::class)
+      ->onlyMethods(['error'])
+      ->getMock();
+
+    $mock_logger->method('error')
+      ->willReturnCallback(function ($message) {
+        $this->log_message = $message;
+        return NULL;
+      }
+    );
+
     $container = \Drupal::getContainer();
+    $container->set('tripal.logger', $mock_logger);
     $this->service_PhenoGenusProject = $container->get('trpcultivate_phenotypes.genus_project');
   }
 
@@ -221,6 +250,108 @@ class ServiceGenusProjectTest extends ChadoTestKernelBase {
         'The rank assigned to the genus does not match expected rank value in scenario: ' . $scenario
       );
     }
+  }
+
+  /**
+   * Data Provider: provides invalid genus and project as test input values.
+   *
+   * @return array
+   *   Each test scenario is an array with the following values:
+   *   - A string, human-readable short description of the test scenario.
+   *   - An array keyed by project and genus to represent project and genus
+   *     input values, respectively.
+   *   - An array of expected values, with the following keys:
+   *     - 'is_set': a boolean value returned by setGenusToProject() method to
+   *       indicate the success or failure of the set genus to project request.
+   *     - 'log_message': the Tripal log error message about the failed value.
+   */
+  public function provideInvalidValuesToGenusProjectService() {
+    return [
+      // #0: An empty string value as project input value.
+      [
+        'Empty string as project',
+        [
+          'project' => '',
+          'genus' => 'Genus1',
+        ],
+        [
+          'is_set' => FALSE,
+          'log_message' => 'Error, Project id is empty string, 0 or not a positive number. Could not replace genus.',
+        ],
+      ],
+
+      // #1: Project ID is the value 0.
+      [
+        'Project ID is 0',
+        [
+          'project' => 0,
+          'genus' => 'Genus1',
+        ],
+        [
+          'is_set' => FALSE,
+          'log_message' => 'Error, Project id is empty string, 0 or not a positive number. Could not replace genus.',
+        ],
+      ],
+
+      // #2: Genus is empty string value.
+      [
+        'Empty string as genus',
+        [
+          'project' => 1,
+          'genus' => '',
+        ],
+        [
+          'is_set' => FALSE,
+          'log_message' => 'Error, Genus is an empty string. Could not replace genus.',
+        ],
+      ],
+
+      // #3: Genus is not configured.
+      [
+        'Empty string as genus',
+        [
+          'project' => 1,
+          'genus' => 'NotConfiguredGenus',
+        ],
+        [
+          'is_set' => FALSE,
+          'log_message' => 'Error, Genus is not configured. Could not replace genus.',
+        ],
+      ],
+    ];
+  }
+
+  /**
+   * Test setGenusToProject() method with invalid values.
+   *
+   * @param string $scenario
+   *   A string, human-readable short description of the test scenario.
+   * @param array $input_value
+   *   An array keyed by project and genus to represent project and genus
+   *   input values, respectively.
+   * @param array $expected
+   *   An array of expected values, with the following keys:
+   *     - 'is_set': a boolean value returned by setGenusToProject() method to
+   *       indicate the success or failure of the set genus to project request.
+   *     - 'log_message': the Tripal log error message about the failed value.
+   *
+   * @dataProvider provideInvalidValuesToGenusProjectService
+   */
+  public function testGenusProjectServiceWithInvalidValues($scenario, $input_value, $expected) {
+
+    $is_set = $this->service_PhenoGenusProject->setGenusToProject($input_value['project'], $input_value['genus']);
+
+    $this->assertEquals(
+      $is_set,
+      $expected['is_set'],
+      'The setGenusToProject() method is expected to return false when project or genus is an invalid value in scenario: ' . $scenario
+    );
+
+    $this->assertEquals(
+      $expected['log_message'],
+      $this->log_message,
+      'The log messaged returned by setGenusToProject() with invalid value does not match expected log message in scenario: ' . $scenario
+    );
   }
 
 }

--- a/trpcultivate_phenotypes/tests/src/Kernel/ServiceGenusProjectTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/ServiceGenusProjectTest.php
@@ -17,6 +17,13 @@ class ServiceGenusProjectTest extends ChadoTestKernelBase {
   use PhenotypeImporterTestTrait;
 
   /**
+   * A genus that is not configured.
+   *
+   * @var string
+   */
+  private const string UNCONFIGURED_GENUS = 'UnconfiguredGenus';
+
+  /**
    * Term Service.
    *
    * @var Drupal\trpcultivate_phenotypes\Service\TripalCultivatePhenotypesGenusProjectService
@@ -110,7 +117,7 @@ class ServiceGenusProjectTest extends ChadoTestKernelBase {
     // This is not a configured genus.
     $this->chado_connection->insert('1:organism')
       ->fields([
-        'genus' => 'NotConfiguredGenus',
+        'genus' => self::UNCONFIGURED_GENUS,
         'species' => 'unconfigured species',
       ])
       ->execute();
@@ -311,7 +318,7 @@ class ServiceGenusProjectTest extends ChadoTestKernelBase {
         'Empty string as genus',
         [
           'project' => 1,
-          'genus' => 'NotConfiguredGenus',
+          'genus' => self::UNCONFIGURED_GENUS,
         ],
         [
           'is_set' => FALSE,
@@ -351,6 +358,35 @@ class ServiceGenusProjectTest extends ChadoTestKernelBase {
       $expected['log_message'],
       $this->log_message,
       'The log messaged returned by setGenusToProject() with invalid value does not match expected log message in scenario: ' . $scenario
+    );
+  }
+
+  /**
+   * Test getGenusOfProject() with a genus that is not configured.
+   */
+  public function testGetGenusOfProjectWithUnconfiguredGenus() {
+
+    foreach ($this->genus as $configured_genus) {
+      $this->service_PhenoGenusProject->setGenusToProject($this->project, $configured_genus);
+    }
+
+    $genus_project_ins = $this->chado_connection->insert('1:projectprop')
+      ->fields([
+        'project_id' => $this->project,
+        'type_id' => $this->sysvar_genus,
+        'value' => self::UNCONFIGURED_GENUS,
+        'rank' => 10,
+      ])
+      ->execute();
+
+    $this->assertIsNumeric($genus_project_ins, 'Unable to create genus-project (unconfigured genus) entry.');
+
+    $project_genus = $this->service_PhenoGenusProject->getGenusOfProject($this->project);
+
+    $this->assertNotContains(
+      self::UNCONFIGURED_GENUS,
+      $project_genus,
+      'Unconfigured genus set to a project is not returned by the getGenusOfProject() method.'
     );
   }
 

--- a/trpcultivate_phenotypes/tests/src/Kernel/ServiceGenusProjectTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/ServiceGenusProjectTest.php
@@ -148,7 +148,7 @@ class ServiceGenusProjectTest extends ChadoTestKernelBase {
         ],
       ],
 
-      // #3: A project with 5 genus.
+      // #2: A project with 5 genus.
       [
         'A project with five genus',
         5,

--- a/trpcultivate_phenotypes/tests/src/Kernel/ServiceGenusProjectTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/ServiceGenusProjectTest.php
@@ -217,12 +217,27 @@ class ServiceGenusProjectTest extends ChadoTestKernelBase {
    */
   public function testGenusProjectService($scenario, $genus_count, $expected) {
 
+    $rand_i = mt_rand(0, $genus_count - 1);
+    $re_set_genus = '';
+
     for ($i = 0; $i < $genus_count; $i++) {
       $genus = 'Genus' . ($i + 1);
 
       $is_set = $this->service_PhenoGenusProject->setGenusToProject($this->project, $genus);
       $this->assertTrue($is_set, 'Project Genus Service failed to set a genus to project in scenario: ' . $scenario);
+
+      if ($i == $rand_i) {
+        $re_set_genus = $genus;
+      }
     }
+
+    // A randomly selected genus in the scenario is re-set to test that it will
+    // not alter the expected list of genus.
+    $is_set = $this->service_PhenoGenusProject->setGenusToProject($this->project, $re_set_genus);
+    $this->assertTrue(
+      $is_set,
+      'setGenusToProject() method failed to return the expected value TRUE when re-setting a genus in scenario: ' . $scenario
+    );
 
     $set_genus = $this->service_PhenoGenusProject->getGenusOfProject($this->project);
 

--- a/trpcultivate_phenotypes/tests/src/Kernel/ServiceGenusProjectTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/ServiceGenusProjectTest.php
@@ -226,9 +226,9 @@ class ServiceGenusProjectTest extends ChadoTestKernelBase {
 
     $set_genus = $this->service_PhenoGenusProject->getGenusOfProject($this->project);
 
-    $this->assertEquals(
-      count($set_genus),
-      count($expected['project_genus']),
+    $this->assertCount(
+      $genus_count,
+      $set_genus,
       'The number of genus set does no match expected genus count in scenario: ' . $scenario
     );
 
@@ -345,6 +345,18 @@ class ServiceGenusProjectTest extends ChadoTestKernelBase {
    * @dataProvider provideInvalidValuesToGenusProjectService
    */
   public function testGenusProjectServiceWithInvalidValues($scenario, $input_value, $expected) {
+
+    $has_genus = $this->chado_connection->select('1:projectprop', 'pp')
+      ->fields('pp', ['projectprop_id'])
+      ->condition('pp.type_id', $this->sysvar_genus, '=')
+      ->condition('pp.value', $input_value['genus'], '=')
+      ->execute()
+      ->fetchCol();
+
+    $this->assertEmpty(
+      $has_genus,
+      'Could not test the genus input value with existing project-genus properties entry in scenario: ' . $scenario
+    );
 
     $is_set = $this->service_PhenoGenusProject->setGenusToProject($input_value['project'], $input_value['genus']);
 

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/MetadataInputTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/MetadataInputTest.php
@@ -25,18 +25,6 @@ class MetadataInputTest extends ChadoTestKernelBase {
   protected TripalCultivateValidatorManager $plugin_manager;
 
   /**
-   * An array of genus for testing.
-   *
-   * Has the following keys:
-   * - 'configured': a configured genus.
-   * - 'not-created': a genus not created.
-   * - 'not-configured': a genus that is not configured.
-   *
-   * @var array
-   */
-  protected array $test_genus;
-
-  /**
    * Modules to enable.
    *
    * @var array
@@ -49,6 +37,18 @@ class MetadataInputTest extends ChadoTestKernelBase {
     'trpcultivate',
     'trpcultivate_phenotypes',
   ];
+
+  /**
+   * An array of genus for testing.
+   *
+   * Has the following keys:
+   * - 'configured': a configured genus.
+   * - 'not-created': a genus not created.
+   * - 'not-configured': a genus that is not configured.
+   *
+   * @var array
+   */
+  private array $test_genus;
 
   /**
    * {@inheritdoc}
@@ -67,9 +67,6 @@ class MetadataInputTest extends ChadoTestKernelBase {
     // our service.
     $this->chado_connection = $this->createTestSchema(ChadoTestKernelBase::PREPARE_TEST_CHADO);
     $this->container->set('tripal_chado.database', $this->chado_connection);
-
-    // Set plugin manager service.
-    $this->plugin_manager = \Drupal::service('plugin.manager.trpcultivate_validator');
 
     $genus = 'Tripalus';
     // Create our organism and configure it.
@@ -97,29 +94,32 @@ class MetadataInputTest extends ChadoTestKernelBase {
     $this->test_genus['not-configured'] = $genus;
 
     // Not created.
-    $this->test_genus['not-created'] = 'genus-' . uniqid();
+    $this->test_genus['not-created'] = 'Pinus';
 
-    // Set terms configuration.
-    $this->setTermConfig();
+    // Set plugin manager service.
+    $this->plugin_manager = $this->container->get('plugin.manager.trpcultivate_validator');
   }
 
   /**
-   * Data Provider: provides invalid test form values.
+   * Data Provider: provides genus test form values.
    *
    * @return array
    *   Each test scenario is an array with the following values:
    *   - A string, human-readable short description of the test scenario.
    *   - Form values input.
    *   - An array of expected values, with the following keys:
+   *     - 'has_exception': TRUE if exception is expected and FALSE if not.
    *     - 'error_message': the expected exception message.
    */
-  public function provideTestFormValues() {
+  public function provideGenusTestFormValue() {
+
     return [
       // #0: An empty string as form values.
       [
         'A string value',
         '',
         [
+          'has_exception' => TRUE,
           'error_message' => 'Argument #1 ($form_values) must be of type array, string given',
         ],
       ],
@@ -129,8 +129,11 @@ class MetadataInputTest extends ChadoTestKernelBase {
         'No genus field element',
         [
           'project_id' => 999,
+          'file_id' => 7,
+          'genes' => TRUE,
         ],
         [
+          'has_exception' => TRUE,
           'error_message' => 'Failed to locate genus field element. GenusExists validator expects a form field element name genus',
         ],
       ],
@@ -140,14 +143,30 @@ class MetadataInputTest extends ChadoTestKernelBase {
         'Drupal FormState object',
         new FormState(),
         [
+          'has_exception' => TRUE,
           'error_message' => 'Argument #1 ($form_values) must be of type array, Drupal\Core\Form\FormState given',
+        ],
+      ],
+
+      // #3: Input value is good.
+      [
+        'Input value is valid',
+        [
+          'project_id' => 999,
+          'file_id' => 7,
+          'genus' => 'Tripalus',
+          'genes' => TRUE,
+        ],
+        [
+          'has_exception' => FALSE,
+          'error_message' => '',
         ],
       ],
     ];
   }
 
   /**
-   * Test genus exists validator with invalid inputs.
+   * Test genus exists validator input requirements.
    *
    * @param string $scenario
    *   A string, human-readable short description of the test scenario.
@@ -155,28 +174,27 @@ class MetadataInputTest extends ChadoTestKernelBase {
    *   Form values input.
    * @param array $expected
    *   An array of expected values, with the following keys:
+   *     - 'has_exception': TRUE if exception is expected and FALSE if not.
    *     - 'error_message': the expected exception message.
    *
-   * @dataProvider provideTestFormValues
+   * @dataProvider provideGenusTestFormValue
    */
-  public function testGenusInputs($scenario, $form_values, $expected) {
-
-    // Create a plugin instance for this validator.
-    $validator_id = 'genus_exists';
-    $instance = $this->plugin_manager->createInstance($validator_id);
+  public function testGenusExistsInputValue($scenario, $form_values, $expected) {
 
     $exception_caught = FALSE;
     $exception_message = '';
 
     try {
-      $instance->validateMetadata($form_values);
+      $this->plugin_manager->createInstance('genus_exists')
+        ->validateMetadata($form_values);
     }
     catch (\Throwable $e) {
       $exception_caught  = TRUE;
       $exception_message = $e->getMessage();
     }
 
-    $this->assertTrue(
+    $this->assertEquals(
+      $expected['has_exception'],
       $exception_caught,
       'Failed to catch exception in scenario: ' . $scenario
     );
@@ -189,7 +207,7 @@ class MetadataInputTest extends ChadoTestKernelBase {
   }
 
   /**
-   * Data Provider: provides test genus.
+   * Data Provider: provides genus test input value.
    *
    * @return array
    *   Each test scenario is an array with the following values:
@@ -198,10 +216,10 @@ class MetadataInputTest extends ChadoTestKernelBase {
    *   - An array of expected values, with the following keys:
    *     - 'case': the case title that evaluated the genus value.
    *     - 'valid': the validation status value returned.
-   *     - 'failedItems': failed items when validation failed. It includes the
-   *        genus input value provided.
+   *     - 'failedItems': genus input value that failed validation.
    */
   public function provideTestGenusInput() {
+
     return [
       // #0: A non-existent genus.
       [
@@ -210,7 +228,9 @@ class MetadataInputTest extends ChadoTestKernelBase {
         [
           'case' => 'Genus does not exist',
           'valid' => FALSE,
-          'failedItems' => ['genus' => 'not-created'],
+          'failedItems' => [
+            'genus_provided' => 'not-created',
+          ],
         ],
       ],
 
@@ -221,7 +241,9 @@ class MetadataInputTest extends ChadoTestKernelBase {
         [
           'case' => 'Genus exists but is not configured',
           'valid' => FALSE,
-          'failedItems' => ['genus' => 'not-created'],
+          'failedItems' => [
+            'genus_provided' => 'not-configured',
+          ],
         ],
       ],
 
@@ -232,6 +254,7 @@ class MetadataInputTest extends ChadoTestKernelBase {
         [
           'case' => 'Genus exists and is configured with phenotypes',
           'valid' => TRUE,
+          'failedItems' => [],
         ],
       ],
     ];
@@ -248,20 +271,16 @@ class MetadataInputTest extends ChadoTestKernelBase {
    *   An array of expected values, with the following keys:
    *     - 'case': the case title that evaluated the genus value.
    *     - 'valid': the validation status value returned.
-   *     - 'failedItems': failed items when validation failed. It includes the
-   *        genus input value provided.
+   *     - 'failedItems':  genus input value that failed validation.
    *
    * @dataProvider provideTestGenusInput
    */
   public function testValidatorGenusExists($scenario, $genus_input, $expected) {
 
-    // Create a plugin instance for this validator.
-    $validator_id = 'genus_exists';
-    $instance = $this->plugin_manager->createInstance($validator_id);
+    $form_values = ['genus' => $this->test_genus[$genus_input]];
 
-    $genus = $this->test_genus[$genus_input];
-    $form_values = ['genus' => $genus];
-    $validation_status = $instance->validateMetadata($form_values);
+    $validation_status = $this->plugin_manager->createInstance('genus_exists')
+      ->validateMetadata($form_values);
 
     $this->assertEquals(
       $expected['case'],
@@ -276,10 +295,14 @@ class MetadataInputTest extends ChadoTestKernelBase {
     );
 
     if (!$validation_status['valid']) {
+      // Resolve the genus.
+      $key = $expected['failedItems']['genus_provided'];
+      $expected['failedItems']['genus_provided'] = $this->test_genus[$key];
+
       $this->assertEquals(
-        $genus,
-        $validation_status['failedItems']['genus_provided'],
-        'Failed genus value is expected in failed items in scenario: ' . $scenario
+        $expected['failedItems'],
+        $validation_status['failedItems'],
+        'Failed genus value does not match expected failed items in scenario: ' . $scenario
       );
     }
   }

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/MetadataInputTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/MetadataInputTest.php
@@ -14,6 +14,7 @@ use Drupal\trpcultivate\TripalCultivateValidator\TripalCultivateValidatorManager
  * @group validators
  */
 class MetadataInputTest extends ChadoTestKernelBase {
+
   use PhenotypeImporterTestTrait;
 
   /**
@@ -28,27 +29,12 @@ class MetadataInputTest extends ChadoTestKernelBase {
    *
    * Has the following keys:
    * - 'configured': a configured genus.
-   * - 'configured-secondary': a configured genus used as secondary genus.
+   * - 'not-created': a genus not created.
    * - 'not-configured': a genus that is not configured.
    *
    * @var array
    */
   protected array $test_genus;
-
-  /**
-   * An array of projects for testing.
-   *
-   * Has the following keys:
-   * - 'project-with-configgenus': a project paired with a configured genus.
-   * - 'project-with-2-configgenus': a project paired with 2 configured genus.
-   * - 'project-with-genus': a project paired with a non-configured genus.
-   * - 'project-genus-not-tru-service': a project paired with a configured genus
-   *   without using the genus_project service.
-   * - 'just-project': a project record not paired to a genus.
-   *
-   * @var array
-   */
-  protected array $test_project;
 
   /**
    * Modules to enable.
@@ -98,19 +84,6 @@ class MetadataInputTest extends ChadoTestKernelBase {
     $this->test_genus['configured'] = $genus;
     $this->setOntologyConfig($this->test_genus['configured']);
 
-    $genus = 'Plantanus';
-    // Create our organism and configure it.
-    $organism_id = $this->chado_connection->insert('1:organism')
-      ->fields([
-        'genus' => $genus,
-        'species' => 'databasica',
-      ])
-      ->execute();
-
-    $this->assertIsNumeric($organism_id, 'We were not able to create an organism for testing (configured).');
-    $this->test_genus['configured-secondary'] = $genus;
-    $this->setOntologyConfig($this->test_genus['configured-secondary']);
-
     // Create another organism and not configure.
     $genus = 'notconfiggenus';
     $organism_id = $this->chado_connection->insert('1:organism')
@@ -123,338 +96,192 @@ class MetadataInputTest extends ChadoTestKernelBase {
     $this->assertIsNumeric($organism_id, 'We were not able to create an organism for testing (not configured).');
     $this->test_genus['not-configured'] = $genus;
 
+    // Not created.
+    $this->test_genus['not-created'] = 'genus-' . uniqid();
+
     // Set terms configuration.
     $this->setTermConfig();
-
-    // Create test project with a genus set.
-    $projects = [
-      'project-with-configgenus' => $this->test_genus['configured'],
-      'project-with-2-configgenus' => $this->test_genus['configured-secondary'],
-      'project-with-genus' => $this->test_genus['not-configured'],
-      'project-genus-not-tru-service' => $this->test_genus['configured'],
-      'just-project' => '',
-    ];
-
-    $genus_term = \Drupal::configFactory()->getEditable('trpcultivate_phenotypes.settings')
-      ->get('trpcultivate.phenotypes.ontology.terms.genus');
-
-    foreach ($projects as $test_case => $project_genus) {
-      $project = 'Research Project: ' . $test_case;
-      $project_id = $this->chado_connection->insert('1:project')
-        ->fields([
-          'name' => $project,
-          'description' => 'A test project',
-        ])
-        ->execute();
-
-      $this->assertIsNumeric($project_id, 'We were not able to create a project ' . $test_case . ' for testing.');
-      $this->test_project[$test_case]['id']    = $project_id;
-      $this->test_project[$test_case]['name']  = $project;
-      $this->test_project[$test_case]['genus'] = $project_genus;
-
-      if ($test_case == 'project-with-configgenus') {
-        // Create project - genus relationship.
-        $project_prop = \Drupal::service('trpcultivate_phenotypes.genus_project')
-          ->setGenusToProject($this->test_project[$test_case]['id'], $this->test_project[$test_case]['genus']);
-
-        $this->assertTrue($project_prop, 'We were not able to create a project-genus (for: ' . $test_case . ') property for testing.');
-      }
-
-      if ($test_case == 'project-with-2-configgenus') {
-        // Create project - genus relationship.
-        $project_prop = \Drupal::service('trpcultivate_phenotypes.genus_project')
-          ->setGenusToProject($this->test_project[$test_case]['id'], $this->test_project[$test_case]['genus']);
-
-        // Assign a scondary genus to project.
-        $this->chado_connection->insert('1:projectprop')
-          ->fields([
-            'project_id' => $this->test_project[$test_case]['id'],
-            'type_id' => $genus_term,
-            'value' => $this->test_genus['configured'],
-            'rank' => 2,
-          ])
-          ->execute();
-      }
-
-      if ($test_case == 'project-genus-not-tru-service') {
-        // Create project-genus relationship not using the project-genus service
-        // to relate a project to a genus.
-        // Using term: null.
-        $project_prop = $this->chado_connection->insert('1:projectprop')
-          ->fields([
-            'project_id' => $project_id,
-            'type_id' => 1,
-            'value' => $project_genus,
-          ])
-          ->execute();
-
-        $this->assertNotEmpty($project_prop, 'We were not able to create a project-genus (for: ' . $test_case . ') property for testing.');
-      }
-    }
   }
 
   /**
-   * Test genus input.
+   * Data Provider: provides test form values.
+   *
+   * @return array
+   *   Each test scenario is an array with the following values:
+   *   - A string, human-readable short description of the test scenario.
+   *   - Form values input.
+   *   - An array of expected values, with the following keys:
+   *     - 'error_message': the expected exception message.
    */
-  public function testGenusInput() {
+  public function provideTestFormValues() {
+    return [
+      // #0: An empty string as form values.
+      [
+        'A string value',
+        '',
+        [
+          'error_message' => 'Argument #1 ($form_values) must be of type array, string given',
+        ],
+      ],
+
+      // #1: No genus field in the form values.
+      [
+        'No genus field element',
+        [
+          'project_id' => 999,
+        ],
+        [
+          'error_message' => 'Failed to locate genus field element. GenusExists validator expects a form field element name genus',
+        ],
+      ],
+
+      // #2: FormState object passed.
+      [
+        'Drupal FormState object',
+        new FormState(),
+        [
+          'error_message' => 'Argument #1 ($form_values) must be of type array, Drupal\Core\Form\FormState given',
+        ],
+      ],
+    ];
+  }
+
+  /**
+   * Test genus exists validator with invalid inputs.
+   *
+   * @param string $scenario
+   *   A string, human-readable short description of the test scenario.
+   * @param mixed $form_values
+   *   Form values input.
+   * @param array $expected
+   *   An array of expected values, with the following keys:
+   *     - 'error_message': the expected exception message.
+   *
+   * @dataProvider provideTestFormValues
+   */
+  public function testGenusInputs($scenario, $form_values, $expected) {
+
     // Create a plugin instance for this validator.
     $validator_id = 'genus_exists';
     $instance = $this->plugin_manager->createInstance($validator_id);
 
-    // Test items that will throw exception:
-    // 1. Passing a string value.
-    // 2. Failed to implement a form field element with genus name/key.
-    // 3. Passing object or the entire $form_state.
-    // Test passing a string value.
-    $form_values = 'Not a valid form values';
-
-    $exception_caught  = FALSE;
+    $exception_caught = FALSE;
     $exception_message = '';
+
     try {
       $instance->validateMetadata($form_values);
     }
-    catch (\TypeError $e) {
+    catch (\Throwable $e) {
       $exception_caught  = TRUE;
       $exception_message = $e->getMessage();
     }
 
-    $this->assertTrue($exception_caught, 'Failed to catch exception when passing a string to genus metadata validator.');
+    $this->assertTrue(
+      $exception_caught,
+      'Failed to catch exception in scenario: ' . $scenario
+    );
+
     $this->assertStringContainsString(
-      'Argument #1 ($form_values) must be of type array, string given', $exception_message,
-      'Expected exception message does not match message when passing string to genus metadata validator.');
-
-    // No genus field.
-    $form_values = ['project_id' => 1111];
-
-    $exception_caught  = FALSE;
-    $exception_message = '';
-    try {
-      $instance->validateMetadata($form_values);
-    }
-    catch (\Exception $e) {
-      $exception_caught  = TRUE;
-      $exception_message = $e->getMessage();
-    }
-
-    $this->assertTrue($exception_caught, 'Failed to catch exception when no genus form field was implemented.');
-    $this->assertStringContainsString('Failed to locate genus field element', $exception_message,
-      'Expected exception message does not match message when importer failed to implement a form field element with the name/key genus.');
-
-    // A Drupal $form_state object.
-    $form_state = new FormState();
-    // A random field.
-    $form_state->setValues(['project' => uniqid()]);
-
-    $exception_caught  = FALSE;
-    $exception_message = '';
-    try {
-      $instance->validateMetadata($form_state);
-    }
-    catch (\TypeError $e) {
-      $exception_caught  = TRUE;
-      $exception_message = $e->getMessage();
-    }
-
-    $this->assertTrue($exception_caught, 'Failed to catch exception when passing a $form_state to genus metadata validator.');
-    $this->assertStringContainsString(
-      'Argument #1 ($form_values) must be of type array, Drupal\Core\Form\FormState given', $exception_message,
-      'Expected exception message does not match message when passing $form_state to genus metadata validator.');
-
-    // Other tests:
-    // Each test checks if genusExists generated the correct validation items.
-    // Failed item is the failed genus value. Failed information is contained in
-    // the case whether genus failed because it doesn't exist or not configured.
-    // Genus does not exist.
-    $genus = 'genus-' . uniqid();
-    $form_values = ['genus' => $genus];
-    $validation_status = $instance->validateMetadata($form_values);
-
-    $this->assertEquals('Genus does not exist', $validation_status['case'],
-      'Genus exists validator case title does not match expected title for non-existent genus.');
-    $this->assertFalse($validation_status['valid'], 'A failed genus must return a FALSE valid status.');
-    $this->assertEquals($genus, $validation_status['failedItems']['genus_provided'], 'Failed genus value is expected in failed items.');
-
-    // Genus exists but not configured/recognized by the module.
-    $genus = $this->test_genus['not-configured'];
-    $form_values = ['genus' => $genus];
-    $validation_status = $instance->validateMetadata($form_values);
-
-    $this->assertEquals('Genus exists but is not configured', $validation_status['case'],
-      'Genus exists validator case title does not match expected title for not configured genus.');
-    $this->assertFalse($validation_status['valid'], 'A failed genus must return a FALSE valid status.');
-    $this->assertEquals($genus, $validation_status['failedItems']['genus_provided'], 'Failed genus value is expected in failed items.');
-
-    // A valid genus - exists and is configured.
-    $genus = $this->test_genus['configured'];
-    $form_values = ['genus' => $genus];
-    $validation_status = $instance->validateMetadata($form_values);
-
-    $this->assertEquals('Genus exists and is configured with phenotypes', $validation_status['case'],
-      'Genus exists validator case title does not match expected title for a valid genus.');
-    $this->assertTrue($validation_status['valid'], 'A valid genus must return a TRUE valid status.');
-    $this->assertEmpty($validation_status['failedItems'], 'A valid genus does not return a failed item value.');
+      $expected['error_message'],
+      $exception_message,
+      'Expected exception message does not match expected error message in scenario: ' . $scenario
+    );
   }
 
   /**
-   * Test project and genus input - project exists and configured genus matches.
+   * Data Provider: provides test genus.
+   *
+   * @return array
+   *   Each test scenario is an array with the following values:
+   *   - A string, human-readable short description of the test scenario.
+   *   - Array key to reference a element in the $test_genus property.
+   *   - An array of expected values, with the following keys:
+   *     - 'case': the case title that evaluated the genus value.
+   *     - 'valid': the validation status value returned.
+   *     - 'failedItems': failed items when validation failed. It includes the
+   *        genus input value provided.
    */
-  public function testProjectGenusInput() {
+  public function provideTestGenusInput() {
+    return [
+      // #0: A non-existent genus.
+      [
+        'Non-existent genus',
+        'not-created',
+        [
+          'case' => 'Genus does not exist',
+          'valid' => FALSE,
+          'faileItems' => ['genus' => 'not-created'],
+        ],
+      ],
+
+      // #1: Genus is not configured.
+      [
+        'Not configured genus',
+        'not-configured',
+        [
+          'case' => 'Genus exists but is not configured',
+          'valid' => FALSE,
+          'faileItems' => ['genus' => 'not-created'],
+        ],
+      ],
+
+      // #2: Exists and configured genus.
+      [
+        'A valid genus',
+        'configured',
+        [
+          'case' => 'Genus exists and is configured with phenotypes',
+          'valid' => TRUE,
+        ],
+      ],
+    ];
+  }
+
+  /**
+   * Test genus exists validator.
+   *
+   * @param string $scenario
+   *   A string, human-readable short description of the test scenario.
+   * @param string $genus_input
+   *   Array key to reference a element in the $test_genus property.
+   * @param array $expected
+   *   An array of expected values, with the following keys:
+   *     - 'case': the case title that evaluated the genus value.
+   *     - 'valid': the validation status value returned.
+   *     - 'failedItems': failed items when validation failed. It includes the
+   *        genus input value provided.
+   *
+   * @dataProvider provideTestGenusInput
+   */
+  public function testValidatorGenusExists($scenario, $genus_input, $expected) {
+
     // Create a plugin instance for this validator.
-    $validator_id = 'project_genus_match';
+    $validator_id = 'genus_exists';
     $instance = $this->plugin_manager->createInstance($validator_id);
 
-    // Test items that will throw exception:
-    // 1. Passing a string value.
-    // 2. Failed to implement form field element with project and genus.
-    // 3. Passing object or the entire $form_state.
-    // Test passing a string value.
-    $form_values = 'Not a valid form values';
-
-    $exception_caught  = FALSE;
-    $exception_message = '';
-    try {
-      $instance->validateMetadata($form_values);
-    }
-    catch (\TypeError $e) {
-      $exception_caught  = TRUE;
-      $exception_message = $e->getMessage();
-    }
-
-    $this->assertTrue($exception_caught, 'Failed to catch exception when passing a string to project genus match metadata validator.');
-    $this->assertStringContainsString(
-      'Argument #1 ($form_values) must be of type array, string given', $exception_message,
-      'Expected exception message does not match message when passing string to project genus match metadata validator.');
-
-    // No project field.
-    $form_values = ['genus' => 'Lens'];
-
-    $exception_caught  = FALSE;
-    $exception_message = '';
-    try {
-      $instance->validateMetadata($form_values);
-    }
-    catch (\Exception $e) {
-      $exception_caught  = TRUE;
-      $exception_message = $e->getMessage();
-    }
-
-    $this->assertTrue($exception_caught, 'Failed to catch exception when no project form field was implemented.');
-    $this->assertStringContainsString('Failed to locate project field element', $exception_message,
-      'Expected exception message does not match message when importer failed to implement a form field element with the name/key project.');
-
-    // No genus field.
-    $form_values = ['project' => 'Test Project'];
-
-    $exception_caught  = FALSE;
-    $exception_message = '';
-    try {
-      $instance->validateMetadata($form_values);
-    }
-    catch (\Exception $e) {
-      $exception_caught  = TRUE;
-      $exception_message = $e->getMessage();
-    }
-
-    $this->assertTrue($exception_caught, 'Failed to catch exception when no genus form field was implemented.');
-    $this->assertStringContainsString('Failed to locate genus field element', $exception_message,
-      'Expected exception message does not match message when importer failed to implement a form field element with the name/key genus.');
-
-    // A Drupal $form_state object.
-    $form_state = new FormState();
-    // A random field.
-    $form_state->setValues(['project' => uniqid()]);
-
-    $exception_caught  = FALSE;
-    $exception_message = '';
-    try {
-      $instance->validateMetadata($form_state);
-    }
-    catch (\TypeError $e) {
-      $exception_caught  = TRUE;
-      $exception_message = $e->getMessage();
-    }
-
-    $this->assertTrue($exception_caught, 'Failed to catch exception when passing a $form_state to project genus match metadata validator.');
-    $this->assertStringContainsString(
-      'Argument #1 ($form_values) must be of type array, Drupal\Core\Form\FormState given', $exception_message,
-      'Expected exception message does not match message when passing $form_state to project genus match metadata validator.');
-
-    // Other tests:
-    // Each test checks if projectGenusMatch generated the correct validation
-    // items.
-    // Failed item is the failed project/genus value. Failed information is
-    // contained in the case to indicate project and genus match.
-    // Test project does not exist.
-    $project = 'project-' . uniqid();
-    $genus = $this->test_genus['configured'];
-
-    $form_values = ['project' => $project, 'genus' => $genus];
+    $genus = $this->test_genus[$genus_input];
+    $form_values = ['genus' => $genus];
     $validation_status = $instance->validateMetadata($form_values);
 
-    $this->assertEquals('Project does not exist', $validation_status['case'],
-      'Project genus match validator case title does not match expected title for non-existent project.');
-    $this->assertFalse($validation_status['valid'], 'A failed project must return a FALSE valid status.');
-    $this->assertEquals($project, $validation_status['failedItems']['project_provided'], 'Failed project value is expected in failed items.');
+    $this->assertEquals(
+      $expected['case'],
+      $validation_status['case'],
+      'Genus exists validator case title does not match expected title in scenario: ' . $scenario
+    );
 
-    // Test project exists but not attached to any genus.
-    $project = $this->test_project['just-project']['id'];
-    $genus = $this->test_project['just-project']['genus'];
+    $this->assertEquals(
+      $expected['valid'],
+      $validation_status['valid'],
+      'The validation status value does not match expected value in scenario: ' . $scenario
+    );
 
-    $form_values = ['project' => $project, 'genus' => $genus];
-    $validation_status = $instance->validateMetadata($form_values);
-
-    $this->assertEquals('Project has no genus set and could not compare with the genus provided', $validation_status['case'],
-      'Project genus match validator case title does not match expected title for a valid project+genus.');
-    $this->assertFalse($validation_status['valid'], 'A failed project-genus must return a FALSE valid status.');
-    $this->assertEquals($genus, $validation_status['failedItems']['genus_provided'], 'Failed genus value is expected in failed items.');
-
-    // Test project exists but is attached to a different genus.
-    $project = $this->test_project['project-with-configgenus']['id'];
-    $genus = $this->test_project['project-with-genus']['genus'];
-
-    $form_values = ['project' => $project, 'genus' => $genus];
-    $validation_status = $instance->validateMetadata($form_values);
-
-    $this->assertEquals('Genus does not match the genus set to the project', $validation_status['case'],
-      'Project genus match validator case title does not match expected title for a valid project+genus.');
-    $this->assertFalse($validation_status['valid'], 'A failed project-genus must return a FALSE valid status.');
-    $this->assertEquals($genus, $validation_status['failedItems']['genus_provided'], 'Failed genus value is expected in failed items.');
-
-    // Test a project-genus created not using the project-genus service.
-    $project = $this->test_project['project-genus-not-tru-service']['id'];
-    $genus = $this->test_project['project-genus-not-tru-service']['genus'];
-
-    $form_values = ['project' => $project, 'genus' => $genus];
-    $validation_status = $instance->validateMetadata($form_values);
-
-    $this->assertEquals('Project has no genus set and could not compare with the genus provided', $validation_status['case'],
-      'Project genus match validator case title does not match expected title for a valid project+genus.');
-    $this->assertFalse($validation_status['valid'], 'A failed project-genus must return a FALSE valid status.');
-    $this->assertEquals($genus, $validation_status['failedItems']['genus_provided'], 'Failed genus value is expected in failed items.');
-
-    // Test project with genus set.
-    $project = $this->test_project['project-with-configgenus']['id'];
-    $genus = $this->test_project['project-with-configgenus']['genus'];
-
-    $form_values = ['project' => $project, 'genus' => $genus];
-    $validation_status = $instance->validateMetadata($form_values);
-
-    $this->assertEquals('Project exists and project-genus match the genus provided', $validation_status['case'],
-      'Project genus match validator case title does not match expected title for a valid project+genus.');
-    $this->assertTrue($validation_status['valid'], 'A valid project+genus must return a TRUE valid status.');
-    $this->assertEmpty($validation_status['failedItems'], 'A valid project+genus does not return a failed item value.');
-
-    // Test a project with multiple genus.
-    $project = $this->test_project['project-with-2-configgenus']['id'];
-    $genus = $this->test_genus['configured-secondary'];
-
-    $form_values = ['project' => $project, 'genus' => $genus];
-    $validation_status = $instance->validateMetadata($form_values);
-
-    $this->assertEquals('Project exists and project-genus match the genus provided', $validation_status['case'],
-      'Project genus match validator case title does not match expected title for a valid project+genus (project with multiple genus).');
-    $this->assertTrue($validation_status['valid'], 'A valid project+genus must return a TRUE valid status.');
-    $this->assertEmpty($validation_status['failedItems'], 'A valid project+genus does not return a failed item value.');
+    if (!$validation_status['valid']) {
+      $this->assertEquals(
+        $genus,
+        $validation_status['failedItems']['genus_provided'],
+        'Failed genus value is expected in failed items in scenario: ' . $scenario
+      );
+    }
   }
 
 }

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/MetadataInputTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/MetadataInputTest.php
@@ -24,10 +24,11 @@ class MetadataInputTest extends ChadoTestKernelBase {
   protected TripalCultivateValidatorManager $plugin_manager;
 
   /**
-   * An array of genera for testing.
+   * An array of genus for testing.
    *
    * Has the following keys:
    * - 'configured': a configured genus.
+   * - 'configured-secondary': a configured genus used as secondary genus.
    * - 'not-configured': a genus that is not configured.
    *
    * @var array
@@ -39,6 +40,7 @@ class MetadataInputTest extends ChadoTestKernelBase {
    *
    * Has the following keys:
    * - 'project-with-configgenus': a project paired with a configured genus.
+   * - 'project-with-2-configgenus': a project paired with 2 configured genus.
    * - 'project-with-genus': a project paired with a non-configured genus.
    * - 'project-genus-not-tru-service': a project paired with a configured genus
    *   without using the genus_project service.
@@ -96,6 +98,19 @@ class MetadataInputTest extends ChadoTestKernelBase {
     $this->test_genus['configured'] = $genus;
     $this->setOntologyConfig($this->test_genus['configured']);
 
+    $genus = 'Plantanus';
+    // Create our organism and configure it.
+    $organism_id = $this->chado_connection->insert('1:organism')
+      ->fields([
+        'genus' => $genus,
+        'species' => 'databasica',
+      ])
+      ->execute();
+
+    $this->assertIsNumeric($organism_id, 'We were not able to create an organism for testing (configured).');
+    $this->test_genus['configured-secondary'] = $genus;
+    $this->setOntologyConfig($this->test_genus['configured-secondary']);
+
     // Create another organism and not configure.
     $genus = 'notconfiggenus';
     $organism_id = $this->chado_connection->insert('1:organism')
@@ -114,10 +129,14 @@ class MetadataInputTest extends ChadoTestKernelBase {
     // Create test project with a genus set.
     $projects = [
       'project-with-configgenus' => $this->test_genus['configured'],
+      'project-with-2-configgenus' => $this->test_genus['configured-secondary'],
       'project-with-genus' => $this->test_genus['not-configured'],
       'project-genus-not-tru-service' => $this->test_genus['configured'],
       'just-project' => '',
     ];
+
+    $genus_term = \Drupal::configFactory()->getEditable('trpcultivate_phenotypes.settings')
+      ->get('trpcultivate.phenotypes.ontology.terms.genus');
 
     foreach ($projects as $test_case => $project_genus) {
       $project = 'Research Project: ' . $test_case;
@@ -139,6 +158,22 @@ class MetadataInputTest extends ChadoTestKernelBase {
           ->setGenusToProject($this->test_project[$test_case]['id'], $this->test_project[$test_case]['genus']);
 
         $this->assertTrue($project_prop, 'We were not able to create a project-genus (for: ' . $test_case . ') property for testing.');
+      }
+
+      if ($test_case == 'project-with-2-configgenus') {
+        // Create project - genus relationship.
+        $project_prop = \Drupal::service('trpcultivate_phenotypes.genus_project')
+          ->setGenusToProject($this->test_project[$test_case]['id'], $this->test_project[$test_case]['genus']);
+
+        // Assign a scondary genus to project.
+        $this->chado_connection->insert('1:projectprop')
+          ->fields([
+            'project_id' => $this->test_project[$test_case]['id'],
+            'type_id' => $genus_term,
+            'value' => $this->test_genus['configured'],
+            'rank' => 2,
+          ])
+          ->execute();
       }
 
       if ($test_case == 'project-genus-not-tru-service') {
@@ -406,6 +441,18 @@ class MetadataInputTest extends ChadoTestKernelBase {
 
     $this->assertEquals('Project exists and project-genus match the genus provided', $validation_status['case'],
       'Project genus match validator case title does not match expected title for a valid project+genus.');
+    $this->assertTrue($validation_status['valid'], 'A valid project+genus must return a TRUE valid status.');
+    $this->assertEmpty($validation_status['failedItems'], 'A valid project+genus does not return a failed item value.');
+
+    // Test a project with multiple genus.
+    $project = $this->test_project['project-with-2-configgenus']['id'];
+    $genus = $this->test_genus['configured-secondary'];
+
+    $form_values = ['project' => $project, 'genus' => $genus];
+    $validation_status = $instance->validateMetadata($form_values);
+
+    $this->assertEquals('Project exists and project-genus match the genus provided', $validation_status['case'],
+      'Project genus match validator case title does not match expected title for a valid project+genus (project with multiple genus).');
     $this->assertTrue($validation_status['valid'], 'A valid project+genus must return a TRUE valid status.');
     $this->assertEmpty($validation_status['failedItems'], 'A valid project+genus does not return a failed item value.');
   }

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/MetadataInputTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/MetadataInputTest.php
@@ -104,7 +104,7 @@ class MetadataInputTest extends ChadoTestKernelBase {
   }
 
   /**
-   * Data Provider: provides test form values.
+   * Data Provider: provides invalid test form values.
    *
    * @return array
    *   Each test scenario is an array with the following values:
@@ -210,7 +210,7 @@ class MetadataInputTest extends ChadoTestKernelBase {
         [
           'case' => 'Genus does not exist',
           'valid' => FALSE,
-          'faileItems' => ['genus' => 'not-created'],
+          'failedItems' => ['genus' => 'not-created'],
         ],
       ],
 
@@ -221,7 +221,7 @@ class MetadataInputTest extends ChadoTestKernelBase {
         [
           'case' => 'Genus exists but is not configured',
           'valid' => FALSE,
-          'faileItems' => ['genus' => 'not-created'],
+          'failedItems' => ['genus' => 'not-created'],
         ],
       ],
 

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorGenusExistsTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorGenusExistsTest.php
@@ -8,12 +8,12 @@ use Drupal\Tests\trpcultivate_phenotypes\Traits\PhenotypeImporterTestTrait;
 use Drupal\trpcultivate\TripalCultivateValidator\TripalCultivateValidatorManager;
 
 /**
- * Tests Tripal Cultivate Phenotypes Metadata Validator Plugins.
+ * Tests Tripal Cultivate Phenotypes Genus Exists Validator Plugin.
  *
  * @group trpcultivate_phenotypes
  * @group validators
  */
-class MetadataInputTest extends ChadoTestKernelBase {
+class ValidatorGenusExistsTest extends ChadoTestKernelBase {
 
   use PhenotypeImporterTestTrait;
 

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorProjectGenusMatchTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorProjectGenusMatchTest.php
@@ -336,7 +336,7 @@ class ValidatorProjectGenusMatchTest extends ChadoTestKernelBase {
         ],
       ],
 
-      // #3: A project set with a non-configured genus.
+      // #4: A project set with a non-configured genus.
       [
         'Unconfigured genus to a project',
         'with-unconfig-genus',
@@ -349,7 +349,7 @@ class ValidatorProjectGenusMatchTest extends ChadoTestKernelBase {
         ],
       ],
 
-      // #4: Project and genus matched.
+      // #5: Project and genus matched.
       [
         'A project-genus match',
         'with-config-genus',
@@ -360,7 +360,7 @@ class ValidatorProjectGenusMatchTest extends ChadoTestKernelBase {
         ],
       ],
 
-      // #5: Project and genus matched from a project with multiple genus set.
+      // #6: Project and genus matched from a project with multiple genus set.
       [
         'A project-genus match from multiple genus',
         'with-more-configgenus',

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorProjectGenusMatchTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorProjectGenusMatchTest.php
@@ -1,0 +1,358 @@
+<?php
+
+namespace Drupal\Tests\trpcultivate_phenotypes\Kernel\Validators;
+
+use Drupal\Core\Form\FormState;
+use Drupal\Tests\tripal_chado\Kernel\ChadoTestKernelBase;
+use Drupal\Tests\trpcultivate_phenotypes\Traits\PhenotypeImporterTestTrait;
+use Drupal\trpcultivate\TripalCultivateValidator\TripalCultivateValidatorManager;
+
+/**
+ * Tests Tripal Cultivate Phenotypes Metadata Validator Plugins.
+ *
+ * @group trpcultivate_phenotypes
+ * @group validators
+ */
+class ValidatorProjectGenusMatchTest extends ChadoTestKernelBase {
+  use PhenotypeImporterTestTrait;
+
+  /**
+   * The Validators plugin manager for creating new validator instances.
+   *
+   * @var \Drupal\trpcultivate\TripalCultivateValidator\TripalCultivateValidatorManager
+   */
+  protected TripalCultivateValidatorManager $plugin_manager;
+
+  /**
+   * An array of genus for testing.
+   *
+   * Has the following keys:
+   * - 'configured': a configured genus.
+   * - 'configured-secondary': a configured genus used as secondary genus.
+   * - 'not-configured': a genus that is not configured.
+   *
+   * @var array
+   */
+  protected array $test_genus;
+
+  /**
+   * An array of projects for testing.
+   *
+   * Has the following keys:
+   * - 'project-with-configgenus': a project paired with a configured genus.
+   * - 'project-with-2-configgenus': a project paired with 2 configured genus.
+   * - 'project-with-genus': a project paired with a non-configured genus.
+   * - 'project-genus-not-tru-service': a project paired with a configured genus
+   *   without using the genus_project service.
+   * - 'just-project': a project record not paired to a genus.
+   *
+   * @var array
+   */
+  protected array $test_project;
+
+  /**
+   * Modules to enable.
+   *
+   * @var array
+   */
+  protected static $modules = [
+    'user',
+    'tripal',
+    'tripal_chado',
+    'tripal_layout',
+    'trpcultivate',
+    'trpcultivate_phenotypes',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    // Set test environment.
+    \Drupal::state()->set('is_a_test_environment', TRUE);
+
+    // Install module configuration.
+    $this->installConfig(['trpcultivate_phenotypes', 'trpcultivate']);
+
+    // Test Chado database.
+    // Create a test chado instance and then set it in the container for use by
+    // our service.
+    $this->chado_connection = $this->createTestSchema(ChadoTestKernelBase::PREPARE_TEST_CHADO);
+    $this->container->set('tripal_chado.database', $this->chado_connection);
+
+    // Set plugin manager service.
+    $this->plugin_manager = \Drupal::service('plugin.manager.trpcultivate_validator');
+
+    $genus = 'Tripalus';
+    // Create our organism and configure it.
+    $organism_id = $this->chado_connection->insert('1:organism')
+      ->fields([
+        'genus' => $genus,
+        'species' => 'databasica',
+      ])
+      ->execute();
+
+    $this->assertIsNumeric($organism_id, 'We were not able to create an organism for testing (configured).');
+    $this->test_genus['configured'] = $genus;
+    $this->setOntologyConfig($this->test_genus['configured']);
+
+    $genus = 'Plantanus';
+    // Create our organism and configure it.
+    $organism_id = $this->chado_connection->insert('1:organism')
+      ->fields([
+        'genus' => $genus,
+        'species' => 'databasica',
+      ])
+      ->execute();
+
+    $this->assertIsNumeric($organism_id, 'We were not able to create an organism for testing (configured).');
+    $this->test_genus['configured-secondary'] = $genus;
+    $this->setOntologyConfig($this->test_genus['configured-secondary']);
+
+    // Create another organism and not configure.
+    $genus = 'notconfiggenus';
+    $organism_id = $this->chado_connection->insert('1:organism')
+      ->fields([
+        'genus' => $genus,
+        'species' => 'databasica',
+      ])
+      ->execute();
+
+    $this->assertIsNumeric($organism_id, 'We were not able to create an organism for testing (not configured).');
+    $this->test_genus['not-configured'] = $genus;
+
+    // Set terms configuration.
+    $this->setTermConfig();
+
+    // Create test project with a genus set.
+    $projects = [
+      'project-with-configgenus' => $this->test_genus['configured'],
+      'project-with-2-configgenus' => $this->test_genus['configured-secondary'],
+      'project-with-genus' => $this->test_genus['not-configured'],
+      'project-genus-not-tru-service' => $this->test_genus['configured'],
+      'just-project' => '',
+    ];
+
+    $genus_term = \Drupal::configFactory()->getEditable('trpcultivate_phenotypes.settings')
+      ->get('trpcultivate.phenotypes.ontology.terms.genus');
+
+    foreach ($projects as $test_case => $project_genus) {
+      $project = 'Research Project: ' . $test_case;
+      $project_id = $this->chado_connection->insert('1:project')
+        ->fields([
+          'name' => $project,
+          'description' => 'A test project',
+        ])
+        ->execute();
+
+      $this->assertIsNumeric($project_id, 'We were not able to create a project ' . $test_case . ' for testing.');
+      $this->test_project[$test_case]['id']    = $project_id;
+      $this->test_project[$test_case]['name']  = $project;
+      $this->test_project[$test_case]['genus'] = $project_genus;
+
+      if ($test_case == 'project-with-configgenus') {
+        // Create project - genus relationship.
+        $project_prop = \Drupal::service('trpcultivate_phenotypes.genus_project')
+          ->setGenusToProject($this->test_project[$test_case]['id'], $this->test_project[$test_case]['genus']);
+
+        $this->assertTrue($project_prop, 'We were not able to create a project-genus (for: ' . $test_case . ') property for testing.');
+      }
+
+      if ($test_case == 'project-with-2-configgenus') {
+        // Create project - genus relationship.
+        $project_prop = \Drupal::service('trpcultivate_phenotypes.genus_project')
+          ->setGenusToProject($this->test_project[$test_case]['id'], $this->test_project[$test_case]['genus']);
+
+        // Assign a scondary genus to project.
+        $this->chado_connection->insert('1:projectprop')
+          ->fields([
+            'project_id' => $this->test_project[$test_case]['id'],
+            'type_id' => $genus_term,
+            'value' => $this->test_genus['configured'],
+            'rank' => 2,
+          ])
+          ->execute();
+      }
+
+      if ($test_case == 'project-genus-not-tru-service') {
+        // Create project-genus relationship not using the project-genus service
+        // to relate a project to a genus.
+        // Using term: null.
+        $project_prop = $this->chado_connection->insert('1:projectprop')
+          ->fields([
+            'project_id' => $project_id,
+            'type_id' => 1,
+            'value' => $project_genus,
+          ])
+          ->execute();
+
+        $this->assertNotEmpty($project_prop, 'We were not able to create a project-genus (for: ' . $test_case . ') property for testing.');
+      }
+    }
+  }
+
+  /**
+   * Test project and genus input - project exists and configured genus matches.
+   */
+  public function testProjectGenusInput() {
+    // Create a plugin instance for this validator.
+    $validator_id = 'project_genus_match';
+    $instance = $this->plugin_manager->createInstance($validator_id);
+
+    // Test items that will throw exception:
+    // 1. Passing a string value.
+    // 2. Failed to implement form field element with project and genus.
+    // 3. Passing object or the entire $form_state.
+    // Test passing a string value.
+    $form_values = 'Not a valid form values';
+
+    $exception_caught  = FALSE;
+    $exception_message = '';
+    try {
+      $instance->validateMetadata($form_values);
+    }
+    catch (\TypeError $e) {
+      $exception_caught  = TRUE;
+      $exception_message = $e->getMessage();
+    }
+
+    $this->assertTrue($exception_caught, 'Failed to catch exception when passing a string to project genus match metadata validator.');
+    $this->assertStringContainsString(
+      'Argument #1 ($form_values) must be of type array, string given', $exception_message,
+      'Expected exception message does not match message when passing string to project genus match metadata validator.');
+
+    // No project field.
+    $form_values = ['genus' => 'Lens'];
+
+    $exception_caught  = FALSE;
+    $exception_message = '';
+    try {
+      $instance->validateMetadata($form_values);
+    }
+    catch (\Exception $e) {
+      $exception_caught  = TRUE;
+      $exception_message = $e->getMessage();
+    }
+
+    $this->assertTrue($exception_caught, 'Failed to catch exception when no project form field was implemented.');
+    $this->assertStringContainsString('Failed to locate project field element', $exception_message,
+      'Expected exception message does not match message when importer failed to implement a form field element with the name/key project.');
+
+    // No genus field.
+    $form_values = ['project' => 'Test Project'];
+
+    $exception_caught  = FALSE;
+    $exception_message = '';
+    try {
+      $instance->validateMetadata($form_values);
+    }
+    catch (\Exception $e) {
+      $exception_caught  = TRUE;
+      $exception_message = $e->getMessage();
+    }
+
+    $this->assertTrue($exception_caught, 'Failed to catch exception when no genus form field was implemented.');
+    $this->assertStringContainsString('Failed to locate genus field element', $exception_message,
+      'Expected exception message does not match message when importer failed to implement a form field element with the name/key genus.');
+
+    // A Drupal $form_state object.
+    $form_state = new FormState();
+    // A random field.
+    $form_state->setValues(['project' => uniqid()]);
+
+    $exception_caught  = FALSE;
+    $exception_message = '';
+    try {
+      $instance->validateMetadata($form_state);
+    }
+    catch (\TypeError $e) {
+      $exception_caught  = TRUE;
+      $exception_message = $e->getMessage();
+    }
+
+    $this->assertTrue($exception_caught, 'Failed to catch exception when passing a $form_state to project genus match metadata validator.');
+    $this->assertStringContainsString(
+      'Argument #1 ($form_values) must be of type array, Drupal\Core\Form\FormState given', $exception_message,
+      'Expected exception message does not match message when passing $form_state to project genus match metadata validator.');
+
+    // Other tests:
+    // Each test checks if projectGenusMatch generated the correct validation
+    // items.
+    // Failed item is the failed project/genus value. Failed information is
+    // contained in the case to indicate project and genus match.
+    // Test project does not exist.
+    $project = 'project-' . uniqid();
+    $genus = $this->test_genus['configured'];
+
+    $form_values = ['project' => $project, 'genus' => $genus];
+    $validation_status = $instance->validateMetadata($form_values);
+
+    $this->assertEquals('Project does not exist', $validation_status['case'],
+      'Project genus match validator case title does not match expected title for non-existent project.');
+    $this->assertFalse($validation_status['valid'], 'A failed project must return a FALSE valid status.');
+    $this->assertEquals($project, $validation_status['failedItems']['project_provided'], 'Failed project value is expected in failed items.');
+
+    // Test project exists but not attached to any genus.
+    $project = $this->test_project['just-project']['id'];
+    $genus = $this->test_project['just-project']['genus'];
+
+    $form_values = ['project' => $project, 'genus' => $genus];
+    $validation_status = $instance->validateMetadata($form_values);
+
+    $this->assertEquals('Project has no genus set and could not compare with the genus provided', $validation_status['case'],
+      'Project genus match validator case title does not match expected title for a valid project+genus.');
+    $this->assertFalse($validation_status['valid'], 'A failed project-genus must return a FALSE valid status.');
+    $this->assertEquals($genus, $validation_status['failedItems']['genus_provided'], 'Failed genus value is expected in failed items.');
+
+    // Test project exists but is attached to a different genus.
+    $project = $this->test_project['project-with-configgenus']['id'];
+    $genus = $this->test_project['project-with-genus']['genus'];
+
+    $form_values = ['project' => $project, 'genus' => $genus];
+    $validation_status = $instance->validateMetadata($form_values);
+
+    $this->assertEquals('Genus does not match the genus set to the project', $validation_status['case'],
+      'Project genus match validator case title does not match expected title for a valid project+genus.');
+    $this->assertFalse($validation_status['valid'], 'A failed project-genus must return a FALSE valid status.');
+    $this->assertEquals($genus, $validation_status['failedItems']['genus_provided'], 'Failed genus value is expected in failed items.');
+
+    // Test a project-genus created not using the project-genus service.
+    $project = $this->test_project['project-genus-not-tru-service']['id'];
+    $genus = $this->test_project['project-genus-not-tru-service']['genus'];
+
+    $form_values = ['project' => $project, 'genus' => $genus];
+    $validation_status = $instance->validateMetadata($form_values);
+
+    $this->assertEquals('Project has no genus set and could not compare with the genus provided', $validation_status['case'],
+      'Project genus match validator case title does not match expected title for a valid project+genus.');
+    $this->assertFalse($validation_status['valid'], 'A failed project-genus must return a FALSE valid status.');
+    $this->assertEquals($genus, $validation_status['failedItems']['genus_provided'], 'Failed genus value is expected in failed items.');
+
+    // Test project with genus set.
+    $project = $this->test_project['project-with-configgenus']['id'];
+    $genus = $this->test_project['project-with-configgenus']['genus'];
+
+    $form_values = ['project' => $project, 'genus' => $genus];
+    $validation_status = $instance->validateMetadata($form_values);
+
+    $this->assertEquals('Project exists and project-genus match the genus provided', $validation_status['case'],
+      'Project genus match validator case title does not match expected title for a valid project+genus.');
+    $this->assertTrue($validation_status['valid'], 'A valid project+genus must return a TRUE valid status.');
+    $this->assertEmpty($validation_status['failedItems'], 'A valid project+genus does not return a failed item value.');
+
+    // Test a project with multiple genus.
+    $project = $this->test_project['project-with-2-configgenus']['id'];
+    $genus = $this->test_genus['configured-secondary'];
+
+    $form_values = ['project' => $project, 'genus' => $genus];
+    $validation_status = $instance->validateMetadata($form_values);
+
+    $this->assertEquals('Project exists and project-genus match the genus provided', $validation_status['case'],
+      'Project genus match validator case title does not match expected title for a valid project+genus (project with multiple genus).');
+    $this->assertTrue($validation_status['valid'], 'A valid project+genus must return a TRUE valid status.');
+    $this->assertEmpty($validation_status['failedItems'], 'A valid project+genus does not return a failed item value.');
+  }
+
+}

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorProjectGenusMatchTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorProjectGenusMatchTest.php
@@ -8,7 +8,7 @@ use Drupal\Tests\trpcultivate_phenotypes\Traits\PhenotypeImporterTestTrait;
 use Drupal\trpcultivate\TripalCultivateValidator\TripalCultivateValidatorManager;
 
 /**
- * Tests Tripal Cultivate Phenotypes Metadata Validator Plugins.
+ * Tests Tripal Cultivate Phenotypes Project-Genus Match Validator Plugin.
  *
  * @group trpcultivate_phenotypes
  * @group validators

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorProjectGenusMatchTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorProjectGenusMatchTest.php
@@ -41,13 +41,14 @@ class ValidatorProjectGenusMatchTest extends ChadoTestKernelBase {
   /**
    * An array of project-genus input values for testing.
    *
-   * 'with-config-genus': a project with a configured genus.
-   * 'with-more-configgenus': a project with multiple configured genus.
-   * 'with-unconfig-genus': a project with unconfigured genus.
-   * 'with-no-genus': a project without a genus.
-   * 'with-other-term': a project with project-genus set not through phenotypes.
-   * 'non-existent': a project that does not exist.
-   * 'conflicting-genus': a project with set genus but is tested with another.
+   * Has the following keys:
+   * - 'with-config-genus': a project with a configured genus.
+   * - 'with-more-configgenus': a project with multiple configured genus.
+   * - 'with-unconfig-genus': a project with unconfigured genus.
+   * - 'with-no-genus': a project without a genus.
+   * - 'with-other-term': project with project-genus set not through phenotypes.
+   * - 'non-existent': a project that does not exist.
+   * - 'conflicting-genus': a project with set genus but is tested with another.
    *
    * @var array
    */
@@ -154,7 +155,7 @@ class ValidatorProjectGenusMatchTest extends ChadoTestKernelBase {
   }
 
   /**
-   * Data Provider: provides invalid project-genus test form values.
+   * Data Provider: provides project-genus test form values.
    *
    * @return array
    *   Each test scenario is an array with the following values:
@@ -164,7 +165,7 @@ class ValidatorProjectGenusMatchTest extends ChadoTestKernelBase {
    *     - 'has_exception': TRUE if exception is expected and FALSE if not.
    *     - 'error_message': the expected exception message.
    */
-  public function provideInvalidTestFormValues() {
+  public function provideProjectGenusTestFormValue() {
 
     return [
       // #0: An empty string as form values.
@@ -211,7 +212,7 @@ class ValidatorProjectGenusMatchTest extends ChadoTestKernelBase {
         ],
       ],
 
-      // #4: All is good.
+      // #4: Input values are valid.
       [
         'Input values are valid',
         [
@@ -227,7 +228,7 @@ class ValidatorProjectGenusMatchTest extends ChadoTestKernelBase {
   }
 
   /**
-   * Test project genus match validator with invalid inputs.
+   * Test project genus match validator input requirements.
    *
    * @param string $scenario
    *   A string, human-readable short description of the test scenario.
@@ -238,9 +239,9 @@ class ValidatorProjectGenusMatchTest extends ChadoTestKernelBase {
    *     - 'has_exception': TRUE if exception is expected and FALSE if not.
    *     - 'error_message': the expected exception message.
    *
-   * @dataProvider provideInvalidTestFormValues
+   * @dataProvider provideProjectGenusTestFormValue
    */
-  public function testProjectGenusWithInvalidInput($scenario, $form_values, $expected) {
+  public function testProjectGenusInputValue($scenario, $form_values, $expected) {
 
     $exception_caught = FALSE;
     $exception_message = '';

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorProjectGenusMatchTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorProjectGenusMatchTest.php
@@ -14,6 +14,7 @@ use Drupal\trpcultivate\TripalCultivateValidator\TripalCultivateValidatorManager
  * @group validators
  */
 class ValidatorProjectGenusMatchTest extends ChadoTestKernelBase {
+
   use PhenotypeImporterTestTrait;
 
   /**
@@ -22,33 +23,6 @@ class ValidatorProjectGenusMatchTest extends ChadoTestKernelBase {
    * @var \Drupal\trpcultivate\TripalCultivateValidator\TripalCultivateValidatorManager
    */
   protected TripalCultivateValidatorManager $plugin_manager;
-
-  /**
-   * An array of genus for testing.
-   *
-   * Has the following keys:
-   * - 'configured': a configured genus.
-   * - 'configured-secondary': a configured genus used as secondary genus.
-   * - 'not-configured': a genus that is not configured.
-   *
-   * @var array
-   */
-  protected array $test_genus;
-
-  /**
-   * An array of projects for testing.
-   *
-   * Has the following keys:
-   * - 'project-with-configgenus': a project paired with a configured genus.
-   * - 'project-with-2-configgenus': a project paired with 2 configured genus.
-   * - 'project-with-genus': a project paired with a non-configured genus.
-   * - 'project-genus-not-tru-service': a project paired with a configured genus
-   *   without using the genus_project service.
-   * - 'just-project': a project record not paired to a genus.
-   *
-   * @var array
-   */
-  protected array $test_project;
 
   /**
    * Modules to enable.
@@ -63,6 +37,21 @@ class ValidatorProjectGenusMatchTest extends ChadoTestKernelBase {
     'trpcultivate',
     'trpcultivate_phenotypes',
   ];
+
+  /**
+   * An array of project-genus input values for testing.
+   *
+   * 'with-config-genus': a project with a configured genus.
+   * 'with-more-configgenus': a project with multiple configured genus.
+   * 'with-unconfig-genus': a project with unconfigured genus.
+   * 'with-no-genus': a project without a genus.
+   * 'with-other-term': a project with project-genus set not through phenotypes.
+   * 'non-existent': a project that does not exist.
+   * 'conflicting-genus': a project with set genus but is tested with another.
+   *
+   * @var array
+   */
+  private array $test_project_genus;
 
   /**
    * {@inheritdoc}
@@ -82,64 +71,21 @@ class ValidatorProjectGenusMatchTest extends ChadoTestKernelBase {
     $this->chado_connection = $this->createTestSchema(ChadoTestKernelBase::PREPARE_TEST_CHADO);
     $this->container->set('tripal_chado.database', $this->chado_connection);
 
-    // Set plugin manager service.
-    $this->plugin_manager = \Drupal::service('plugin.manager.trpcultivate_validator');
-
-    $genus = 'Tripalus';
-    // Create our organism and configure it.
-    $organism_id = $this->chado_connection->insert('1:organism')
-      ->fields([
-        'genus' => $genus,
-        'species' => 'databasica',
-      ])
-      ->execute();
-
-    $this->assertIsNumeric($organism_id, 'We were not able to create an organism for testing (configured).');
-    $this->test_genus['configured'] = $genus;
-    $this->setOntologyConfig($this->test_genus['configured']);
-
-    $genus = 'Plantanus';
-    // Create our organism and configure it.
-    $organism_id = $this->chado_connection->insert('1:organism')
-      ->fields([
-        'genus' => $genus,
-        'species' => 'databasica',
-      ])
-      ->execute();
-
-    $this->assertIsNumeric($organism_id, 'We were not able to create an organism for testing (configured).');
-    $this->test_genus['configured-secondary'] = $genus;
-    $this->setOntologyConfig($this->test_genus['configured-secondary']);
-
-    // Create another organism and not configure.
-    $genus = 'notconfiggenus';
-    $organism_id = $this->chado_connection->insert('1:organism')
-      ->fields([
-        'genus' => $genus,
-        'species' => 'databasica',
-      ])
-      ->execute();
-
-    $this->assertIsNumeric($organism_id, 'We were not able to create an organism for testing (not configured).');
-    $this->test_genus['not-configured'] = $genus;
-
-    // Set terms configuration.
     $this->setTermConfig();
-
-    // Create test project with a genus set.
-    $projects = [
-      'project-with-configgenus' => $this->test_genus['configured'],
-      'project-with-2-configgenus' => $this->test_genus['configured-secondary'],
-      'project-with-genus' => $this->test_genus['not-configured'],
-      'project-genus-not-tru-service' => $this->test_genus['configured'],
-      'just-project' => '',
-    ];
-
     $genus_term = \Drupal::configFactory()->getEditable('trpcultivate_phenotypes.settings')
       ->get('trpcultivate.phenotypes.ontology.terms.genus');
 
-    foreach ($projects as $test_case => $project_genus) {
-      $project = 'Research Project: ' . $test_case;
+    $test_project_genus = [
+      'with-config-genus' => ['Tripalus'],
+      'with-more-configgenus' => ['Plantanus', 'Tripalus', 'Pinus'],
+      'with-unconfig-genus' => ['notconfiggenus'],
+      'with-no-genus' => [''],
+      'with-other-term' => ['Tripalus'],
+    ];
+
+    foreach ($test_project_genus as $type => $genus) {
+      // Create the project.
+      $project = 'Project: ' . $type;
       $project_id = $this->chado_connection->insert('1:project')
         ->fields([
           'name' => $project,
@@ -147,212 +93,339 @@ class ValidatorProjectGenusMatchTest extends ChadoTestKernelBase {
         ])
         ->execute();
 
-      $this->assertIsNumeric($project_id, 'We were not able to create a project ' . $test_case . ' for testing.');
-      $this->test_project[$test_case]['id']    = $project_id;
-      $this->test_project[$test_case]['name']  = $project;
-      $this->test_project[$test_case]['genus'] = $project_genus;
+      $this->assertIsNumeric($project_id, 'We were not able to create a project ' . $project . ' for testing.');
+      $this->test_project_genus[$type]['project_id'] = $project_id;
+      $this->test_project_genus[$type]['name'] = $project;
 
-      if ($test_case == 'project-with-configgenus') {
-        // Create project - genus relationship.
-        $project_prop = \Drupal::service('trpcultivate_phenotypes.genus_project')
-          ->setGenusToProject($this->test_project[$test_case]['id'], $this->test_project[$test_case]['genus']);
+      // Create and set each genus.
+      $genus_list = [];
+      foreach ($genus as $i => $genus_ins) {
+        if (empty($genus_ins)) {
+          continue;
+        }
 
-        $this->assertTrue($project_prop, 'We were not able to create a project-genus (for: ' . $test_case . ') property for testing.');
-      }
-
-      if ($test_case == 'project-with-2-configgenus') {
-        // Create project - genus relationship.
-        $project_prop = \Drupal::service('trpcultivate_phenotypes.genus_project')
-          ->setGenusToProject($this->test_project[$test_case]['id'], $this->test_project[$test_case]['genus']);
-
-        // Assign a scondary genus to project.
-        $this->chado_connection->insert('1:projectprop')
+        $organism_id = $this->chado_connection->insert('1:organism')
           ->fields([
-            'project_id' => $this->test_project[$test_case]['id'],
-            'type_id' => $genus_term,
-            'value' => $this->test_genus['configured'],
-            'rank' => 2,
+            'genus' => $genus_ins,
+            'species' => 'species:' . $type,
           ])
           ->execute();
-      }
 
-      if ($test_case == 'project-genus-not-tru-service') {
-        // Create project-genus relationship not using the project-genus service
-        // to relate a project to a genus.
-        // Using term: null.
-        $project_prop = $this->chado_connection->insert('1:projectprop')
+        $this->assertIsNumeric($organism_id, 'We were not able to create an organism for testing: ' . $genus_ins);
+
+        if ($genus_ins != 'notconfiggenus') {
+          $this->setOntologyConfig($genus_ins);
+        }
+
+        $project_genus_id = $this->chado_connection->insert('1:projectprop')
           ->fields([
             'project_id' => $project_id,
-            'type_id' => 1,
-            'value' => $project_genus,
+            'type_id' => ($type == 'with-other-term') ? 1 : $genus_term,
+            'value' => $genus_ins,
+            'rank' => $i + 1,
           ])
           ->execute();
 
-        $this->assertNotEmpty($project_prop, 'We were not able to create a project-genus (for: ' . $test_case . ') property for testing.');
+        $this->assertIsNumeric($project_genus_id, 'We were not able to create an project-genus property for testing.');
+        $genus_list[] = $genus_ins;
       }
+
+      $this->test_project_genus[$type]['genus'] = $genus_list;
     }
+
+    // Adds a non-existent project.
+    $this->test_project_genus['non-existent'] = [
+      'project_id' => 999,
+      'name' => 'A Spurious Project',
+      'genus' => ['Tripalus'],
+    ];
+
+    // Adds an existing project with configured genus but using a genus
+    // of another project.
+    $project = $this->test_project_genus['with-config-genus'];
+    $this->test_project_genus['conflicting-genus'] = [
+      'project_id' => $project['project_id'],
+      'name' => $project['name'],
+      'genus' => ['Pinus'],
+    ];
+
+    // Set plugin manager service.
+    $this->plugin_manager = $this->container->get('plugin.manager.trpcultivate_validator');
   }
 
   /**
-   * Test project and genus input - project exists and configured genus matches.
+   * Data Provider: provides invalid project-genus test form values.
+   *
+   * @return array
+   *   Each test scenario is an array with the following values:
+   *   - A string, human-readable short description of the test scenario.
+   *   - Form values input.
+   *   - An array of expected values, with the following keys:
+   *     - 'has_exception': TRUE if exception is expected and FALSE if not.
+   *     - 'error_message': the expected exception message.
    */
-  public function testProjectGenusInput() {
-    // Create a plugin instance for this validator.
-    $validator_id = 'project_genus_match';
-    $instance = $this->plugin_manager->createInstance($validator_id);
+  public function provideInvalidTestFormValues() {
 
-    // Test items that will throw exception:
-    // 1. Passing a string value.
-    // 2. Failed to implement form field element with project and genus.
-    // 3. Passing object or the entire $form_state.
-    // Test passing a string value.
-    $form_values = 'Not a valid form values';
+    return [
+      // #0: An empty string as form values.
+      [
+        'A string value',
+        '',
+        [
+          'has_exception' => TRUE,
+          'error_message' => 'Argument #1 ($form_values) must be of type array, string given',
+        ],
+      ],
 
-    $exception_caught  = FALSE;
+      // #1: No project field in the form values.
+      [
+        'No genus field element',
+        [
+          'genus' => 'Lens',
+        ],
+        [
+          'has_exception' => TRUE,
+          'error_message' => 'Failed to locate project field element',
+        ],
+      ],
+
+      // #2: No genus field in the form values.
+      [
+        'No genus field element',
+        [
+          'project' => 999,
+        ],
+        [
+          'has_exception' => TRUE,
+          'error_message' => 'Failed to locate genus field element',
+        ],
+      ],
+
+      // #3: FormState object passed.
+      [
+        'Drupal FormState object',
+        new FormState(),
+        [
+          'has_exception' => TRUE,
+          'error_message' => 'Argument #1 ($form_values) must be of type array, Drupal\Core\Form\FormState given',
+        ],
+      ],
+
+      // #4: All is good.
+      [
+        'Input values are valid',
+        [
+          'project' => 1,
+          'genus' => 'Genus',
+        ],
+        [
+          'has_exception' => FALSE,
+          'error_message' => '',
+        ],
+      ],
+    ];
+  }
+
+  /**
+   * Test project genus match validator with invalid inputs.
+   *
+   * @param string $scenario
+   *   A string, human-readable short description of the test scenario.
+   * @param mixed $form_values
+   *   Form values input.
+   * @param array $expected
+   *   An array of expected values, with the following keys:
+   *     - 'has_exception': TRUE if exception is expected and FALSE if not.
+   *     - 'error_message': the expected exception message.
+   *
+   * @dataProvider provideInvalidTestFormValues
+   */
+  public function testProjectGenusWithInvalidInput($scenario, $form_values, $expected) {
+
+    $exception_caught = FALSE;
     $exception_message = '';
+
     try {
-      $instance->validateMetadata($form_values);
+      $this->plugin_manager->createInstance('project_genus_match')
+        ->validateMetadata($form_values);
     }
-    catch (\TypeError $e) {
-      $exception_caught  = TRUE;
+    catch (\Throwable $e) {
+      $exception_caught = TRUE;
       $exception_message = $e->getMessage();
     }
 
-    $this->assertTrue($exception_caught, 'Failed to catch exception when passing a string to project genus match metadata validator.');
+    $this->assertEquals(
+      $expected['has_exception'],
+      $exception_caught,
+      'Failed to catch exception in scenario: ' . $scenario
+    );
+
     $this->assertStringContainsString(
-      'Argument #1 ($form_values) must be of type array, string given', $exception_message,
-      'Expected exception message does not match message when passing string to project genus match metadata validator.');
+      $expected['error_message'],
+      $exception_message,
+      'Expected exception message does not match expected error message in scenario: ' . $scenario
+    );
+  }
 
-    // No project field.
-    $form_values = ['genus' => 'Lens'];
+  /**
+   * Data Provider: provides project-genus test input values.
+   *
+   * @return array
+   *   Each test scenario is an array with the following values:
+   *   - A string, human-readable short description of the test scenario.
+   *   - Array key to reference an element in the $test_project_genus property.
+   *   - An array of expected values, with the following keys:
+   *     - 'case': the case title that evaluated the project/genus value.
+   *     - 'valid': the validation status value returned.
+   *     - 'failedItems': input items that failed validation, including the
+   *       project and/or genus input values provided.
+   */
+  public function provideTestProjectGenusInput() {
 
-    $exception_caught  = FALSE;
-    $exception_message = '';
-    try {
-      $instance->validateMetadata($form_values);
+    return [
+      // #0: A non-existent project.
+      [
+        'Non-existent project',
+        'non-existent',
+        [
+          'case' => 'Project does not exist',
+          'valid' => FALSE,
+          'failedItems' => [
+            'project_provided' => 'project',
+          ],
+        ],
+      ],
+
+      // #1: A project without genus attached.
+      [
+        'Project without genus',
+        'with-no-genus',
+        [
+          'case' => 'Project has no genus set and could not compare with the genus provided',
+          'valid' => FALSE,
+          'failedItems' => [
+            'genus_provided' => 'genus',
+          ],
+        ],
+      ],
+
+      // #2: Using a genus not set to a project.
+      [
+        'Incorrect genus for a project',
+        'conflicting-genus',
+        [
+          'case' => 'Genus does not match the genus set to the project',
+          'valid' => FALSE,
+          'failedItems' => [
+            'genus_provided' => 'genus',
+          ],
+        ],
+      ],
+
+      // #3: A genus set to a project not through the phenotypes module.
+      [
+        'Project-genus set not through phenotypes',
+        'with-other-term',
+        [
+          'case' => 'Project has no genus set and could not compare with the genus provided',
+          'valid' => FALSE,
+          'failedItems' => [
+            'genus_provided' => 'genus',
+          ],
+        ],
+      ],
+
+      // #3: A project set with a non-configured genus.
+      [
+        'Unconfigured genus to a project',
+        'with-unconfig-genus',
+        [
+          'case' => 'Project has no genus set and could not compare with the genus provided',
+          'valid' => FALSE,
+          'failedItems' => [
+            'genus_provided' => 'genus',
+          ],
+        ],
+      ],
+
+      // #4: Project and genus matched.
+      [
+        'A project-genus match',
+        'with-config-genus',
+        [
+          'case' => 'Project exists and project-genus match the genus provided',
+          'valid' => TRUE,
+          'failedItems' => [],
+        ],
+      ],
+
+      // #5: Project and genus matched from a project with multiple genus set.
+      [
+        'A project-genus match from multiple genus',
+        'with-more-configgenus',
+        [
+          'case' => 'Project exists and project-genus match the genus provided',
+          'valid' => TRUE,
+          'failedItems' => [],
+        ],
+      ],
+    ];
+  }
+
+  /**
+   * Test project-genus match validator.
+   *
+   * @param string $scenario
+   *   A string, human-readable short description of the test scenario.
+   * @param string $project_genus_input
+   *   Array key to reference a element in the $test_project_genus property.
+   * @param array $expected
+   *   An array of expected values, with the following keys:
+   *     - 'case': the case title that evaluated the project/genus value.
+   *     - 'valid': the validation status value returned.
+   *     - 'failedItems': input items that failed validation, including the
+   *       project and/or genus input values provided.
+   *
+   * @dataProvider provideTestProjectGenusInput
+   */
+  public function testValidatorProjectGenusMatch($scenario, $project_genus_input, $expected) {
+
+    $input_values = $this->test_project_genus[$project_genus_input];
+    $genus = reset($input_values['genus']);
+
+    // Project value can be the project id or project name. Test for both cases.
+    foreach (['project_id', 'name'] as $project_input) {
+      $project = $input_values[$project_input];
+
+      $form_values = ['project' => $project, 'genus' => $genus];
+      $validation_status = $this->plugin_manager->createInstance('project_genus_match')
+        ->validateMetadata($form_values);
+
+      $this->assertEquals(
+        $expected['case'],
+        $validation_status['case'],
+        'Project-genus match validator case title does not match expected title in scenario: ' . $scenario
+      );
+
+      $this->assertEquals(
+        $expected['valid'],
+        $validation_status['valid'],
+        'The validation status value does not match expected value in scenario: ' . $scenario
+      );
+
+      if (!$validation_status['valid']) {
+        $expected_failed_items = [];
+        foreach ($expected['failedItems'] as $item => $input_key) {
+          $expected_failed_items[$item] = $form_values[$input_key];
+        }
+
+        $this->assertEquals(
+          $expected_failed_items,
+          $validation_status['failedItems'],
+          'Failed test value does not match expected failed items in scenario: ' . $scenario
+        );
+      }
     }
-    catch (\Exception $e) {
-      $exception_caught  = TRUE;
-      $exception_message = $e->getMessage();
-    }
-
-    $this->assertTrue($exception_caught, 'Failed to catch exception when no project form field was implemented.');
-    $this->assertStringContainsString('Failed to locate project field element', $exception_message,
-      'Expected exception message does not match message when importer failed to implement a form field element with the name/key project.');
-
-    // No genus field.
-    $form_values = ['project' => 'Test Project'];
-
-    $exception_caught  = FALSE;
-    $exception_message = '';
-    try {
-      $instance->validateMetadata($form_values);
-    }
-    catch (\Exception $e) {
-      $exception_caught  = TRUE;
-      $exception_message = $e->getMessage();
-    }
-
-    $this->assertTrue($exception_caught, 'Failed to catch exception when no genus form field was implemented.');
-    $this->assertStringContainsString('Failed to locate genus field element', $exception_message,
-      'Expected exception message does not match message when importer failed to implement a form field element with the name/key genus.');
-
-    // A Drupal $form_state object.
-    $form_state = new FormState();
-    // A random field.
-    $form_state->setValues(['project' => uniqid()]);
-
-    $exception_caught  = FALSE;
-    $exception_message = '';
-    try {
-      $instance->validateMetadata($form_state);
-    }
-    catch (\TypeError $e) {
-      $exception_caught  = TRUE;
-      $exception_message = $e->getMessage();
-    }
-
-    $this->assertTrue($exception_caught, 'Failed to catch exception when passing a $form_state to project genus match metadata validator.');
-    $this->assertStringContainsString(
-      'Argument #1 ($form_values) must be of type array, Drupal\Core\Form\FormState given', $exception_message,
-      'Expected exception message does not match message when passing $form_state to project genus match metadata validator.');
-
-    // Other tests:
-    // Each test checks if projectGenusMatch generated the correct validation
-    // items.
-    // Failed item is the failed project/genus value. Failed information is
-    // contained in the case to indicate project and genus match.
-    // Test project does not exist.
-    $project = 'project-' . uniqid();
-    $genus = $this->test_genus['configured'];
-
-    $form_values = ['project' => $project, 'genus' => $genus];
-    $validation_status = $instance->validateMetadata($form_values);
-
-    $this->assertEquals('Project does not exist', $validation_status['case'],
-      'Project genus match validator case title does not match expected title for non-existent project.');
-    $this->assertFalse($validation_status['valid'], 'A failed project must return a FALSE valid status.');
-    $this->assertEquals($project, $validation_status['failedItems']['project_provided'], 'Failed project value is expected in failed items.');
-
-    // Test project exists but not attached to any genus.
-    $project = $this->test_project['just-project']['id'];
-    $genus = $this->test_project['just-project']['genus'];
-
-    $form_values = ['project' => $project, 'genus' => $genus];
-    $validation_status = $instance->validateMetadata($form_values);
-
-    $this->assertEquals('Project has no genus set and could not compare with the genus provided', $validation_status['case'],
-      'Project genus match validator case title does not match expected title for a valid project+genus.');
-    $this->assertFalse($validation_status['valid'], 'A failed project-genus must return a FALSE valid status.');
-    $this->assertEquals($genus, $validation_status['failedItems']['genus_provided'], 'Failed genus value is expected in failed items.');
-
-    // Test project exists but is attached to a different genus.
-    $project = $this->test_project['project-with-configgenus']['id'];
-    $genus = $this->test_project['project-with-genus']['genus'];
-
-    $form_values = ['project' => $project, 'genus' => $genus];
-    $validation_status = $instance->validateMetadata($form_values);
-
-    $this->assertEquals('Genus does not match the genus set to the project', $validation_status['case'],
-      'Project genus match validator case title does not match expected title for a valid project+genus.');
-    $this->assertFalse($validation_status['valid'], 'A failed project-genus must return a FALSE valid status.');
-    $this->assertEquals($genus, $validation_status['failedItems']['genus_provided'], 'Failed genus value is expected in failed items.');
-
-    // Test a project-genus created not using the project-genus service.
-    $project = $this->test_project['project-genus-not-tru-service']['id'];
-    $genus = $this->test_project['project-genus-not-tru-service']['genus'];
-
-    $form_values = ['project' => $project, 'genus' => $genus];
-    $validation_status = $instance->validateMetadata($form_values);
-
-    $this->assertEquals('Project has no genus set and could not compare with the genus provided', $validation_status['case'],
-      'Project genus match validator case title does not match expected title for a valid project+genus.');
-    $this->assertFalse($validation_status['valid'], 'A failed project-genus must return a FALSE valid status.');
-    $this->assertEquals($genus, $validation_status['failedItems']['genus_provided'], 'Failed genus value is expected in failed items.');
-
-    // Test project with genus set.
-    $project = $this->test_project['project-with-configgenus']['id'];
-    $genus = $this->test_project['project-with-configgenus']['genus'];
-
-    $form_values = ['project' => $project, 'genus' => $genus];
-    $validation_status = $instance->validateMetadata($form_values);
-
-    $this->assertEquals('Project exists and project-genus match the genus provided', $validation_status['case'],
-      'Project genus match validator case title does not match expected title for a valid project+genus.');
-    $this->assertTrue($validation_status['valid'], 'A valid project+genus must return a TRUE valid status.');
-    $this->assertEmpty($validation_status['failedItems'], 'A valid project+genus does not return a failed item value.');
-
-    // Test a project with multiple genus.
-    $project = $this->test_project['project-with-2-configgenus']['id'];
-    $genus = $this->test_genus['configured-secondary'];
-
-    $form_values = ['project' => $project, 'genus' => $genus];
-    $validation_status = $instance->validateMetadata($form_values);
-
-    $this->assertEquals('Project exists and project-genus match the genus provided', $validation_status['case'],
-      'Project genus match validator case title does not match expected title for a valid project+genus (project with multiple genus).');
-    $this->assertTrue($validation_status['valid'], 'A valid project+genus must return a TRUE valid status.');
-    $this->assertEmpty($validation_status['failedItems'], 'A valid project+genus does not return a failed item value.');
   }
 
 }


### PR DESCRIPTION
**Issue #156 Allow multiple genus to be assigned to a project**

## Motivation

<!-- This can usually be copied from the issue. Please do not just say, go see issue but instead copy the relevant details here. -->

This PR revises the Genus-Project service to allow assignment of one or many genus to a project.

## What does this PR do?
*Please describe each things this PR does. For example, a PR may 1) solve a specific bug, 2) create an automated test to ensure it doesn't return.*

1. Update genus-project service setter method to insert a genus instead of overriding.
2. To keep the method simple, the replace option is no longer supported since it requires search and replace logic.
3. Update project genus match validator to account for multiple genus.
4. Update automated tests.
5. Disable auto-select genus in the Importer Share form

## Testing

### Automated Testing
*Please describe each automated test this PR creates and provide a list of the assertions it makes using casual language.*
*Do not just say things like "asserts the array is not empty" but rather say "Ensures that the return value of method X with these parameters is not an empty array".*

ServiceGenusProjectTest->testGenusProjectService
- Test one genus
- Test 2 genus
- Test 5 genus
- Test getter returned correct set of genus
- Test that the rank value assigned to each genus is a sequence order

### Manual Testing
*Describe in detail how someone should manually test this functionality.*
*Make sure to include whether they need to build a docker from scratch, create any records, etc.*

1. In a fully configured clone, create a research experiment Tripal content type in my site/bio_data/add/research_experiment
2. Create organism in my site/bio_data/add/organism. Insert as many to test multiple genus.
3. Configure every genus added in step 2 in my site/admin/tripal/extension/tripal-cultivate/phenotypes/ontology
4. In your sites deve/php page, paste the following code:

```
$m = \Drupal::service('trpcultivate_phenotypes.genus_project');
$project_id = 1; // In a fresh clone with one project, this is 1.

// Add one.
$genus = REPLACE WITH A GENUS NAME ADDED IN STEP 2
$m->setGenusToProject($project_id, $genus);
// Pull the genus set.
$p_genus = $m->getGenusOfProject($project_id);
dpm($p_genus);
```

Repeat to add additional genus.

To inspect from a database level:
```
$genus = \Drupal::service('tripal_chado.database')
  ->select('1:projectprop', 'pp')
  ->fields('pp', ['project_id', 'value', 'rank'])
  ->condition('pp.project_id', $project_id, '=')
  ->execute()
  ->fetchAll();

dpm($genus);

```



