### PR TITLE
G4.182 Migrate from annotations to attributes

### DIFF
--- a/trpcultivate_phenocollect/tests/src/Functional/InstallTest.php
+++ b/trpcultivate_phenocollect/tests/src/Functional/InstallTest.php
@@ -12,6 +12,8 @@ use Drupal\Tests\tripal_chado\Functional\ChadoTestBrowserBase;
  * @group TripPheno Collect
  * @group Installation
  */
+#[Group('TripPheno Collect')]
+#[Group('Installation')]
 class InstallTest extends ChadoTestBrowserBase {
 
   /**

--- a/trpcultivate_phenocollect/tests/src/Functional/InstallTest.php
+++ b/trpcultivate_phenocollect/tests/src/Functional/InstallTest.php
@@ -5,6 +5,7 @@ namespace Drupal\Tests\trpcultivate_phenocollect\Functional;
 use Drupal\Core\Routing\RouteMatch;
 use Drupal\Core\Url;
 use Drupal\Tests\tripal_chado\Functional\ChadoTestBrowserBase;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Simple test to ensure that main page loads with module enabled.

--- a/trpcultivate_phenoshare/src/Plugin/TripalImporter/TripalCultivatePhenoShareImporter.php
+++ b/trpcultivate_phenoshare/src/Plugin/TripalImporter/TripalCultivatePhenoShareImporter.php
@@ -28,6 +28,29 @@ use Drupal\Core\StringTranslation\TranslatableMarkup;
  *
  * An importer focused on phenotypic data which has already been published or
  * which is ready to be freely shared.
+ *
+ * @TripalImporter(
+ *   id = "trpcultivate-phenotypes-share-importer",
+ *   label = @Translation("Tripal Cultivate: Open Science Phenotypic Data"),
+ *   description = @Translation("Imports phenotypic data which has already been published or which is ready to be freely shared."),
+ *   file_types = {"tsv"},
+ *   upload_description = @Translation("Please provide a data file."),
+ *   upload_title = @Translation("Phenotypic Data File"),
+ *   use_analysis = FALSE,
+ *   require_analysis = FALSE,
+ *   use_button = TRUE,
+ *   submit_disabled = TRUE,
+ *   button_text = "Import",
+ *   file_upload = TRUE,
+ *   file_local  = FALSE,
+ *   file_remote = FALSE,
+ *   file_required = TRUE,
+ *   cardinality = 1,
+ *   menu_path = "",
+ *   callback = "",
+ *   callback_module = "",
+ *   callback_path = "",
+ * )
  */
 #[TripalImporter(
    id: 'trpcultivate-phenotypes-share-importer',

--- a/trpcultivate_phenoshare/src/Plugin/TripalImporter/TripalCultivatePhenoShareImporter.php
+++ b/trpcultivate_phenoshare/src/Plugin/TripalImporter/TripalCultivatePhenoShareImporter.php
@@ -20,36 +20,36 @@ use Drupal\trpcultivate\TripalCultivateValidator\TripalCultivateValidatorManager
 use Drupal\trpcultivate\Service\TripalCultivateFileTemplateService;
 use Drupal\trpcultivate\Service\ImportValidationHelper;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\tripal\TripalImporter\Attribute\TripalImporter;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 
 /**
  * Tripal Cultivate Phenotypes - Share Importer.
  *
  * An importer focused on phenotypic data which has already been published or
  * which is ready to be freely shared.
- *
- * @TripalImporter(
- *   id = "trpcultivate-phenotypes-share-importer",
- *   label = @Translation("Tripal Cultivate: Open Science Phenotypic Data"),
- *   description = @Translation("Imports phenotypic data which has already been published or which is ready to be freely shared."),
- *   file_types = {"tsv"},
- *   upload_description = @Translation("Please provide a data file."),
- *   upload_title = @Translation("Phenotypic Data File"),
- *   use_analysis = FALSE,
- *   require_analysis = FALSE,
- *   use_button = TRUE,
- *   submit_disabled = TRUE,
- *   button_text = "Import",
- *   file_upload = TRUE,
- *   file_local  = FALSE,
- *   file_remote = FALSE,
- *   file_required = TRUE,
- *   cardinality = 1,
- *   menu_path = "",
- *   callback = "",
- *   callback_module = "",
- *   callback_path = "",
- * )
  */
+#[TripalImporter(
+   id: 'trpcultivate-phenotypes-share-importer',
+   label: new TranslatableMarkup('Tripal Cultivate: Open Science Phenotypic Data'),
+   description: new TranslatableMarkup('Imports phenotypic data which has already been published or which is ready to be freely shared.'),
+   file_types: ['tsv'],
+   upload_description: new TranslatableMarkup('Please provide a data file.'),
+   upload_title: new TranslatableMarkup('Phenotypic Data File'),
+   use_analysis: FALSE,
+   require_analysis: FALSE,
+   use_button: TRUE,
+   submit_disabled: TRUE,
+   button_text: new TranslatableMarkup('Import'),
+   file_upload: TRUE,
+   file_local: FALSE,
+   file_remote: FALSE,
+   file_required: TRUE,
+   cardinality: 1,
+   menu_path: '',
+   callback: '',
+   callback_path: '',
+ )]
 class TripalCultivatePhenoShareImporter extends ChadoImporterBase implements ContainerFactoryPluginInterface {
 
   use StringTranslationTrait;

--- a/trpcultivate_phenoshare/tests/src/Functional/InstallTest.php
+++ b/trpcultivate_phenoshare/tests/src/Functional/InstallTest.php
@@ -5,6 +5,7 @@ namespace Drupal\Tests\trpcultivate_phenoshare\Functional;
 use Drupal\Core\Routing\RouteMatch;
 use Drupal\Core\Url;
 use Drupal\Tests\tripal_chado\Functional\ChadoTestBrowserBase;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Simple test to ensure that main page loads with module enabled.

--- a/trpcultivate_phenoshare/tests/src/Functional/InstallTest.php
+++ b/trpcultivate_phenoshare/tests/src/Functional/InstallTest.php
@@ -12,6 +12,8 @@ use Drupal\Tests\tripal_chado\Functional\ChadoTestBrowserBase;
  * @group TripPheno Share
  * @group Installation
  */
+#[Group('TripPheno Share')]
+#[Group('Installation')]
 class InstallTest extends ChadoTestBrowserBase {
 
   /**

--- a/trpcultivate_phenoshare/tests/src/Kernel/TripalImporter/ShareImporterFormTest.php
+++ b/trpcultivate_phenoshare/tests/src/Kernel/TripalImporter/ShareImporterFormTest.php
@@ -10,6 +10,7 @@ use Drupal\tripal\Services\TripalLogger;
 use Drupal\tripal_chado\Database\ChadoConnection;
 use Drupal\user\Entity\User;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests the form + form-related functionality of the Share Importer.

--- a/trpcultivate_phenoshare/tests/src/Kernel/TripalImporter/ShareImporterFormTest.php
+++ b/trpcultivate_phenoshare/tests/src/Kernel/TripalImporter/ShareImporterFormTest.php
@@ -9,12 +9,14 @@ use Drupal\Tests\user\Traits\UserCreationTrait;
 use Drupal\tripal\Services\TripalLogger;
 use Drupal\tripal_chado\Database\ChadoConnection;
 use Drupal\user\Entity\User;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Tests the form + form-related functionality of the Share Importer.
  *
  * @group shareImporter
  */
+#[Group('shareImporter')]
 class ShareImporterFormTest extends ChadoTestKernelBase {
 
   use UserCreationTrait;
@@ -270,6 +272,7 @@ class ShareImporterFormTest extends ChadoTestKernelBase {
    *
    * @dataProvider provideFormValues
    */
+  #[DataProvider('provideFormValues')]
   public function testForm($scenario, $stage_index, $trigger_element, $expected) {
 
     // Build $form_state parameter. These values are used to determine
@@ -473,6 +476,7 @@ class ShareImporterFormTest extends ChadoTestKernelBase {
    *
    * @dataProvider provideStageDetails
    */
+  #[DataProvider('provideStageDetails')]
   public function testStages($scenario, $stage_wrapper, $stage_method, $expected) {
 
     // Build $form parameter.
@@ -643,6 +647,7 @@ class ShareImporterFormTest extends ChadoTestKernelBase {
    *
    * @dataProvider provideValidationResultArray
    */
+  #[DataProvider('provideValidationResultArray')]
   public function testHasFailedValidation($scenario, $validation_result_array, $expected) {
 
     $has_failed = $this->phenoshare_importer
@@ -705,6 +710,7 @@ class ShareImporterFormTest extends ChadoTestKernelBase {
    *
    * @dataProvider provideAllowNewConfig
    */
+  #[DataProvider('provideAllowNewConfig')]
   public function testFormAllowNewNotification($scenario, $set_value, $expected) {
 
     $form = $this->form_importer;

--- a/trpcultivate_phenoshare/tests/src/Kernel/TripalImporter/ShareImporterFormValidateTest.php
+++ b/trpcultivate_phenoshare/tests/src/Kernel/TripalImporter/ShareImporterFormValidateTest.php
@@ -9,6 +9,8 @@ use Drupal\Tests\tripal_chado\Kernel\ChadoTestKernelBase;
 use Drupal\Tests\user\Traits\UserCreationTrait;
 use Drupal\tripal\Services\TripalLogger;
 use Drupal\tripal_chado\Database\ChadoConnection;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests the formValidate() functionality of the Share Importer.

--- a/trpcultivate_phenoshare/tests/src/Kernel/TripalImporter/ShareImporterFormValidateTest.php
+++ b/trpcultivate_phenoshare/tests/src/Kernel/TripalImporter/ShareImporterFormValidateTest.php
@@ -15,6 +15,7 @@ use Drupal\tripal_chado\Database\ChadoConnection;
  *
  * @group shareImporter
  */
+#[Group('shareImporter')]
 class ShareImporterFormValidateTest extends ChadoTestKernelBase {
 
   use UserCreationTrait;
@@ -600,6 +601,7 @@ class ShareImporterFormValidateTest extends ChadoTestKernelBase {
    *
    * @dataProvider provideFormInputValues
    */
+  #[DataProvider('provideFormInputValues')]
   public function testShareImporterFormValidateStage1(
     string $scenario,
     array $input_values,

--- a/trpcultivate_phenotypes/src/Entity/PhenodataBackup.php
+++ b/trpcultivate_phenotypes/src/Entity/PhenodataBackup.php
@@ -5,55 +5,59 @@ declare(strict_types=1);
 namespace Drupal\trpcultivate_phenotypes\Entity;
 
 use Drupal\Core\Config\Entity\ConfigEntityBase;
+use Drupal\Core\Entity\Attribute\ConfigEntityType;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\trpcultivate_phenotypes\ListBuilder\PhenodataBackupListBuilder;
+use Drupal\trpcultivate_phenotypes\Form\PhenodataBackupForm;
+use Drupal\Core\Entity\EntityDeleteForm;
 
 /**
  * Defines the phenotypic data backup entity type.
- *
- * @ConfigEntityType(
- *   id = "phenodata_backup",
- *   label = @Translation("Phenotypic Data Backup"),
- *   label_collection = @Translation("Phenotypic Data Backups"),
- *   label_singular = @Translation("phenotypic data backup"),
- *   label_plural = @Translation("phenotypic data backups"),
- *   label_count = @PluralTranslation(
- *     singular = "@count phenotypic data backup",
- *     plural = "@count phenotypic data backups",
- *   ),
- *   handlers = {
- *     "list_builder" = "Drupal\trpcultivate_phenotypes\ListBuilder\PhenodataBackupListBuilder",
- *     "form" = {
- *       "add" = "Drupal\trpcultivate_phenotypes\Form\PhenodataBackupForm",
- *       "edit" = "Drupal\trpcultivate_phenotypes\Form\PhenodataBackupForm",
- *       "delete" = "Drupal\Core\Entity\EntityDeleteForm",
- *     },
- *   },
- *   config_prefix = "phenodata_backup",
- *   admin_permission = "administer phenodata_backup",
- *   links = {
- *     "collection" = "/admin/structure/phenodata-backup",
- *     "add-form" = "/admin/structure/phenodata-backup/add",
- *     "edit-form" = "/admin/structure/phenodata-backup/{phenodata_backup}",
- *     "delete-form" = "/admin/structure/phenodata-backup/{phenodata_backup}/delete",
- *   },
- *   entity_keys = {
- *     "id" = "id",
- *     "uuid" = "uuid",
- *     "file_id" = "file_id",
- *     "project_id" = "project_id",
- *     "comments" = "comments",
- *     "backup_date" = "backup_date",
- *     "user_id" = "user_id",
- *   },
- *   config_export = {
- *     "id",
- *     "file_id",
- *     "project_id",
- *     "comments",
- *     "backup_date",
- *     "user_id",
- *   },
- * )
  */
+#[ConfigEntityType(
+ id: 'phenodata_backup',
+ label: new TranslatableMarkup('Phenotypic Data Backup'),
+ label_collection: new TranslatableMarkup('Phenotypic Data Backups'),
+ label_singular: new TranslatableMarkup('phenotypic data backup'),
+ label_plural: new TranslatableMarkup('phenotypic data backups'),
+ label_count: [
+   'singular' => '@count phenotypic data backup',
+   'plural' => '@count phenotypic data backups',
+ ],
+ handlers: [
+   'list_builder' => PhenodataBackupListBuilder::class,
+   'form' => [
+     'add' => PhenodataBackupForm::class,
+     'edit' => PhenodataBackupForm::class,
+     'delete' => EntityDeleteForm::class,
+   ],
+ ],
+ config_prefix: 'phenodata_backup',
+ admin_permission: 'administer phenodata_backup',
+ links: [
+   'collection' => '/admin/structure/phenodata-backup',
+   'add-form' => '/admin/structure/phenodata-backup/add',
+   'edit-form' => '/admin/structure/phenodata-backup/{phenodata_backup}',
+   'delete-form' => '/admin/structure/phenodata-backup/{phenodata_backup}/delete',
+ ],
+ entity_keys: [
+   'id' => 'id',
+   'uuid' => 'uuid',
+   'file_id' => 'file_id',
+   'project_id' => 'project_id',
+   'comments' => 'comments',
+   'backup_date' => 'backup_date',
+   'user_id' => 'user_id',
+ ],
+ config_export: [
+   'id',
+   'file_id',
+   'project_id',
+   'comments',
+   'backup_date',
+   'user_id',
+ ],
+)]
 final class PhenodataBackup extends ConfigEntityBase implements PhenodataBackupInterface {
 
   /**

--- a/trpcultivate_phenotypes/src/Entity/PhenodataBackup.php
+++ b/trpcultivate_phenotypes/src/Entity/PhenodataBackup.php
@@ -13,6 +13,51 @@ use Drupal\Core\Entity\EntityDeleteForm;
 
 /**
  * Defines the phenotypic data backup entity type.
+ *
+ * @ConfigEntityType(
+ *   id = "phenodata_backup",
+ *   label = @Translation("Phenotypic Data Backup"),
+ *   label_collection = @Translation("Phenotypic Data Backups"),
+ *   label_singular = @Translation("phenotypic data backup"),
+ *   label_plural = @Translation("phenotypic data backups"),
+ *   label_count = @PluralTranslation(
+ *     singular = "@count phenotypic data backup",
+ *     plural = "@count phenotypic data backups",
+ *   ),
+ *   handlers = {
+ *     "list_builder" = "Drupal\trpcultivate_phenotypes\ListBuilder\PhenodataBackupListBuilder",
+ *     "form" = {
+ *       "add" = "Drupal\trpcultivate_phenotypes\Form\PhenodataBackupForm",
+ *       "edit" = "Drupal\trpcultivate_phenotypes\Form\PhenodataBackupForm",
+ *       "delete" = "Drupal\Core\Entity\EntityDeleteForm",
+ *     },
+ *   },
+ *   config_prefix = "phenodata_backup",
+ *   admin_permission = "administer phenodata_backup",
+ *   links = {
+ *     "collection" = "/admin/structure/phenodata-backup",
+ *     "add-form" = "/admin/structure/phenodata-backup/add",
+ *     "edit-form" = "/admin/structure/phenodata-backup/{phenodata_backup}",
+ *     "delete-form" = "/admin/structure/phenodata-backup/{phenodata_backup}/delete",
+ *   },
+ *   entity_keys = {
+ *     "id" = "id",
+ *     "uuid" = "uuid",
+ *     "file_id" = "file_id",
+ *     "project_id" = "project_id",
+ *     "comments" = "comments",
+ *     "backup_date" = "backup_date",
+ *     "user_id" = "user_id",
+ *   },
+ *   config_export = {
+ *     "id",
+ *     "file_id",
+ *     "project_id",
+ *     "comments",
+ *     "backup_date",
+ *     "user_id",
+ *   },
+ * )
  */
 #[ConfigEntityType(
  id: 'phenodata_backup',

--- a/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
+++ b/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
@@ -20,35 +20,35 @@ use Drupal\trpcultivate\TripalCultivateValidator\TripalCultivateValidatorManager
 use Drupal\trpcultivate\Service\TripalCultivateFileTemplateService;
 use Drupal\trpcultivate\Service\ImportValidationHelper;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\tripal\TripalImporter\Attribute\TripalImporter;
 
 /**
  * Tripal Cultivate Phenotypes - Traits Importer.
  *
  * An importer for traits with a defined method and unit.
- *
- * @TripalImporter(
- *   id = "trpcultivate-phenotypes-traits-importer",
- *   label = @Translation("Tripal Cultivate: Phenotypic Trait Importer"),
- *   description = @Translation("Loads Traits for phenotypic data into the system. This is useful for large phenotypic datasets to ease the upload process."),
- *   file_types = {"tsv"},
- *   upload_description = @Translation("Please provide a data file."),
- *   upload_title = @Translation("Phenotypic Trait Data File*"),
- *   use_analysis = FALSE,
- *   require_analysis = FALSE,
- *   use_button = True,
- *   submit_disabled = FALSE,
- *   button_text = "Import",
- *   file_upload = TRUE,
- *   file_local = FALSE,
- *   file_remote = FALSE,
- *   file_required = TRUE,
- *   cardinality = 1,
- *   menu_path = "",
- *   callback = "",
- *   callback_module = "",
- *   callback_path = "",
- * )
  */
+#[TripalImporter(
+   id: 'trpcultivate-phenotypes-traits-importer',
+   label: new TranslatableMarkup('Tripal Cultivate: Phenotypic Trait Importer'),
+   description: new TranslatableMarkup('Loads Traits for phenotypic data into the system. This is useful for large phenotypic datasets to ease the upload process.'),
+   file_types: ['tsv'],
+   upload_description: new TranslatableMarkup('Please provide a data file.'),
+   upload_title: new TranslatableMarkup('Phenotypic Trait Data File*'),
+   use_analysis: FALSE,
+   require_analysis: FALSE,
+   use_button: TRUE,
+   submit_disabled: FALSE,
+   button_text: new TranslatableMarkup('Import'),
+   file_upload: TRUE,
+   file_local: FALSE,
+   file_remote: FALSE,
+   file_required: TRUE,
+   cardinality: 1,
+   menu_path: '',
+   callback: '',
+   callback_path: '',
+  )]
 class TripalCultivatePhenotypesTraitsImporter extends ChadoImporterBase implements ContainerFactoryPluginInterface {
 
   use StringTranslationTrait;

--- a/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
+++ b/trpcultivate_phenotypes/src/Plugin/TripalImporter/TripalCultivatePhenotypesTraitsImporter.php
@@ -27,6 +27,29 @@ use Drupal\tripal\TripalImporter\Attribute\TripalImporter;
  * Tripal Cultivate Phenotypes - Traits Importer.
  *
  * An importer for traits with a defined method and unit.
+ *
+ * @TripalImporter(
+ *   id = "trpcultivate-phenotypes-traits-importer",
+ *   label = @Translation("Tripal Cultivate: Phenotypic Trait Importer"),
+ *   description = @Translation("Loads Traits for phenotypic data into the system. This is useful for large phenotypic datasets to ease the upload process."),
+ *   file_types = {"tsv"},
+ *   upload_description = @Translation("Please provide a data file."),
+ *   upload_title = @Translation("Phenotypic Trait Data File*"),
+ *   use_analysis = FALSE,
+ *   require_analysis = FALSE,
+ *   use_button = True,
+ *   submit_disabled = FALSE,
+ *   button_text = "Import",
+ *   file_upload = TRUE,
+ *   file_local = FALSE,
+ *   file_remote = FALSE,
+ *   file_required = TRUE,
+ *   cardinality = 1,
+ *   menu_path = "",
+ *   callback = "",
+ *   callback_module = "",
+ *   callback_path = "",
+ * )
  */
 #[TripalImporter(
    id: 'trpcultivate-phenotypes-traits-importer',

--- a/trpcultivate_phenotypes/src/Plugin/Validators/DuplicateTraits.php
+++ b/trpcultivate_phenotypes/src/Plugin/Validators/DuplicateTraits.php
@@ -10,16 +10,17 @@ use Drupal\trpcultivate_phenotypes\TripalCultivateValidator\ValidatorTraits\Genu
 use Drupal\trpcultivate_phenotypes\TripalCultivateValidator\TripalCultivatePhenotypesValidatorBase;
 use Drupal\trpcultivate\TripalCultivateValidator\ValidatorTraits\ColumnIndices;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\trpcultivate\TripalCultivateValidator\Attribute\TripalCultivateValidator;
 
 /**
  * Validate duplicate traits within a file.
- *
- * @TripalCultivateValidator(
- *   id = "duplicate_traits",
- *   validator_name = @Translation("Duplicate Traits Validator"),
- *   input_types = {"data-row"},
- * )
  */
+#[TripalCultivateValidator(
+   id: 'duplicate_traits',
+   validator_name: new TranslatableMarkup("Duplicate Traits Validator"),
+   input_types: ['data-row'],
+ )]
 class DuplicateTraits extends TripalCultivatePhenotypesValidatorBase implements ContainerFactoryPluginInterface {
 
   /**

--- a/trpcultivate_phenotypes/src/Plugin/Validators/DuplicateTraits.php
+++ b/trpcultivate_phenotypes/src/Plugin/Validators/DuplicateTraits.php
@@ -15,6 +15,12 @@ use Drupal\trpcultivate\TripalCultivateValidator\Attribute\TripalCultivateValida
 
 /**
  * Validate duplicate traits within a file.
+ *
+ * @TripalCultivateValidator(
+ *   id = "duplicate_traits",
+ *   validator_name = @Translation("Duplicate Traits Validator"),
+ *   input_types = {"data-row"},
+ * )
  */
 #[TripalCultivateValidator(
    id: 'duplicate_traits',

--- a/trpcultivate_phenotypes/src/Plugin/Validators/DuplicateTraits.php
+++ b/trpcultivate_phenotypes/src/Plugin/Validators/DuplicateTraits.php
@@ -18,7 +18,7 @@ use Drupal\trpcultivate\TripalCultivateValidator\Attribute\TripalCultivateValida
  */
 #[TripalCultivateValidator(
    id: 'duplicate_traits',
-   validator_name: new TranslatableMarkup("Duplicate Traits Validator"),
+   validator_name: new TranslatableMarkup('Duplicate Traits Validator'),
    input_types: ['data-row'],
  )]
 class DuplicateTraits extends TripalCultivatePhenotypesValidatorBase implements ContainerFactoryPluginInterface {

--- a/trpcultivate_phenotypes/src/Plugin/Validators/GenusExists.php
+++ b/trpcultivate_phenotypes/src/Plugin/Validators/GenusExists.php
@@ -7,16 +7,17 @@ use Drupal\tripal_chado\Database\ChadoConnection;
 use Drupal\trpcultivate_phenotypes\Service\TripalCultivatePhenotypesGenusOntologyService;
 use Drupal\trpcultivate_phenotypes\TripalCultivateValidator\TripalCultivatePhenotypesValidatorBase;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\trpcultivate\TripalCultivateValidator\Attribute\TripalCultivateValidator;
 
 /**
  * Validate that genus exists and is configured.
- *
- * @TripalCultivateValidator(
- *   id = "genus_exists",
- *   validator_name = @Translation("Genus Exists and Configured Validator"),
- *   input_types = {"metadata"}
- * )
  */
+#[TripalCultivateValidator(
+   id: 'genus_exists',
+   validator_name: new TranslatableMarkup('Genus Exists and Configured Validator'),
+   input_types: ['metadata']
+ )]
 class GenusExists extends TripalCultivatePhenotypesValidatorBase implements ContainerFactoryPluginInterface {
 
   /**

--- a/trpcultivate_phenotypes/src/Plugin/Validators/GenusExists.php
+++ b/trpcultivate_phenotypes/src/Plugin/Validators/GenusExists.php
@@ -12,6 +12,12 @@ use Drupal\trpcultivate\TripalCultivateValidator\Attribute\TripalCultivateValida
 
 /**
  * Validate that genus exists and is configured.
+ *
+ * @TripalCultivateValidator(
+ *   id = "genus_exists",
+ *   validator_name = @Translation("Genus Exists and Configured Validator"),
+ *   input_types = {"metadata"}
+ * )
  */
 #[TripalCultivateValidator(
    id: 'genus_exists',

--- a/trpcultivate_phenotypes/src/Plugin/Validators/ProjectGenusMatch.php
+++ b/trpcultivate_phenotypes/src/Plugin/Validators/ProjectGenusMatch.php
@@ -8,16 +8,17 @@ use Drupal\trpcultivate\Service\ImportValidationHelper;
 use Drupal\trpcultivate_phenotypes\Service\TripalCultivatePhenotypesGenusProjectService;
 use Drupal\trpcultivate_phenotypes\TripalCultivateValidator\TripalCultivatePhenotypesValidatorBase;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\trpcultivate\TripalCultivateValidator\Attribute\TripalCultivateValidator;
 
 /**
  * Validate that project exits and project-genus match the genus provided.
- *
- * @TripalCultivateValidator(
- *   id = "project_genus_match",
- *   validator_name = @Translation("Project Exists and Genus Match Validator"),
- *   input_types = {"metadata"}
- * )
  */
+#[TripalCultivateValidator(
+   id: 'project_genus_match',
+   validator_name: new TranslatableMarkup('Project Exists and Genus Match Validator'),
+   input_types: ['metadata']
+ )]
 class ProjectGenusMatch extends TripalCultivatePhenotypesValidatorBase implements ContainerFactoryPluginInterface {
 
   /**

--- a/trpcultivate_phenotypes/src/Plugin/Validators/ProjectGenusMatch.php
+++ b/trpcultivate_phenotypes/src/Plugin/Validators/ProjectGenusMatch.php
@@ -13,6 +13,12 @@ use Drupal\trpcultivate\TripalCultivateValidator\Attribute\TripalCultivateValida
 
 /**
  * Validate that project exits and project-genus match the genus provided.
+ *
+ * @TripalCultivateValidator(
+ *   id = "project_genus_match",
+ *   validator_name = @Translation("Project Exists and Genus Match Validator"),
+ *   input_types = {"metadata"}
+ * )
  */
 #[TripalCultivateValidator(
    id: 'project_genus_match',

--- a/trpcultivate_phenotypes/tests/src/Functional/InstallTest.php
+++ b/trpcultivate_phenotypes/tests/src/Functional/InstallTest.php
@@ -6,6 +6,7 @@ use Drupal\Core\Routing\RouteMatch;
 use Drupal\Core\Url;
 use Drupal\tripal_chado\Database\ChadoConnection;
 use Drupal\Tests\tripal_chado\Functional\ChadoTestBrowserBase;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Simple test to ensure that main page loads with module enabled.

--- a/trpcultivate_phenotypes/tests/src/Functional/InstallTest.php
+++ b/trpcultivate_phenotypes/tests/src/Functional/InstallTest.php
@@ -13,6 +13,8 @@ use Drupal\Tests\tripal_chado\Functional\ChadoTestBrowserBase;
  * @group TripPheno Phenotypes
  * @group Installation
  */
+#[Group('TripPheno Phenotypes')]
+#[Group('Installation')]
 class InstallTest extends ChadoTestBrowserBase {
 
   /**

--- a/trpcultivate_phenotypes/tests/src/Kernel/Entity/PhenodataBackupFormTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Entity/PhenodataBackupFormTest.php
@@ -16,6 +16,7 @@ use Drupal\trpcultivate_phenotypes\Entity\PhenodataBackup;
  *
  * @group trpcultivate_phenotypes
  */
+#[Group('trpcultivate_phenotypes')]
 class PhenodataBackupFormTest extends ChadoTestKernelBase {
 
   use TripalCultivateImporterTestTrait;
@@ -327,6 +328,7 @@ class PhenodataBackupFormTest extends ChadoTestKernelBase {
    *
    * @dataProvider providePhenodataBackupScenarios
    */
+  #[DataProvider('providePhenodataBackupScenarios')]
   public function testPhenodataBackupFormAccess(string $current_user, array $test_backups, array $expected) {
 
     // Login the current user.
@@ -466,6 +468,7 @@ class PhenodataBackupFormTest extends ChadoTestKernelBase {
    *
    * @dataProvider providePhenodataBackupValues
    */
+  #[DataProvider('providePhenodataBackupValues')]
   public function testPhenodataBackupFormSubmit(array $create_input, array $create_expectations, array $edit_input, array $edit_expectations) {
 
     // Login the current user.

--- a/trpcultivate_phenotypes/tests/src/Kernel/Entity/PhenodataBackupFormTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Entity/PhenodataBackupFormTest.php
@@ -10,6 +10,8 @@ use Drupal\Tests\trpcultivate\Traits\TripalCultivateImporterTestTrait;
 use Drupal\tripal\Entity\TripalEntityType;
 use Drupal\tripal_chado\Database\ChadoConnection;
 use Drupal\trpcultivate_phenotypes\Entity\PhenodataBackup;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests associated with the Phenodata Backup create/edit form.

--- a/trpcultivate_phenotypes/tests/src/Kernel/Entity/PhenodataBackupListTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Entity/PhenodataBackupListTest.php
@@ -9,6 +9,8 @@ use Drupal\Tests\tripal_chado\Kernel\ChadoTestKernelBase;
 use Drupal\Tests\trpcultivate\Traits\TripalCultivateImporterTestTrait;
 use Drupal\tripal_chado\Database\ChadoConnection;
 use Symfony\Component\HttpFoundation\Request;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests associated with the Phenodata Backup listing.

--- a/trpcultivate_phenotypes/tests/src/Kernel/Entity/PhenodataBackupListTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Entity/PhenodataBackupListTest.php
@@ -15,6 +15,7 @@ use Symfony\Component\HttpFoundation\Request;
  *
  * @group trpcultivate_phenotypes
  */
+#[Group('trpcultivate_phenotypes')]
 class PhenodataBackupListTest extends ChadoTestKernelBase {
 
   use TripalCultivateImporterTestTrait;
@@ -317,6 +318,7 @@ class PhenodataBackupListTest extends ChadoTestKernelBase {
    *
    * @dataProvider providePhenodataBackupScenarios
    */
+  #[DataProvider('providePhenodataBackupScenarios')]
   public function testPhenodataBackupListRequest(string $current_user, array $expected) {
 
     // Login the current user.
@@ -398,6 +400,7 @@ class PhenodataBackupListTest extends ChadoTestKernelBase {
    *
    * @dataProvider providePhenodataBackupScenarios
    */
+  #[DataProvider('providePhenodataBackupScenarios')]
   public function testPhenodataBackupListLoad(string $current_user, array $expected) {
 
     // Login the current user.

--- a/trpcultivate_phenotypes/tests/src/Kernel/Forms/ConfigWatermarkFormTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Forms/ConfigWatermarkFormTest.php
@@ -6,6 +6,7 @@ use Drupal\Core\Form\FormState;
 use Drupal\file\Entity\File;
 use Drupal\Tests\tripal_chado\Kernel\ChadoTestKernelBase;
 use Drupal\trpcultivate_phenotypes\Form\TripalCultivatePhenotypesWatermarkSettingsForm;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Class definition ConfigWatermarkFormTest.

--- a/trpcultivate_phenotypes/tests/src/Kernel/Forms/ConfigWatermarkFormTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Forms/ConfigWatermarkFormTest.php
@@ -13,6 +13,7 @@ use Drupal\trpcultivate_phenotypes\Form\TripalCultivatePhenotypesWatermarkSettin
  * @coversDefaultClass Drupal\trpcultivate_phenotypes\Form\TripalCultivatePhenotypesWatermarkSettingsForm
  * @group trpcultivate_phenotypes
  */
+#[Group('trpcultivate_phenotypes')]
 class ConfigWatermarkFormTest extends ChadoTestKernelBase {
 
   /**

--- a/trpcultivate_phenotypes/tests/src/Kernel/PhenotypeTermInstallTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/PhenotypeTermInstallTest.php
@@ -10,6 +10,7 @@ use Drupal\tripal_chado\Database\ChadoConnection;
  *
  * @group trpcultivate_phenotypes
  */
+#[Group('trpcultivate_phenotypes')]
 class PhenotypeTermInstallTest extends ChadoTestKernelBase {
 
   /**

--- a/trpcultivate_phenotypes/tests/src/Kernel/PhenotypeTermInstallTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/PhenotypeTermInstallTest.php
@@ -4,6 +4,7 @@ namespace Drupal\Tests\trpcultivate_phenotypes\Kernel;
 
 use Drupal\Tests\tripal_chado\Kernel\ChadoTestKernelBase;
 use Drupal\tripal_chado\Database\ChadoConnection;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests trpcultivate_phenotypes.module.

--- a/trpcultivate_phenotypes/tests/src/Kernel/ServiceGenusOntologyTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/ServiceGenusOntologyTest.php
@@ -12,6 +12,7 @@ use Drupal\tripal\Services\TripalLogger;
  *
  * @group trpcultivate_phenotypes
  */
+#[Group('trpcultivate_phenotypes')]
 class ServiceGenusOntologyTest extends ChadoTestKernelBase {
 
   use PhenotypeImporterTestTrait;
@@ -189,6 +190,7 @@ class ServiceGenusOntologyTest extends ChadoTestKernelBase {
    *
    * @dataProvider provideGenusForGenusOntologyService
    */
+  #[DataProvider('provideGenusForGenusOntologyService')]
   public function testGenusOntologyService($scenario, $genus, $species, $expected) {
     // Create an organism.
     $organism_id = $this->chado_connection->insert('1:organism')
@@ -381,6 +383,7 @@ class ServiceGenusOntologyTest extends ChadoTestKernelBase {
    *
    * @dataProvider provideInvalidValuesForGenusOntologyService
    */
+  #[DataProvider('provideInvalidValuesForGenusOntologyService')]
   public function testInvalidGenusOntologyService($scenario, $genus, $species, $invalid_input, $expected) {
     // Create an organism.
     $organism_id = $this->chado_connection->insert('1:organism')

--- a/trpcultivate_phenotypes/tests/src/Kernel/ServiceGenusOntologyTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/ServiceGenusOntologyTest.php
@@ -6,6 +6,8 @@ use Drupal\Tests\tripal_chado\Kernel\ChadoTestKernelBase;
 use Drupal\tripal_chado\Database\ChadoConnection;
 use Drupal\Tests\trpcultivate_phenotypes\Traits\PhenotypeImporterTestTrait;
 use Drupal\tripal\Services\TripalLogger;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests associated with the Genus Ontology Service.

--- a/trpcultivate_phenotypes/tests/src/Kernel/ServiceGenusProjectTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/ServiceGenusProjectTest.php
@@ -6,6 +6,8 @@ use Drupal\Tests\tripal_chado\Kernel\ChadoTestKernelBase;
 use Drupal\tripal_chado\Database\ChadoConnection;
 use Drupal\Tests\trpcultivate_phenotypes\Traits\PhenotypeImporterTestTrait;
 use Drupal\tripal\Services\TripalLogger;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test Tripal Cultivate Phenotypes Genus Project service.

--- a/trpcultivate_phenotypes/tests/src/Kernel/ServiceGenusProjectTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/ServiceGenusProjectTest.php
@@ -12,6 +12,7 @@ use Drupal\tripal\Services\TripalLogger;
  *
  * @group trpcultivate_phenotypes
  */
+#[Group('trpcultivate_phenotypes')]
 class ServiceGenusProjectTest extends ChadoTestKernelBase {
 
   use PhenotypeImporterTestTrait;
@@ -215,6 +216,7 @@ class ServiceGenusProjectTest extends ChadoTestKernelBase {
    *
    * @dataProvider provideGenusProjectForGenusProjectService
    */
+  #[DataProvider('provideGenusProjectForGenusProjectService')]
   public function testGenusProjectService($scenario, $genus_count, $expected) {
 
     $rand_i = mt_rand(0, $genus_count - 1);
@@ -359,6 +361,7 @@ class ServiceGenusProjectTest extends ChadoTestKernelBase {
    *
    * @dataProvider provideInvalidValuesToGenusProjectService
    */
+  #[DataProvider('provideInvalidValuesToGenusProjectService')]
   public function testGenusProjectServiceWithInvalidValues($scenario, $input_value, $expected) {
 
     $has_genus = $this->chado_connection->select('1:projectprop', 'pp')

--- a/trpcultivate_phenotypes/tests/src/Kernel/ServiceTermTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/ServiceTermTest.php
@@ -9,6 +9,8 @@ use Drupal\tripal\Services\TripalLogger;
 use Drupal\tripal_chado\ChadoBuddy\PluginManagers\ChadoBuddyPluginManager;
 use Drupal\tripal_chado\Plugin\ChadoBuddy\ChadoCvtermBuddy;
 use Drupal\tripal_chado\Plugin\ChadoBuddy\ChadoDbxrefBuddy;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test Tripal Cultivate Phenotypes Terms service.

--- a/trpcultivate_phenotypes/tests/src/Kernel/ServiceTermTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/ServiceTermTest.php
@@ -15,6 +15,7 @@ use Drupal\tripal_chado\Plugin\ChadoBuddy\ChadoDbxrefBuddy;
  *
  * @group trpcultivate_phenotypes
  */
+#[Group('trpcultivate_phenotypes')]
 class ServiceTermTest extends ChadoTestKernelBase {
 
   use PhenotypeImporterTestTrait;
@@ -200,6 +201,7 @@ class ServiceTermTest extends ChadoTestKernelBase {
    *
    * @dataProvider provideTermIdentifierForGetTermIdMethod
    */
+  #[DataProvider('provideTermIdentifierForGetTermIdMethod')]
   public function testGetTermId($scenario, $input_term_identifier, $expected) {
     $term_id = $this->service_PhenoTerms->getTermId($input_term_identifier);
     $term_exists = ($term_id > 0) ? TRUE : FALSE;
@@ -277,6 +279,7 @@ class ServiceTermTest extends ChadoTestKernelBase {
    *
    * @dataProvider provideTermsForSaveTermConfigValuesMethod
    */
+  #[DataProvider('provideTermsForSaveTermConfigValuesMethod')]
   public function testSaveTermConfigValuesMethod($scenario, $input_term, $term_identifier, $expected) {
     // Create or fectch input term.
     $term_exists = $this->chado_connection->select('1:cvterm', 'cvt')
@@ -373,6 +376,7 @@ class ServiceTermTest extends ChadoTestKernelBase {
    *
    * @dataProvider provideInvalidTermsForSaveTermConfigValuesMethod
    */
+  #[DataProvider('provideInvalidTermsForSaveTermConfigValuesMethod')]
   public function testSaveTermConfigValuesMethodInvalidKey($scenario, $input_term, $term_identifier, $expected) {
     // Create or fectch input term.
     $cvterm_id = $this->chado_connection->select('1:cvterm', 'cvt')
@@ -458,6 +462,7 @@ class ServiceTermTest extends ChadoTestKernelBase {
    *
    * @dataProvider provideInvalidConfigForSaveTermConfigValuesMethod
    */
+  #[DataProvider('provideInvalidConfigForSaveTermConfigValuesMethod')]
   public function testSaveTermConfigValuesMethodFailure($scenario, $config_value, $expected) {
     // Test when the config values is not valid.
     $is_saved = $this->service_PhenoTerms->saveTermConfigValues($config_value);

--- a/trpcultivate_phenotypes/tests/src/Kernel/Services/Traits/ValidTraitTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Services/Traits/ValidTraitTest.php
@@ -7,6 +7,7 @@ use Drupal\Tests\trpcultivate_phenotypes\Traits\PhenotypeImporterTestTrait;
 use Drupal\tripal_chado\Database\ChadoConnection;
 use Drupal\Core\Url;
 use Drupal\Core\Database\StatementWrapperIterator;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests that a valid trait/method/unit combination can be inserted/retrieved.

--- a/trpcultivate_phenotypes/tests/src/Kernel/Services/Traits/ValidTraitTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Services/Traits/ValidTraitTest.php
@@ -15,6 +15,9 @@ use Drupal\Core\Database\StatementWrapperIterator;
  * @group services
  * @group traits
  */
+#[Group('trpcultivate_phenotypes')]
+#[Group('services')]
+#[Group('traits')]
 class ValidTraitTest extends ChadoTestKernelBase {
   use PhenotypeImporterTestTrait;
 

--- a/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterFormTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterFormTest.php
@@ -16,6 +16,7 @@ use Drupal\user\Entity\User;
  *
  * @group traitsImporter
  */
+#[Group('traitsImporter')]
 class TraitImporterFormTest extends ChadoTestKernelBase {
 
   use UserCreationTrait;

--- a/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterFormTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterFormTest.php
@@ -10,6 +10,7 @@ use Drupal\Tests\user\Traits\UserCreationTrait;
 use Drupal\tripal\Services\TripalLogger;
 use Drupal\tripal_chado\Database\ChadoConnection;
 use Drupal\user\Entity\User;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests the form + form-related functionality of the Traits Importer.

--- a/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterFormValidateTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterFormValidateTest.php
@@ -15,6 +15,7 @@ use Drupal\tripal_chado\Database\ChadoConnection;
  *
  * @group traitsImporter
  */
+#[Group('traitsImporter')]
 class TraitImporterFormValidateTest extends ChadoTestKernelBase {
 
   use UserCreationTrait;
@@ -418,6 +419,7 @@ class TraitImporterFormValidateTest extends ChadoTestKernelBase {
    *
    * @dataProvider provideFilesForValidation
    */
+  #[DataProvider('provideFilesForValidation')]
   public function testTraitFormValidation(string $submitted_genus, string $filename, array $expected_validator_results, int $expected_num_form_validation_errors) {
 
     $formBuilder = \Drupal::formBuilder();

--- a/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterFormValidateTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterFormValidateTest.php
@@ -9,6 +9,8 @@ use Drupal\Tests\trpcultivate_phenotypes\Traits\PhenotypeImporterTestTrait;
 use Drupal\Tests\user\Traits\UserCreationTrait;
 use Drupal\tripal\Services\TripalLogger;
 use Drupal\tripal_chado\Database\ChadoConnection;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests the formValidate() functionality of the Traits Importer.

--- a/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterProcessValidationTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterProcessValidationTest.php
@@ -9,6 +9,8 @@ use Drupal\Tests\user\Traits\UserCreationTrait;
 use Drupal\tripal\Services\TripalLogger;
 use Drupal\tripal_chado\Database\ChadoConnection;
 use Drupal\trpcultivate_phenotypes\Plugin\TripalImporter\TripalCultivatePhenotypesTraitsImporter;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests processValidationMessages() and related methods in the Traits Importer.

--- a/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterProcessValidationTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterProcessValidationTest.php
@@ -15,6 +15,7 @@ use Drupal\trpcultivate_phenotypes\Plugin\TripalImporter\TripalCultivatePhenotyp
  *
  * @group traitsImporter
  */
+#[Group('traitsImporter')]
 class TraitImporterProcessValidationTest extends ChadoTestKernelBase {
 
   use AssertContentTrait;
@@ -217,6 +218,7 @@ class TraitImporterProcessValidationTest extends ChadoTestKernelBase {
    *
    * @dataProvider provideGenusExistsFailedCases
    */
+  #[DataProvider('provideGenusExistsFailedCases')]
   public function testProcessGenusExistsFailures(array $validation_result, array $expectations) {
     // Call the process method on our validation result.
     $render_array = $this->importer->processGenusExistsFailures($validation_result);
@@ -466,6 +468,7 @@ class TraitImporterProcessValidationTest extends ChadoTestKernelBase {
    *
    * @dataProvider provideDuplicateTraitsFailedCases
    */
+  #[DataProvider('provideDuplicateTraitsFailedCases')]
   public function testProcessDuplicateTraitsFailures(array $failures, array $expectations) {
     // Process our test failures array.
     $render_array = $this->importer->processDuplicateTraitsFailures($failures);
@@ -681,6 +684,7 @@ class TraitImporterProcessValidationTest extends ChadoTestKernelBase {
    *
    * @dataProvider providePassedAndUnrecognizableCases
    */
+  #[DataProvider('providePassedAndUnrecognizableCases')]
   public function testProcessFailuresExceptions(string $process_method, array $passed_case, array $unrecognized_case) {
     // Test with a passed validation case string.
     $exception_caught = FALSE;

--- a/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterRunTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterRunTest.php
@@ -15,6 +15,7 @@ use Drupal\trpcultivate_phenotypes\Plugin\TripalImporter\TripalCultivatePhenotyp
  *
  * @group traitsImporter
  */
+#[Group('traitsImporter')]
 class TraitImporterRunTest extends ChadoTestKernelBase {
 
   use UserCreationTrait;

--- a/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterRunTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/TripalImporter/TraitImporterRunTest.php
@@ -9,6 +9,7 @@ use Drupal\Tests\user\Traits\UserCreationTrait;
 use Drupal\tripal\Services\TripalLogger;
 use Drupal\tripal_chado\Database\ChadoConnection;
 use Drupal\trpcultivate_phenotypes\Plugin\TripalImporter\TripalCultivatePhenotypesTraitsImporter;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests the functionality of the run() method of the Traits Importer.

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/FakeValidators/BasicallyBase.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/FakeValidators/BasicallyBase.php
@@ -3,18 +3,19 @@
 namespace Drupal\Tests\trpcultivate_phenotypes\Kernel\Validators\FakeValidators;
 
 use Drupal\trpcultivate_phenotypes\TripalCultivateValidator\TripalCultivatePhenotypesValidatorBase;
+use Drupal\trpcultivate\TripalCultivateValidator\Attribute\TripalCultivateValidator;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 
 /**
  * Fake Validator that does not implement any of its own methods.
  *
  * Used to test the base class.
- *
- * @TripalCultivateValidator(
- *   id = "fake_basically_base",
- *   validator_name = @Translation("Basically Base Validator"),
- *   input_types = {"header-row", "data-row"}
- * )
  */
+#[TripalCultivateValidator(
+   id: 'fake_basically_base',
+   validator_name: new TranslatableMarkup('Basically Base Validator'),
+   input_types: ['header-row', 'data-row']
+ )]
 class BasicallyBase extends TripalCultivatePhenotypesValidatorBase {
 
 }

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/FakeValidators/BasicallyBase.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/FakeValidators/BasicallyBase.php
@@ -10,6 +10,12 @@ use Drupal\Core\StringTranslation\TranslatableMarkup;
  * Fake Validator that does not implement any of its own methods.
  *
  * Used to test the base class.
+ *
+ * @TripalCultivateValidator(
+ *   id = "fake_basically_base",
+ *   validator_name = @Translation("Basically Base Validator"),
+ *   input_types = {"header-row", "data-row"}
+ * )
  */
 #[TripalCultivateValidator(
    id: 'fake_basically_base',

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/FakeValidators/ValidatorGenusConfigured.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/FakeValidators/ValidatorGenusConfigured.php
@@ -7,18 +7,19 @@ use Drupal\trpcultivate_phenotypes\Service\TripalCultivatePhenotypesGenusOntolog
 use Drupal\trpcultivate_phenotypes\Service\TripalCultivatePhenotypesTraitsService;
 use Drupal\trpcultivate_phenotypes\TripalCultivateValidator\ValidatorTraits\GenusConfigured;
 use Drupal\trpcultivate\TripalCultivateValidator\TripalCultivateValidatorBase;
+use Drupal\trpcultivate\TripalCultivateValidator\Attribute\TripalCultivateValidator;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 
 /**
  * Fake Validator that does not implement any of its own methods.
  *
  * Used to test the GenusConfigured trait.
- *
- * @TripalCultivateValidator(
- *   id = "validator_requiring_configured_genus",
- *   validator_name = @Translation("Validator Using GenusConfigured Trait"),
- *   input_types = {"header-row", "data-row"}
- * )
  */
+#[TripalCultivateValidator(
+   id: "validator_requiring_configured_genus",
+   validator_name: new TranslatableMarkup('Validator Using GenusConfigured Trait'),
+   input_types: ['header-row', 'data-row']
+ )]
 class ValidatorGenusConfigured extends TripalCultivateValidatorBase {
 
   use GenusConfigured;

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/FakeValidators/ValidatorGenusConfigured.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/FakeValidators/ValidatorGenusConfigured.php
@@ -14,6 +14,12 @@ use Drupal\Core\StringTranslation\TranslatableMarkup;
  * Fake Validator that does not implement any of its own methods.
  *
  * Used to test the GenusConfigured trait.
+ *
+ * @TripalCultivateValidator(
+ *   id = "validator_requiring_configured_genus",
+ *   validator_name = @Translation("Validator Using GenusConfigured Trait"),
+ *   input_types = {"header-row", "data-row"}
+ * )
  */
 #[TripalCultivateValidator(
    id: 'validator_requiring_configured_genus',

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/FakeValidators/ValidatorGenusConfigured.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/FakeValidators/ValidatorGenusConfigured.php
@@ -16,7 +16,7 @@ use Drupal\Core\StringTranslation\TranslatableMarkup;
  * Used to test the GenusConfigured trait.
  */
 #[TripalCultivateValidator(
-   id: "validator_requiring_configured_genus",
+   id: 'validator_requiring_configured_genus',
    validator_name: new TranslatableMarkup('Validator Using GenusConfigured Trait'),
    input_types: ['header-row', 'data-row']
  )]

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/FakeValidators/ValidatorGenusConfiguredNOConnection.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/FakeValidators/ValidatorGenusConfiguredNOConnection.php
@@ -7,18 +7,19 @@ use Drupal\trpcultivate_phenotypes\Service\TripalCultivatePhenotypesGenusOntolog
 use Drupal\trpcultivate_phenotypes\Service\TripalCultivatePhenotypesTraitsService;
 use Drupal\trpcultivate_phenotypes\TripalCultivateValidator\ValidatorTraits\GenusConfigured;
 use Drupal\trpcultivate\TripalCultivateValidator\TripalCultivateValidatorBase;
+use Drupal\trpcultivate\TripalCultivateValidator\Attribute\TripalCultivateValidator;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 
 /**
  * Fake Validator that does not implement any of its own methods.
  *
  * Used to test the GenusConfigured trait with NO ChadoConnection.
- *
- * @TripalCultivateValidator(
- *   id = "validator_configured_genus_no_connection",
- *   validator_name = @Translation("Validator Using GenusConfigured Trait"),
- *   input_types = {"header-row", "data-row"}
- * )
  */
+#[TripalCultivateValidator(
+   id: 'validator_configured_genus_no_connection',
+   validator_name: new TranslatableMarkup('Validator Using GenusConfigured Trait'),
+   input_types: ['header-row', 'data-row']
+ )]
 class ValidatorGenusConfiguredNOConnection extends TripalCultivateValidatorBase {
 
   use GenusConfigured;

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/FakeValidators/ValidatorGenusConfiguredNOConnection.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/FakeValidators/ValidatorGenusConfiguredNOConnection.php
@@ -14,6 +14,12 @@ use Drupal\Core\StringTranslation\TranslatableMarkup;
  * Fake Validator that does not implement any of its own methods.
  *
  * Used to test the GenusConfigured trait with NO ChadoConnection.
+ *
+ * @TripalCultivateValidator(
+ *   id = "validator_configured_genus_no_connection",
+ *   validator_name = @Translation("Validator Using GenusConfigured Trait"),
+ *   input_types = {"header-row", "data-row"}
+ * )
  */
 #[TripalCultivateValidator(
    id: 'validator_configured_genus_no_connection',

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/FakeValidators/ValidatorGenusConfiguredNOServiceGenusontology.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/FakeValidators/ValidatorGenusConfiguredNOServiceGenusontology.php
@@ -7,18 +7,19 @@ use Drupal\trpcultivate_phenotypes\Service\TripalCultivatePhenotypesGenusOntolog
 use Drupal\trpcultivate_phenotypes\Service\TripalCultivatePhenotypesTraitsService;
 use Drupal\trpcultivate_phenotypes\TripalCultivateValidator\ValidatorTraits\GenusConfigured;
 use Drupal\trpcultivate\TripalCultivateValidator\TripalCultivateValidatorBase;
+use Drupal\trpcultivate\TripalCultivateValidator\Attribute\TripalCultivateValidator;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 
 /**
  * Fake Validator that does not implement any of its own methods.
  *
  * Used to test the GenusConfigured trait with NO PhenoGenusOntology service.
- *
- * @TripalCultivateValidator(
- *   id = "validator_configured_genus_no_service_genusontology",
- *   validator_name = @Translation("Validator Using GenusConfigured Trait"),
- *   input_types = {"header-row", "data-row"}
- * )
  */
+#[TripalCultivateValidator(
+   id: 'validator_configured_genus_no_service_genusontology',
+   validator_name: new TranslatableMarkup('Validator Using GenusConfigured Trait'),
+   input_types: ['header-row', 'data-row']
+ )]
 class ValidatorGenusConfiguredNOServiceGenusontology extends TripalCultivateValidatorBase {
 
   use GenusConfigured;

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/FakeValidators/ValidatorGenusConfiguredNOServiceGenusontology.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/FakeValidators/ValidatorGenusConfiguredNOServiceGenusontology.php
@@ -14,6 +14,12 @@ use Drupal\Core\StringTranslation\TranslatableMarkup;
  * Fake Validator that does not implement any of its own methods.
  *
  * Used to test the GenusConfigured trait with NO PhenoGenusOntology service.
+ *
+ * @TripalCultivateValidator(
+ *   id = "validator_configured_genus_no_service_genusontology",
+ *   validator_name = @Translation("Validator Using GenusConfigured Trait"),
+ *   input_types = {"header-row", "data-row"}
+ * )
  */
 #[TripalCultivateValidator(
    id: 'validator_configured_genus_no_service_genusontology',

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/FakeValidators/ValidatorGenusConfiguredNOServiceTraits.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/FakeValidators/ValidatorGenusConfiguredNOServiceTraits.php
@@ -14,6 +14,12 @@ use Drupal\Core\StringTranslation\TranslatableMarkup;
  * Fake Validator that does not implement any of its own methods.
  *
  * Used to test the GenusConfigured trait with NO PhenoTraits service.
+ *
+ * @TripalCultivateValidator(
+ *   id = "validator_configured_genus_no_service_trait",
+ *   validator_name = @Translation("Validator Using GenusConfigured Trait"),
+ *   input_types = {"header-row", "data-row"}
+ * )
  */
 #[TripalCultivateValidator(
    id: 'validator_configured_genus_no_service_trait',

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/FakeValidators/ValidatorGenusConfiguredNOServiceTraits.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/FakeValidators/ValidatorGenusConfiguredNOServiceTraits.php
@@ -7,18 +7,19 @@ use Drupal\trpcultivate_phenotypes\Service\TripalCultivatePhenotypesGenusOntolog
 use Drupal\trpcultivate_phenotypes\Service\TripalCultivatePhenotypesTraitsService;
 use Drupal\trpcultivate_phenotypes\TripalCultivateValidator\ValidatorTraits\GenusConfigured;
 use Drupal\trpcultivate\TripalCultivateValidator\TripalCultivateValidatorBase;
+use Drupal\trpcultivate\TripalCultivateValidator\Attribute\TripalCultivateValidator;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 
 /**
  * Fake Validator that does not implement any of its own methods.
  *
  * Used to test the GenusConfigured trait with NO PhenoTraits service.
- *
- * @TripalCultivateValidator(
- *   id = "validator_configured_genus_no_service_trait",
- *   validator_name = @Translation("Validator Using GenusConfigured Trait"),
- *   input_types = {"header-row", "data-row"}
- * )
  */
+#[TripalCultivateValidator(
+   id: 'validator_configured_genus_no_service_trait',
+   validator_name: new TranslatableMarkup('Validator Using GenusConfigured Trait'),
+   input_types: ['header-row', 'data-row']
+ )]
 class ValidatorGenusConfiguredNOServiceTraits extends TripalCultivateValidatorBase {
 
   use GenusConfigured;

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/FakeValidators/ValidatorProject.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/FakeValidators/ValidatorProject.php
@@ -4,18 +4,19 @@ namespace Drupal\Tests\trpcultivate_phenotypes\Kernel\Validators\FakeValidators;
 
 use Drupal\trpcultivate_phenotypes\TripalCultivateValidator\ValidatorTraits\Project;
 use Drupal\trpcultivate\TripalCultivateValidator\TripalCultivateValidatorBase;
+use Drupal\trpcultivate\TripalCultivateValidator\Attribute\TripalCultivateValidator;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 
 /**
  * Fake Validator that does not implement any of its own methods.
  *
  * Used to test the Project trait.
- *
- * @TripalCultivateValidator(
- *   id = "validator_requiring_project",
- *   validator_name = @Translation("Validator Using Project Trait"),
- *   input_types = {"metadata"}
- * )
  */
+#[TripalCultivateValidator(
+   id: 'validator_requiring_project',
+   validator_name: new TranslatableMarkup('Validator Using Project Trait'),
+   input_types: ['metadata']
+ )]
 class ValidatorProject extends TripalCultivateValidatorBase {
 
   use Project;

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/FakeValidators/ValidatorProject.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/FakeValidators/ValidatorProject.php
@@ -11,6 +11,12 @@ use Drupal\Core\StringTranslation\TranslatableMarkup;
  * Fake Validator that does not implement any of its own methods.
  *
  * Used to test the Project trait.
+ *
+ * @TripalCultivateValidator(
+ *   id = "validator_requiring_project",
+ *   validator_name = @Translation("Validator Using Project Trait"),
+ *   input_types = {"metadata"}
+ * )
  */
 #[TripalCultivateValidator(
    id: 'validator_requiring_project',

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/Traits/ValidatorTraitGenusConfiguredTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/Traits/ValidatorTraitGenusConfiguredTest.php
@@ -7,6 +7,7 @@ use Drupal\Tests\trpcultivate_phenotypes\Kernel\Validators\FakeValidators\Valida
 use Drupal\Tests\trpcultivate_phenotypes\Traits\PhenotypeImporterTestTrait;
 use Drupal\tripal\Services\TripalLogger;
 use Drupal\tripal_chado\Database\ChadoConnection;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests the GenusConfigured validator trait.

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/Traits/ValidatorTraitGenusConfiguredTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/Traits/ValidatorTraitGenusConfiguredTest.php
@@ -14,6 +14,8 @@ use Drupal\tripal_chado\Database\ChadoConnection;
  * @group trpcultivate_phenotypes
  * @group validator_traits
  */
+#[Group('trpcultivate_phenotypes')]
+#[Group('validator_traits')]
 class ValidatorTraitGenusConfiguredTest extends ChadoTestKernelBase {
 
   use PhenotypeImporterTestTrait;

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/Traits/ValidatorTraitProjectTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/Traits/ValidatorTraitProjectTest.php
@@ -6,6 +6,7 @@ use Drupal\Tests\tripal_chado\Kernel\ChadoTestKernelBase;
 use Drupal\Tests\trpcultivate_phenotypes\Kernel\Validators\FakeValidators\ValidatorProject;
 use Drupal\Tests\trpcultivate_phenotypes\Traits\PhenotypeImporterTestTrait;
 use Drupal\tripal\Services\TripalLogger;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests the Project validator trait.

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/Traits/ValidatorTraitProjectTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/Traits/ValidatorTraitProjectTest.php
@@ -13,6 +13,8 @@ use Drupal\tripal\Services\TripalLogger;
  * @group trpcultivate_phenotypes
  * @group validator_traits
  */
+#[Group('trpcultivate_phenotypes')]
+#[Group('validator_traits')]
 class ValidatorTraitProjectTest extends ChadoTestKernelBase {
 
   use PhenotypeImporterTestTrait;

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/Traits/ValidatorTraitsMissingDependenciesTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/Traits/ValidatorTraitsMissingDependenciesTest.php
@@ -11,6 +11,8 @@ use Drupal\Tests\trpcultivate_phenotypes\Traits\PhenotypeImporterTestTrait;
  * @group trpcultivate_phenotypes
  * @group validator_traits
  */
+#[Group('trpcultivate_phenotypes')]
+#[Group('validator_traits')]
 class ValidatorTraitsMissingDependenciesTest extends ChadoTestKernelBase {
 
   use PhenotypeImporterTestTrait;
@@ -120,6 +122,7 @@ class ValidatorTraitsMissingDependenciesTest extends ChadoTestKernelBase {
    *
    * @dataProvider provideBadlyConfiguredValidators
    */
+  #[DataProvider('provideBadlyConfiguredValidators')]
   public function testConfiguredGenusBadlyConfigured($case, $validator_defn, $expected_message) {
 
     // Create a fake plugin instance for testing.

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/Traits/ValidatorTraitsMissingDependenciesTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/Traits/ValidatorTraitsMissingDependenciesTest.php
@@ -4,6 +4,8 @@ namespace Drupal\Tests\trpcultivate_phenotypes\Kernel\Validators;
 
 use Drupal\Tests\tripal_chado\Kernel\ChadoTestKernelBase;
 use Drupal\Tests\trpcultivate_phenotypes\Traits\PhenotypeImporterTestTrait;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests the GenusConfigured validator trait.

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorBaseTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorBaseTest.php
@@ -5,6 +5,7 @@ namespace Drupal\Tests\trpcultivate_phenotypes\Kernel\Validators;
 use Drupal\Tests\tripal_chado\Kernel\ChadoTestKernelBase;
 use Drupal\Tests\trpcultivate_phenotypes\Kernel\Validators\FakeValidators\BasicallyBase;
 use Drupal\tripal_chado\Database\ChadoConnection;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests Tripal Cultivate Phenotypes Validator Base functions.

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorBaseTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorBaseTest.php
@@ -12,6 +12,8 @@ use Drupal\tripal_chado\Database\ChadoConnection;
  * @group trpcultivate_phenotypes
  * @group validators
  */
+#[Group('trpcultivate_phenotypes')]
+#[Group('validators')]
 class ValidatorBaseTest extends ChadoTestKernelBase {
 
   /**

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorDuplicateTraitsTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorDuplicateTraitsTest.php
@@ -7,6 +7,8 @@ use Drupal\Tests\trpcultivate_phenotypes\Traits\PhenotypeImporterTestTrait;
 use Drupal\tripal_chado\Database\ChadoConnection;
 use Drupal\trpcultivate_phenotypes\Service\TripalCultivatePhenotypesTraitsService;
 use Drupal\trpcultivate\TripalCultivateValidator\TripalCultivateValidatorManager;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests the Duplicate Traits validator.

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorDuplicateTraitsTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorDuplicateTraitsTest.php
@@ -18,6 +18,10 @@ use Drupal\trpcultivate\TripalCultivateValidator\TripalCultivateValidatorManager
  * @group row_validators
  * @group trait_importer_validators
  */
+#[Group('trpcultivate_phenotypes')]
+#[Group('validators')]
+#[Group('row_validators')]
+#[Group('trait_importer_validators')]
 class ValidatorDuplicateTraitsTest extends ChadoTestKernelBase {
 
   use PhenotypeImporterTestTrait;
@@ -184,6 +188,7 @@ class ValidatorDuplicateTraitsTest extends ChadoTestKernelBase {
    *
    * @dataProvider provideWrongIndexKeys
    */
+  #[DataProvider('provideWrongIndexKeys')]
   public function testIndexKeyExceptions(string $label, array $indices) {
 
     // Create a plugin instance for this validator.

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorGenusExistsTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorGenusExistsTest.php
@@ -7,6 +7,7 @@ use Drupal\Tests\tripal_chado\Kernel\ChadoTestKernelBase;
 use Drupal\Tests\trpcultivate_phenotypes\Traits\PhenotypeImporterTestTrait;
 use Drupal\trpcultivate\TripalCultivateValidator\TripalCultivateValidatorManager;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests Tripal Cultivate Phenotypes Genus Exists Validator Plugin.

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorGenusExistsTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorGenusExistsTest.php
@@ -6,6 +6,7 @@ use Drupal\Core\Form\FormState;
 use Drupal\Tests\tripal_chado\Kernel\ChadoTestKernelBase;
 use Drupal\Tests\trpcultivate_phenotypes\Traits\PhenotypeImporterTestTrait;
 use Drupal\trpcultivate\TripalCultivateValidator\TripalCultivateValidatorManager;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Tests Tripal Cultivate Phenotypes Genus Exists Validator Plugin.
@@ -13,6 +14,8 @@ use Drupal\trpcultivate\TripalCultivateValidator\TripalCultivateValidatorManager
  * @group trpcultivate_phenotypes
  * @group validators
  */
+#[Group('trpcultivate_phenotypes')]
+#[Group('validators')]
 class ValidatorGenusExistsTest extends ChadoTestKernelBase {
 
   use PhenotypeImporterTestTrait;
@@ -179,6 +182,7 @@ class ValidatorGenusExistsTest extends ChadoTestKernelBase {
    *
    * @dataProvider provideGenusTestFormValue
    */
+  #[DataProvider('provideGenusTestFormValue')]
   public function testGenusExistsInputValue($scenario, $form_values, $expected) {
 
     $exception_caught = FALSE;
@@ -275,6 +279,7 @@ class ValidatorGenusExistsTest extends ChadoTestKernelBase {
    *
    * @dataProvider provideTestGenusInput
    */
+  #[DataProvider('provideTestGenusInput')]
   public function testValidatorGenusExists($scenario, $genus_input, $expected) {
 
     $form_values = ['genus' => $this->test_genus[$genus_input]];

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorProjectGenusMatchProcessTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorProjectGenusMatchProcessTest.php
@@ -6,6 +6,8 @@ use Drupal\Core\Render\Renderer;
 use Drupal\Tests\tripal_chado\Kernel\ChadoTestKernelBase;
 use Drupal\tripal_chado\Database\ChadoConnection;
 use Drupal\trpcultivate\TripalCultivateValidator\TripalCultivateValidatorManager;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests any message processing methods for the ProjectGenusMatch validator.

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorProjectGenusMatchProcessTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorProjectGenusMatchProcessTest.php
@@ -13,6 +13,8 @@ use Drupal\trpcultivate\TripalCultivateValidator\TripalCultivateValidatorManager
  * @group trpcultivate_phenotypes
  * @group validators
  */
+#[Group('trpcultivate_phenotypes')]
+#[Group('validators')]
 class ValidatorProjectGenusMatchProcessTest extends ChadoTestKernelBase {
 
   /**
@@ -292,6 +294,7 @@ class ValidatorProjectGenusMatchProcessTest extends ChadoTestKernelBase {
    *
    * @dataProvider provideProjectGenusMatchFailedCases
    */
+  #[DataProvider('provideProjectGenusMatchFailedCases')]
   public function testProcessItemWithSimpleList(array $validation_result, array $tokens, array $expectations) {
 
     // Create a plugin instance for this validator.
@@ -407,6 +410,7 @@ class ValidatorProjectGenusMatchProcessTest extends ChadoTestKernelBase {
    *
    * @dataProvider provideExceptionCases
    */
+  #[DataProvider('provideExceptionCases')]
   public function testProcessItemWithSimpleListExceptions(array $validation_result, array $tokens, array $expectations) {
 
     // Create a plugin instance for this validator.

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorProjectGenusMatchTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorProjectGenusMatchTest.php
@@ -13,6 +13,8 @@ use Drupal\trpcultivate\TripalCultivateValidator\TripalCultivateValidatorManager
  * @group trpcultivate_phenotypes
  * @group validators
  */
+#[Group('trpcultivate_phenotypes')]
+#[Group('validators')]
 class ValidatorProjectGenusMatchTest extends ChadoTestKernelBase {
 
   use PhenotypeImporterTestTrait;
@@ -241,6 +243,7 @@ class ValidatorProjectGenusMatchTest extends ChadoTestKernelBase {
    *
    * @dataProvider provideProjectGenusTestFormValue
    */
+  #[DataProvider('provideProjectGenusTestFormValue')]
   public function testProjectGenusInputValue($scenario, $form_values, $expected) {
 
     $exception_caught = FALSE;
@@ -393,6 +396,7 @@ class ValidatorProjectGenusMatchTest extends ChadoTestKernelBase {
    *
    * @dataProvider provideTestProjectGenusInput
    */
+  #[DataProvider('provideTestProjectGenusInput')]
   public function testValidatorProjectGenusMatch($scenario, $project_genus_input, $expected) {
 
     $input_values = $this->test_project_genus[$project_genus_input];

--- a/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorProjectGenusMatchTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Validators/ValidatorProjectGenusMatchTest.php
@@ -6,6 +6,8 @@ use Drupal\Core\Form\FormState;
 use Drupal\Tests\tripal_chado\Kernel\ChadoTestKernelBase;
 use Drupal\Tests\trpcultivate_phenotypes\Traits\PhenotypeImporterTestTrait;
 use Drupal\trpcultivate\TripalCultivateValidator\TripalCultivateValidatorManager;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests Tripal Cultivate Phenotypes Project-Genus Match Validator Plugin.

--- a/trpcultivate_phenotypes/tests/src/Traits/PhenotypeImporterTestTraitTest.php
+++ b/trpcultivate_phenotypes/tests/src/Traits/PhenotypeImporterTestTraitTest.php
@@ -5,6 +5,7 @@ namespace Drupal\Tests\tripalcultivate_phenotypes\Traits;
 use Drupal\Tests\tripal_chado\Kernel\ChadoTestKernelBase;
 use Drupal\tripal_chado\Database\ChadoConnection;
 use Drupal\Tests\trpcultivate_phenotypes\Traits\PhenotypeImporterTestTrait;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test importer test trait.

--- a/trpcultivate_phenotypes/tests/src/Traits/PhenotypeImporterTestTraitTest.php
+++ b/trpcultivate_phenotypes/tests/src/Traits/PhenotypeImporterTestTraitTest.php
@@ -11,6 +11,7 @@ use Drupal\Tests\trpcultivate_phenotypes\Traits\PhenotypeImporterTestTrait;
  *
  * @group trpcultivate_phenotypes_test_trait
  */
+#[Group('trpcultivate_phenotypes_test_trait')]
 class PhenotypeImporterTestTraitTest extends ChadoTestKernelBase {
 
   use PhenotypeImporterTestTrait;

--- a/trpcultivate_phenotypes/tests/src/Unit/ConfigRRulesFormTest.php
+++ b/trpcultivate_phenotypes/tests/src/Unit/ConfigRRulesFormTest.php
@@ -10,6 +10,7 @@ use Drupal\Core\Form\FormState;
 use Drupal\Core\StringTranslation\TranslationInterface;
 use Drupal\Tests\UnitTestCase;
 use Drupal\trpcultivate_phenotypes\Form\TripalCultivatePhenotypesRSettingsForm;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Class definition ConfigRRulesFormTest.

--- a/trpcultivate_phenotypes/tests/src/Unit/ConfigRRulesFormTest.php
+++ b/trpcultivate_phenotypes/tests/src/Unit/ConfigRRulesFormTest.php
@@ -17,6 +17,7 @@ use Drupal\trpcultivate_phenotypes\Form\TripalCultivatePhenotypesRSettingsForm;
  * @coversDefaultClass Drupal\trpcultivate_phenotypes\Form\TripalCultivatePhenotypesRSettingsForm
  * @group trpcultivate_phenotypes
  */
+#[Group('trpcultivate_phenotypes')]
 class ConfigRRulesFormTest extends UnitTestCase {
   /**
    * An instance of the R rules configuration form.

--- a/trpcultivate_phenotypes/tests/src/Unit/ConfigWatermarkFormTest.php
+++ b/trpcultivate_phenotypes/tests/src/Unit/ConfigWatermarkFormTest.php
@@ -19,6 +19,7 @@ use Drupal\trpcultivate_phenotypes\Form\TripalCultivatePhenotypesWatermarkSettin
  * @coversDefaultClass Drupal\trpcultivate_phenotypes\Form\TripalCultivatePhenotypesWatermarkSettingsForm
  * @group trpcultivate_phenotypes
  */
+#[Group('trpcultivate_phenotypes')]
 class ConfigWatermarkFormTest extends UnitTestCase {
 
   /**

--- a/trpcultivate_phenotypes/tests/src/Unit/ConfigWatermarkFormTest.php
+++ b/trpcultivate_phenotypes/tests/src/Unit/ConfigWatermarkFormTest.php
@@ -12,6 +12,7 @@ use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\StringTranslation\TranslationInterface;
 use Drupal\Tests\UnitTestCase;
 use Drupal\trpcultivate_phenotypes\Form\TripalCultivatePhenotypesWatermarkSettingsForm;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Class definition ConfigWatermarkFormTest.


### PR DESCRIPTION
**Issue #182**

## Motivation

<!-- This can usually be copied from the issue. Please do not just say, go see issue but instead copy the relevant details here. -->
Drupal is migrating its plugin discovery mechanism from Annotations to PHP Attributes, particularly Drupal 10.2 and newer versions. This change is in alignment with Symfony and PHP 8 best practices. We are currently using Doctrine annotations (eg. @TripalCultivateValidator) for metadata declarations. These should be migrated to PHP 8 attributes to ensure forward compatibility.

## What does this PR do?
Update the following annotations to attributes:

- [x] TripalCultivateValidator
- [x] Group
- [x] Data Provider
- [x] TripalImporter

## Testing

### Automated Testing
There are no new automated testing for this PR; however, all the automated tests should pass with drupal 11.1.x.
