### PR TITLE
G4.179 ValidHeaders validator message processor removal

### DIFF
--- a/trpcultivate_phenoshare/src/Plugin/TripalImporter/TripalCultivatePhenoShareImporter.php
+++ b/trpcultivate_phenoshare/src/Plugin/TripalImporter/TripalCultivatePhenoShareImporter.php
@@ -12,6 +12,7 @@ use Drupal\tripal_chado\Database\ChadoConnection;
 use Drupal\tripal_chado\TripalImporter\ChadoImporterBase;
 use Drupal\trpcultivate\Plugin\Validators\EmptyCell;
 use Drupal\trpcultivate\Plugin\Validators\ValidDataFile;
+use Drupal\trpcultivate\Plugin\Validators\ValidHeaders;
 use Drupal\trpcultivate_phenotypes\Plugin\Validators\ProjectGenusMatch;
 use Drupal\trpcultivate_phenotypes\Service\TripalCultivatePhenotypesGenusOntologyService;
 use Drupal\trpcultivate\TripalCultivateValidator\TripalCultivateValidatorManager;
@@ -1023,7 +1024,11 @@ class TripalCultivatePhenoShareImporter extends ChadoImporterBase implements Con
     if (array_key_exists($validator_name, $failures)) {
       if (!empty($failures[$validator_name])) {
         $messages[$validator_name]['status'] = 'fail';
-        $messages[$validator_name]['details'] = $this->processValidHeadersFailures($failures[$validator_name]);
+
+        $metadata = [
+          'column_headers' => $header_names,
+        ];
+        $messages[$validator_name]['details'] = ValidHeaders::processListWithDescribedTable($failures[$validator_name], $metadata);
       }
       else {
         $messages[$validator_name]['status'] = 'pass';
@@ -1049,103 +1054,6 @@ class TripalCultivatePhenoShareImporter extends ChadoImporterBase implements Con
     }
 
     return $messages;
-  }
-
-  /**
-   * Processes failed validation from ValidHeaders into a render array.
-   *
-   * @param array $validation_result
-   *   An associative array that was returned by the ValidHeaders validator in
-   *   the event of failed validation. It contains the following keys:
-   *   - 'case': a developer-focused string describing the case checked.
-   *   - 'valid': FALSE to indicate that validation failed.
-   *   - 'failedItems': an array of items that failed, either:
-   *     - 'headers': A string indicating the header row is empty.
-   *     - an array of column headers that was in the input file.
-   *
-   * @return array
-   *   A render array of type unordered list which is used to display feedback
-   *   to the user about the case that failed and the failed items from the
-   *   input file. This unordered list will include a table with a row of the
-   *   expected headers followed by a row of the provided headers.
-   *
-   * @throws \Exception
-   *   - If the validation_result parameter was not formatted properly.
-   *   - If the case string returned by the validator implied validation passed.
-   *   - If the case string returned by the validator is not recognized.
-   */
-  public function processValidHeadersFailures(array $validation_result) {
-    // Check the format of the validation_result parameter.
-    ImportValidationHelper::checkValidationStatusArray($validation_result, 'ValidHeaders');
-
-    if ($validation_result['case'] == 'Header row is an empty value') {
-      $message = 'The file has an empty row where the header was expected.';
-      $provided_headers = [];
-    }
-    elseif ($validation_result['case'] == 'Headers do not match expected headers') {
-      $message = 'One or more of the column headers in the input file does not match what was expected. Please check if your column header is in the correct order and matches the template exactly.';
-      $provided_headers = $validation_result['failedItems'];
-    }
-    elseif ($validation_result['case'] == 'Headers provided does not have the expected number of headers') {
-      $num_expected_columns = count($this->headers);
-      $message = "This importer requires a strict number of $num_expected_columns column headers. Please ensure your column header matches the template exactly and remove any additional column headers from the file.";
-      $provided_headers = $validation_result['failedItems'];
-    }
-    elseif ($validation_result['case'] == 'Headers exist and match expected headers') {
-      throw new \Exception('The case string returned by the ValidHeaders validator implies validation passed, but valid is set to FALSE.');
-    }
-    else {
-      throw new \Exception('The case string returned by the ValidHeaders validator is not recognized as a potential case.');
-    }
-    // Get the expected and actual headers to build the rows in our table render
-    // array.
-    $expected_headers = array_column($this->headers, 'name');
-
-    // Build the render array.
-    $render_array = [
-      '#theme' => 'item_list',
-      '#type' => 'ul',
-      '#attributes' => [
-        'class' => [
-          'tcp-valid-headers-failures',
-        ],
-      ],
-      '#items' => [
-        [
-          [
-            '#prefix' => '<div class="case-message">',
-            '#markup' => $message,
-            '#suffix' => '</div>',
-          ],
-          [
-            '#type' => 'table',
-            '#attributes' => [],
-            '#rows' => [
-              [
-                'data' => [
-                  'header' => [
-                    'data' => 'Expected Headers',
-                    'header' => TRUE,
-                  ],
-                ] + $expected_headers,
-                'class' => ['expected-headers'],
-              ],
-              [
-                'data' => [
-                  'header' => [
-                    'data' => 'Provided Headers',
-                    'header' => TRUE,
-                  ],
-                ] + $provided_headers,
-                'class' => ['provided-headers'],
-              ],
-            ],
-          ],
-        ],
-      ],
-    ];
-
-    return $render_array;
   }
 
   /**

--- a/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
+++ b/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
@@ -11,6 +11,7 @@ use Drupal\tripal_chado\Database\ChadoConnection;
 use Drupal\tripal_chado\TripalImporter\ChadoImporterBase;
 use Drupal\trpcultivate\Plugin\Validators\ValidDataFile;
 use Drupal\trpcultivate\Plugin\Validators\EmptyCell;
+use Drupal\trpcultivate\Plugin\Validators\ValidHeaders;
 use Drupal\trpcultivate_phenotypes\Service\TripalCultivatePhenotypesGenusOntologyService;
 use Drupal\trpcultivate_phenotypes\Service\TripalCultivatePhenotypesTraitsService;
 use Drupal\trpcultivate\TripalCultivateValidator\TripalCultivateValidatorManager;
@@ -777,7 +778,11 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
     if (array_key_exists($validator_name, $failures)) {
       if (!empty($failures[$validator_name])) {
         $messages[$validator_name]['status'] = 'fail';
-        $messages[$validator_name]['details'] = $this->processValidHeadersFailures($failures[$validator_name]);
+
+        $metadata = [
+          'column_headers' => $header_names,
+        ];
+        $messages[$validator_name]['details'] = ValidHeaders::processListWithDescribedTable($failures[$validator_name], $metadata);
       }
       else {
         $messages[$validator_name]['status'] = 'pass';
@@ -891,103 +896,6 @@ class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implemen
         '#items' => [
           [
             '#markup' => $validation_result['failedItems']['genus_provided'],
-          ],
-        ],
-      ],
-    ];
-
-    return $render_array;
-  }
-
-  /**
-   * Processes failed validation from ValidHeaders into a render array.
-   *
-   * @param array $validation_result
-   *   An associative array that was returned by the ValidHeaders validator in
-   *   the event of failed validation. It contains the following keys:
-   *   - 'case': a developer-focused string describing the case checked.
-   *   - 'valid': FALSE to indicate that validation failed.
-   *   - 'failedItems': an array of items that failed, either:
-   *     - 'headers': A string indicating the header row is empty.
-   *     - an array of column headers that was in the input file.
-   *
-   * @return array
-   *   A render array of type unordered list which is used to display feedback
-   *   to the user about the case that failed and the failed items from the
-   *   input file. This unordered list will include a table with a row of the
-   *   expected headers followed by a row of the provided headers.
-   *
-   * @throws \Exception
-   *   - If the validation_result parameter was not formatted properly.
-   *   - If the case string returned by the validator implied validation passed.
-   *   - If the case string returned by the validator is not recognized.
-   */
-  public function processValidHeadersFailures(array $validation_result) {
-    // Check the format of the validation_result parameter.
-    ImportValidationHelper::checkValidationStatusArray($validation_result, 'ValidHeaders');
-
-    if ($validation_result['case'] == 'Header row is an empty value') {
-      $message = 'The file has an empty row where the header was expected.';
-      $provided_headers = [];
-    }
-    elseif ($validation_result['case'] == 'Headers do not match expected headers') {
-      $message = 'One or more of the column headers in the input file does not match what was expected. Please check if your column header is in the correct order and matches the template exactly.';
-      $provided_headers = $validation_result['failedItems'];
-    }
-    elseif ($validation_result['case'] == 'Headers provided does not have the expected number of headers') {
-      $num_expected_columns = count($this->headers);
-      $message = "This importer requires a strict number of $num_expected_columns column headers. Please ensure your column header matches the template exactly and remove any additional column headers from the file.";
-      $provided_headers = $validation_result['failedItems'];
-    }
-    elseif ($validation_result['case'] == 'Headers exist and match expected headers') {
-      throw new \Exception('The case string returned by the ValidHeaders validator implies validation passed, but valid is set to FALSE.');
-    }
-    else {
-      throw new \Exception('The case string returned by the ValidHeaders validator is not recognized as a potential case.');
-    }
-    // Get the expected and actual headers to build the rows in our table render
-    // array.
-    $expected_headers = array_column($this->headers, 'name');
-
-    // Build the render array.
-    $render_array = [
-      '#theme' => 'item_list',
-      '#type' => 'ul',
-      '#attributes' => [
-        'class' => [
-          'tcp-valid-headers-failures',
-        ],
-      ],
-      '#items' => [
-        [
-          [
-            '#prefix' => '<div class="case-message">',
-            '#markup' => $message,
-            '#suffix' => '</div>',
-          ],
-          [
-            '#type' => 'table',
-            '#attributes' => [],
-            '#rows' => [
-              [
-                'data' => [
-                  'header' => [
-                    'data' => 'Expected Headers',
-                    'header' => TRUE,
-                  ],
-                ] + $expected_headers,
-                'class' => ['expected-headers'],
-              ],
-              [
-                'data' => [
-                  'header' => [
-                    'data' => 'Provided Headers',
-                    'header' => TRUE,
-                  ],
-                ] + $provided_headers,
-                'class' => ['provided-headers'],
-              ],
-            ],
           ],
         ],
       ],

--- a/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterProcessValidationTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterProcessValidationTest.php
@@ -238,136 +238,6 @@ class TraitImporterProcessValidationTest extends ChadoTestKernelBase {
   }
 
   /**
-   * Data Provider for testProcessValidHeadersFailures().
-   *
-   * @return array
-   *   Each scenario is an array with the following:
-   *   - The validation result array that gets passed to the process method. It
-   *     contains the following keys:
-   *     - 'case': a developer-focused string describing the case checked.
-   *     - 'valid': FALSE to indicate that validation failed.
-   *     - 'failedItems': an array of items that failed with the following keys.
-   *       - 'headers': A string indicating the header row is empty.
-   *       - an array of column headers that was in the input file.
-   *   - An array of expectations in the rendered output which has the following
-   *     keys:
-   *     - 'expected_message': The message expected in the return value of the
-   *       process method for this scenario.
-   */
-  public static function provideValidHeadersFailedCases() {
-    $scenarios = [];
-
-    // #0: The header row is empty.
-    $scenarios[] = [
-      [
-        'case' => 'Header row is an empty value',
-        'valid' => FALSE,
-        'failedItems' => [
-          'headers' => 'headers array is an empty array',
-        ],
-      ],
-      [
-        'expected_message' => 'The file has an empty row where the header was expected.',
-      ],
-    ];
-
-    // #1: Correct number of headers, but there's a mismatch.
-    $scenarios[] = [
-      [
-        'case' => 'Headers do not match expected headers',
-        'valid' => FALSE,
-        'failedItems' => [
-          'Trait Name',
-          'Trait Description',
-          '',
-          'Method Description',
-          'Unit',
-          'Type',
-        ],
-      ],
-      [
-        'expected_message' => 'One or more of the column headers in the input file does not match what was expected.',
-      ],
-    ];
-
-    // #2: Incorrect number of headers
-    $scenarios[] = [
-      [
-        'case' => 'Headers provided does not have the expected number of headers',
-        'valid' => FALSE,
-        'failedItems' => [
-          'Trait Name',
-          'Trait Description',
-          'Method Short Name',
-          'Method Description',
-        ],
-      ],
-      [
-        'expected_message' => 'This importer requires a strict number of 6 column headers.',
-      ],
-    ];
-
-    return $scenarios;
-  }
-
-  /**
-   * Tests the message processor method for ValidHeaders validator.
-   *
-   * @param array $validation_result
-   *   The validation result array that gets passed to the process method. It
-   *   contains the following keys:
-   *   - 'case': a developer-focused string describing the case checked.
-   *   - 'valid': FALSE to indicate that validation failed.
-   *   - 'failedItems': an array of items that failed with the following keys.
-   *     - 'headers': A string indicating the header row is empty.
-   *     - an array of column headers that was in the input file.
-   * @param array $expectations
-   *   An array of the expected items in the rendered output. It has the
-   *   following keys:
-   *   - 'expected_message': The message expected in the return value of the
-   *     process method for this scenario.
-   *
-   * @dataProvider provideValidHeadersFailedCases
-   */
-  public function testProcessValidHeadersFailures(array $validation_result, array $expectations) {
-    // Call the process method on our validation result.
-    $render_array = $this->importer->processValidHeadersFailures($validation_result);
-    // Render the array we were returned.
-    $rendered_markup = $this->renderer->renderRoot($render_array);
-    $this->setRawContent($rendered_markup);
-
-    // Check the rendered output.
-    // First check that we were given the correct message.
-    $selected_message_markup = $this->cssSelect('ul li div.case-message');
-    $this->assertStringContainsString(
-      $expectations['expected_message'],
-      (string) $selected_message_markup[0],
-      'The message expected from processing ValidHeaders failures for this scenario did not match the message in the render array.'
-    );
-    // Check that we have a table that contains the expected 2 rows.
-    $selected_table_rows = $this->cssSelect('tbody tr');
-    $this->assertCount(2, $selected_table_rows, 'The rendered table by processValidHeadersFailures does not contain the expected 2 rows for this scenario.');
-    // Check for the "Provided Headers" heading on the 2nd row.
-    $selected_provided_headers_th = $this->cssSelect('tbody tr.provided-headers th');
-    $this->assertEquals(
-      'Provided Headers',
-      (string) $selected_provided_headers_th[0],
-      'The second row of the rendered table does not contain the "Provided Headers" table header for this scenario.'
-    );
-    // Check that the row values are the same as what we provided.
-    $selected_provided_headers_td = $this->cssSelect('tbody tr.provided-headers td');
-    // If the headers row was empty, check that we have no values in row 2.
-    if (array_key_exists('headers', $validation_result['failedItems'])) {
-      $this->assertEmpty($selected_provided_headers_td, "The values in the \"Provided Headers\" row were expected to be empty since an empty header was provided, but are not.");
-    }
-    else {
-      // Iterate through our provided headers to compare with what's in the
-      // rendered provided headers row.
-      $this->assertEquals($validation_result['failedItems'], $selected_provided_headers_td, "The header row provided does not match the second row (the \'provided headers\' row) of the rendered table.");
-    }
-  }
-
-  /**
    * Data Provider for testProcessValidDelimitedFileFailures().
    *
    * @return array
@@ -1233,36 +1103,7 @@ class TraitImporterProcessValidationTest extends ChadoTestKernelBase {
       ],
     ];
 
-    // #1: ValidHeaders passed + unrecognizable validation case message.
-    $scenarios[] = [
-      'processValidHeadersFailures',
-      [
-        'process_method_params' => [
-          [
-            'case' => 'Headers exist and match expected headers',
-            'valid' => FALSE,
-            'failedItems' => [
-              'headers' => 'headers array is an empty array',
-            ],
-          ],
-        ],
-        'expected_message' => 'The case string returned by the ValidHeaders validator implies validation passed, but valid is set to FALSE.',
-      ],
-      [
-        'process_method_params' => [
-          [
-            'case' => $unrecognized_case_string,
-            'valid' => FALSE,
-            'failedItems' => [
-              'headers' => 'headers array is an empty array',
-            ],
-          ],
-        ],
-        'expected_message' => 'The case string returned by the ValidHeaders validator is not recognized as a potential case.',
-      ],
-    ];
-
-    // #2: ValidDelimitedFile passed + unrecognizable validation case message.
+    // #1: ValidDelimitedFile passed + unrecognizable validation case message.
     $scenarios[] = [
       'processValidDelimitedFileFailures',
       [
@@ -1295,7 +1136,7 @@ class TraitImporterProcessValidationTest extends ChadoTestKernelBase {
       ],
     ];
 
-    // #3: ValueInList passed + unrecognizable validation case message.
+    // #2: ValueInList passed + unrecognizable validation case message.
     $scenarios[] = [
       'processValueInListFailures',
       [
@@ -1330,7 +1171,7 @@ class TraitImporterProcessValidationTest extends ChadoTestKernelBase {
       ],
     ];
 
-    // #4: DuplicateTraits passed + unrecognizable validation case message.
+    // #3: DuplicateTraits passed + unrecognizable validation case message.
     $scenarios[] = [
       'processDuplicateTraitsFailures',
       [


### PR DESCRIPTION
**Issue #174 G4.174 Removal of validator message processor**

## Motivation

<!-- This can usually be copied from the issue. Please do not just say, go see issue but instead copy the relevant details here. -->

Remove ValidHeaders validator message processor from Trait and Share Importers.

- [x] This PR is dependent upon the merging of EmptyCell validator message processor removal PR

## What does this PR do?

- [x] Remove ValidHeader message processor method from Traits Importer Class.
- [x] Update the line that calls the message processor to use the validator static message processor method. Define metadata requirements as needed.
- [x] Ensure continued success of kernel tests namely,  TraitImporterFormTest and TraitImporterFormValidateTest
- [x] Remove test cases in TraitImporterProcessValidationTest specifically provideVALIDATORNAME + testVALIDATORNAME and entry of the same for providePassedAndUnrecognizableCases(). Re-run test to ensure continued success.
- [x] Remove the same validator message processor in Share Importer Class.
- [x] Update the line that calls the message processor to use the validator static message processor method. Define metadata requirements as needed.
- [x] Ensure continued success of kernel tests namely, ShareImporterFormTest and ShareImporterFormValidateTest.

