### PR TITLE
Revise connection name

### DIFF
--- a/trpcultivate_phenotypes/src/Service/TripalCultivatePhenotypesTermsService.php
+++ b/trpcultivate_phenotypes/src/Service/TripalCultivatePhenotypesTermsService.php
@@ -146,8 +146,8 @@ class TripalCultivatePhenotypesTermsService {
 
     if ($terms) {
       if ($schema) {
-        $this->cvterm_buddy->setChadoSchema($schema);
-        $this->dbxref_buddy->setChadoSchema($schema);
+        $this->cvterm_buddy->setSchemaName($schema);
+        $this->dbxref_buddy->setSchemaName($schema);
       }
 
       // Install terms.

--- a/trpcultivate_phenotypes/src/Service/TripalCultivatePhenotypesTermsService.php
+++ b/trpcultivate_phenotypes/src/Service/TripalCultivatePhenotypesTermsService.php
@@ -146,8 +146,13 @@ class TripalCultivatePhenotypesTermsService {
 
     if ($terms) {
       if ($schema) {
-        $this->cvterm_buddy->connection->setSchemaName($schema);
-        $this->dbxref_buddy->connection->setSchemaName($schema);
+        // @todo We should be able to set the schema for a buddy! Either through
+        // something like $this->cvterm_buddy->setChadoSchema($schema_name) or
+        // when creating the buddy via the plugin manager? However, the buddies
+        // do not support this right now but instead only work on
+        // the main schema.
+        $this->cvterm_buddy->chado_connection->setSchemaName($schema);
+        $this->dbxref_buddy->chado_connection->setSchemaName($schema);
       }
 
       // Install terms.

--- a/trpcultivate_phenotypes/src/Service/TripalCultivatePhenotypesTermsService.php
+++ b/trpcultivate_phenotypes/src/Service/TripalCultivatePhenotypesTermsService.php
@@ -146,13 +146,8 @@ class TripalCultivatePhenotypesTermsService {
 
     if ($terms) {
       if ($schema) {
-        // @todo We should be able to set the schema for a buddy! Either through
-        // something like $this->cvterm_buddy->setChadoSchema($schema_name) or
-        // when creating the buddy via the plugin manager? However, the buddies
-        // do not support this right now but instead only work on
-        // the main schema.
-        $this->cvterm_buddy->chado_connection->setSchemaName($schema);
-        $this->dbxref_buddy->chado_connection->setSchemaName($schema);
+        $this->cvterm_buddy->setChadoSchema($schema);
+        $this->dbxref_buddy->setChadoSchema($schema);
       }
 
       // Install terms.

--- a/trpcultivate_phenotypes/src/Service/TripalCultivatePhenotypesTraitsService.php
+++ b/trpcultivate_phenotypes/src/Service/TripalCultivatePhenotypesTraitsService.php
@@ -217,8 +217,13 @@ class TripalCultivatePhenotypesTraitsService {
     $genus_config = $this->config;
 
     if ($schema) {
-      $this->cvterm_buddy->connection->setSchemaName($schema);
-      $this->dbxref_buddy->connection->setSchemaName($schema);
+      // @todo We should be able to set the schema for a buddy! Either through
+      // something like $this->cvterm_buddy->setChadoSchema($schema_name) or
+      // when creating the buddy via the plugin manager? However, the buddies
+      // do not support this right now but instead only work on
+      // the main schema.
+      $this->cvterm_buddy->chado_connection->setSchemaName($schema);
+      $this->dbxref_buddy->chado_connection->setSchemaName($schema);
     }
 
     if (!$genus_config) {

--- a/trpcultivate_phenotypes/src/Service/TripalCultivatePhenotypesTraitsService.php
+++ b/trpcultivate_phenotypes/src/Service/TripalCultivatePhenotypesTraitsService.php
@@ -217,8 +217,8 @@ class TripalCultivatePhenotypesTraitsService {
     $genus_config = $this->config;
 
     if ($schema) {
-      $this->cvterm_buddy->setChadoSchema($schema);
-      $this->dbxref_buddy->setChadoSchema($schema);
+      $this->cvterm_buddy->setSchemaName($schema);
+      $this->dbxref_buddy->setSchemaName($schema);
     }
 
     if (!$genus_config) {

--- a/trpcultivate_phenotypes/src/Service/TripalCultivatePhenotypesTraitsService.php
+++ b/trpcultivate_phenotypes/src/Service/TripalCultivatePhenotypesTraitsService.php
@@ -217,13 +217,8 @@ class TripalCultivatePhenotypesTraitsService {
     $genus_config = $this->config;
 
     if ($schema) {
-      // @todo We should be able to set the schema for a buddy! Either through
-      // something like $this->cvterm_buddy->setChadoSchema($schema_name) or
-      // when creating the buddy via the plugin manager? However, the buddies
-      // do not support this right now but instead only work on
-      // the main schema.
-      $this->cvterm_buddy->chado_connection->setSchemaName($schema);
-      $this->dbxref_buddy->chado_connection->setSchemaName($schema);
+      $this->cvterm_buddy->setChadoSchema($schema);
+      $this->dbxref_buddy->setChadoSchema($schema);
     }
 
     if (!$genus_config) {


### PR DESCRIPTION
**Issue #201 **

## Motivation

<!-- This can usually be copied from the issue. Please do not just say, go see issue but instead copy the relevant details here. -->

This will bring the Terms and Traits services connection reference to the latest connection name - chado_connection as described in the issue.

## What does this PR do?
*Please describe each things this PR does. For example, a PR may 1) solve a specific bug, 2) create an automated test to ensure it doesn't return.*

1. Rename connection to chado_connection in terms service loadTerms() method.

## Testing

### Manual Testing
*Describe in detail how someone should manually test this functionality.*
*Make sure to include whether they need to build a docker from scratch, create any records, etc.*

1. Switch to barnch  gBuG.201-BrokenTermService.
2. Build a docker clone and verify that the build was successful and no error similar to the screenshots below:

<img width="643" height="360" alt="image" src="https://github.com/user-attachments/assets/d6f92834-a271-4fb0-b8a0-3b98b7518856" />

<img width="1094" height="1256" alt="image" src="https://github.com/user-attachments/assets/7be55e9c-ed3f-43d5-b2a6-fbee423dfb6c" />

