### PR TITLE
G0.197 - Replace the text value of Experiment Name with a link to content page

### DIFF
--- a/trpcultivate_phenotypes/src/ListBuilder/PhenodataBackupListBuilder.php
+++ b/trpcultivate_phenotypes/src/ListBuilder/PhenodataBackupListBuilder.php
@@ -14,6 +14,7 @@ use Drupal\Core\Form\FormInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Url;
+use Drupal\tripal\Services\TripalEntityLookup;
 use Drupal\tripal_chado\Controller\ChadoProjectAutocompleteController;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -44,6 +45,13 @@ final class PhenodataBackupListBuilder extends ConfigEntityListBuilder implement
   protected AccountInterface $user;
 
   /**
+   * Tripal Entity lookup.
+   *
+   * @var Drupal\tripal\Services\TripalEntityLookup
+   */
+  protected TripalEntityLookup $service_TripalEntityLookup;
+
+  /**
    * Configuration entity fields per permission.
    *
    * @var array
@@ -70,6 +78,8 @@ final class PhenodataBackupListBuilder extends ConfigEntityListBuilder implement
    *   The entity type manager.
    * @param \Drupal\Core\Session\AccountInterface $user
    *   Drupal users.
+   * @param \Drupal\tripal\Services\TripalEntityLookup $tripalentity_lookup
+   *   Tripal entity lookup service.
    */
   public function __construct(
     EntityTypeInterface $entity_type,
@@ -77,6 +87,7 @@ final class PhenodataBackupListBuilder extends ConfigEntityListBuilder implement
     FormBuilderInterface $form_builder,
     EntityTypeManagerInterface $entity_type_manager,
     AccountInterface $user,
+    TripalEntityLookup $tripalentity_lookup,
   ) {
     parent::__construct($entity_type, $storage);
 
@@ -114,6 +125,8 @@ final class PhenodataBackupListBuilder extends ConfigEntityListBuilder implement
 
     $entity_ids = $query->execute();
     $this->user_backup = $this->storage->loadMultiple($entity_ids);
+
+    $this->service_TripalEntityLookup = $tripalentity_lookup;
   }
 
   /**
@@ -127,6 +140,7 @@ final class PhenodataBackupListBuilder extends ConfigEntityListBuilder implement
       $container->get('form_builder'),
       $container->get('entity_type.manager'),
       $container->get('current_user'),
+      $container->get('tripal.tripal_entity.lookup'),
     );
   }
 
@@ -148,7 +162,14 @@ final class PhenodataBackupListBuilder extends ConfigEntityListBuilder implement
     $key = 'project_id';
     $project_id = (int) $entity->get($key);
     $project_name = ChadoProjectAutocompleteController::getProjectName($project_id);
-    $values[$key]['data'] = $project_name;
+
+    $entity_id = $this->service_TripalEntityLookup
+      ->getEntityId($project_id, 'SIO', '000994', 'project');
+
+    $values[$key]['data'] = $this->service_TripalEntityLookup
+      ->getRenderableItem($project_name, $entity_id) + [
+        '#attributes' => ['target' => '_blank'],
+      ];
 
     $key = 'comments';
     $comments = $entity->get($key);


### PR DESCRIPTION
**Issue https://github.com/TripalCultivate/TripalCultivate-Phenotypes/issues/154**

## Motivation

In phenotypes backup data list-builder, the experiment name is rendered as plain text. This PR transforms this value into link render array that links to the Tripal entity page for the experiment.

<!-- This can usually be copied from the issue. Please do not just say, go see issue but instead copy the relevant details here. -->

## What does this PR do?
*Please describe each things this PR does. For example, a PR may 1) solve a specific bug, 2) create an automated test to ensure it doesn't return.*

1. Implement Tripal Entity Lookup service as described in the issue.

## Testing

### Manual Testing
*Describe in detail how someone should manually test this functionality.*
*Make sure to include whether they need to build a docker from scratch, create any records, etc.*

1. In a fully setup clone create a Research Experiment Tripal Content Type using this link - **my clone/bio_data/add/research_experiment** or /Content/Tripal Content/Add Tripal Content/Research Experiment.
2. Access **mysite/admin/structure/phenodata-backup**.
3. Upload a test backup file by clicking the the + Backup Phenotypic Data button.
<img width="251" height="77" alt="image" src="https://github.com/user-attachments/assets/2f9c9eaf-ef40-4946-aeec-aafad075f201" />

4.  Test the link to see if it will link to the Tripal Content Type Research Experiment page.
<img width="1742" height="444" alt="image" src="https://github.com/user-attachments/assets/9a4e8102-9af1-4353-bf4a-907b2f0b12e3" />

