### PR TITLE
G0.192  - Refine the layout of trait summary table

### DIFF
--- a/trpcultivate_phenotypes/components/trait_combo/trait_combo.component.yml
+++ b/trpcultivate_phenotypes/components/trait_combo/trait_combo.component.yml
@@ -2,8 +2,6 @@ name: trait_combo
 props:
   type: object
   required:
-    - name
-    - definition
     - method_unit_combo
     - multiselect_method
   properties:

--- a/trpcultivate_phenotypes/components/trait_combo/trait_combo.css
+++ b/trpcultivate_phenotypes/components/trait_combo/trait_combo.css
@@ -27,3 +27,11 @@
   color: #CCCCCC;
   font-style: italic;
 }
+
+#tcp-phenocombo-summary-table tbody tr:hover {
+  background: none !important;
+}
+
+.tcp-exp-phenocombo tr {
+  border-bottom: none;
+}

--- a/trpcultivate_phenotypes/components/trait_combo/trait_combo.twig
+++ b/trpcultivate_phenotypes/components/trait_combo/trait_combo.twig
@@ -1,63 +1,54 @@
 <div {{ attributes.addClass('tcp-trait-combo') }}>
 
-	{% if (name is defined) %}
-		<def>
-			{{ name }}
+  {% if (name is defined) %} <def>{{ name }}</def> {% endif %}
+  {% if (definition is defined) %} <em>{{ definition }}</em> {% endif %}
 
-			{% if status %}
-				{% set status_attributes = {
-					'required': {
-						'class': 'fa-star',
-						'title': 'Required: this measurement is required to answer the questions in this experiment and must be included when uploading phenotypic data for this experiment.'
-					},
-					'archived': {
-						'class': 'fa-box-archive',
-						'title': 'Archived: this describes measurements previously collected for this experiment but which are no longer recommended or have been updated.'
-					},
-					'shared': {
-						'class': 'fa-hand-holding-heart',
-						'title': 'Shared: final datasets including this measurement have been imported using the "Tripal Cultivate: Open-Science Phenotypic Data" importer.'
-					},
-					'collected': {
-						'class': 'fa-ruler',
-						'title': 'Collected: data has been imported using the "Tripal Cultivate: Collected Phenotypic Data" importer.'
-					}
-				} %}
+  {{ multiselect_method ? '<div>' : '' }}
+  {% for i, method in method_unit_combo %}
+    <section>
+      <def>
+        {{ method['method_shortname'] }}: ({{ method['unit'] }})
+        <small>{{ method['type'] }}</small>
+        {% if status %}
+          {% set status_attributes = {
+            'required': {
+              'class': 'fa-star',
+              'title': 'Required: this measurement is required to answer the questions in this experiment and must be included when uploading phenotypic data for this experiment.'
+            },
+            'archived': {
+              'class': 'fa-box-archive',
+              'title': 'Archived: this describes measurements previously collected for this experiment but which are no longer recommended or have been updated.'
+            },
+            'shared': {
+              'class': 'fa-hand-holding-heart',
+              'title': 'Shared: final datasets including this measurement have been imported using the "Tripal Cultivate: Open-Science Phenotypic Data" importer.'
+            },
+            'collected': {
+              'class': 'fa-ruler',
+              'title': 'Collected: data has been imported using the "Tripal Cultivate: Collected Phenotypic Data" importer.'
+            }
+          } %}
 
-				{% for status_item, status_value in status %}
-					{% if status_value == 1 %}
-						{%
-							set attributes = create_attribute(status_attributes[status_item])
-								.addClass(['fa-solid', 'tcp-pheno-' ~ status_item])
-						%}
-						<i {{ attributes }}></i>
-					{% endif %}
-				{% endfor %}
-			{% endif %}
-		</def>
-	{% endif %}
+          {% for status_item, status_value in status %}
+            {% if status_value == 1 %}
+              {%
+                set attributes = create_attribute(status_attributes[status_item])
+                  .addClass(['fa-solid', 'tcp-pheno-' ~ status_item])
+              %}
 
-	{% if (definition is defined) %}
-	  <em>{{ definition }}</em>
-	{% endif %}
+              <i {{ attributes }}></i>
+            {% endif %}
+          {% endfor %}
+        {% endif %}
+      </def>
 
-    {{ multiselect_method ? '<div>' : '' }}
-		  {% for i, method in method_unit_combo %}
+      {{ method['collection_method'] }}
 
-				<section>
-					<def>{{ method['method_shortname'] }}: ({{ method['unit'] }})
-						<small>{{ method['type'] }}</small>
-					</def>
-					{{ method['collection_method'] }}
-
-					{% if multiselect_method %}
-						<br />
-
-					  {{ content['combo_' ~ trait_id ~ '_' ~ method['method_id']] }}
-					{% endif %}
-				</section>
-
-		  {% endfor %}
-    {{ multiselect_method ? '</div>' : '' }}
+      {% if multiselect_method %}
+        <br /> {{ content['combo_' ~ trait_id ~ '_' ~ method['method_id']] }}
+      {% endif %}
+    </section>
+  {% endfor %}
+  {{ multiselect_method ? '</div>' : '' }}
 
 </div>

--- a/trpcultivate_phenotypes/components/trait_combo/trait_combo.twig
+++ b/trpcultivate_phenotypes/components/trait_combo/trait_combo.twig
@@ -1,41 +1,45 @@
 <div {{ attributes.addClass('tcp-trait-combo') }}>
 
-	<def>
-		{{ name }}
+	{% if (name is defined) %}
+		<def>
+			{{ name }}
 
-    {% if status %}
-		  {% set status_attributes = {
-				'required': {
-					'class': 'fa-star',
-					'title': 'Required: this measurement is required to answer the questions in this experiment and must be included when uploading phenotypic data for this experiment.'
-				},
-				'archived': {
-					'class': 'fa-box-archive',
-					'title': 'Archived: this describes measurements previously collected for this experiment but which are no longer recommended or have been updated.'
-				},
-				'shared': {
-					'class': 'fa-hand-holding-heart',
-					'title': 'Shared: final datasets including this measurement have been imported using the "Tripal Cultivate: Open-Science Phenotypic Data" importer.'
-				},
-				'collected': {
-					'class': 'fa-ruler',
-					'title': 'Collected: data has been imported using the "Tripal Cultivate: Collected Phenotypic Data" importer.'
-				}
-			} %}
+			{% if status %}
+				{% set status_attributes = {
+					'required': {
+						'class': 'fa-star',
+						'title': 'Required: this measurement is required to answer the questions in this experiment and must be included when uploading phenotypic data for this experiment.'
+					},
+					'archived': {
+						'class': 'fa-box-archive',
+						'title': 'Archived: this describes measurements previously collected for this experiment but which are no longer recommended or have been updated.'
+					},
+					'shared': {
+						'class': 'fa-hand-holding-heart',
+						'title': 'Shared: final datasets including this measurement have been imported using the "Tripal Cultivate: Open-Science Phenotypic Data" importer.'
+					},
+					'collected': {
+						'class': 'fa-ruler',
+						'title': 'Collected: data has been imported using the "Tripal Cultivate: Collected Phenotypic Data" importer.'
+					}
+				} %}
 
-      {% for status_item, status_value in status %}
-        {% if status_value == 1 %}
-				  {%
-					  set attributes = create_attribute(status_attributes[status_item])
-	            .addClass(['fa-solid', 'tcp-pheno-' ~ status_item])
-					%}
-					<i {{ attributes }}></i>
-        {% endif %}
-   		{% endfor %}
-    {% endif %}
-	</def>
+				{% for status_item, status_value in status %}
+					{% if status_value == 1 %}
+						{%
+							set attributes = create_attribute(status_attributes[status_item])
+								.addClass(['fa-solid', 'tcp-pheno-' ~ status_item])
+						%}
+						<i {{ attributes }}></i>
+					{% endif %}
+				{% endfor %}
+			{% endif %}
+		</def>
+	{% endif %}
 
-	<em>{{ definition }}</em>
+	{% if (definition is defined) %}
+	  <em>{{ definition }}</em>
+	{% endif %}
 
     {{ multiselect_method ? '<div>' : '' }}
 		  {% for i, method in method_unit_combo %}

--- a/trpcultivate_phenotypes/src/Form/PhenoExperimentConfigurationForm.php
+++ b/trpcultivate_phenotypes/src/Form/PhenoExperimentConfigurationForm.php
@@ -282,7 +282,7 @@ class PhenoExperimentConfigurationForm extends FormBase {
         [
           '#prefix' => 'No traits found ' . ($genus ? 'for genus "<i>' . $genus . '</i>" ' : '') . 'for this research experiment: ',
           '#attributes' => [
-            'style' => 'color: blue; font-weight: 200; text-decoration: underline;',
+            'style' => 'font-weight: 200; text-decoration: underline;',
           ],
         ]
       ),

--- a/trpcultivate_phenotypes/src/Form/PhenoExperimentConfigurationForm.php
+++ b/trpcultivate_phenotypes/src/Form/PhenoExperimentConfigurationForm.php
@@ -265,40 +265,11 @@ class PhenoExperimentConfigurationForm extends FormBase {
     $this->messenger()
       ->addWarning('A Trait cannot be modified or removed from an Experiment once phenotypic data has been associated with it.');
 
-    $table_header = [
-      'label' => [
-        'data' => '',
-        'style' => 'width: 15%',
-      ],
-      'combo' => [
-        'data' => 'Trait Method Unit',
-        'style' => 'width: 84%',
-      ],
-      'operations' => [
-        'data' => 'Operations',
-        'style' => 'width: 1%;',
-      ],
-    ];
-
-    $table_header['label']['data'] = [
-      '#type' => 'html_tag',
-      '#tag' => 'i',
-      '#prefix' => 'Label',
-      '#value' => '',
-      '#attributes' => [
-        'class' => [
-          'fa-solid',
-          'fa-circle-question',
-        ],
-        'title' => 'A short experiment-specific label referring to this Trait-Method-Unit combination. This will be used in the data collection file and must be unique within this experiment',
-      ],
-    ];
-
     $summary_table_name = 'experiment_traits_summary_table';
 
     $form[$summary_table_name] = [
       '#type' => 'table',
-      '#header' => $table_header,
+      '#header' => [],
       '#rows' => [],
       '#sticky' => FALSE,
       '#allowed_tags' => ['a', 'br', 'em', 'def', 'small', 'span', 'section'],
@@ -341,32 +312,41 @@ class PhenoExperimentConfigurationForm extends FormBase {
     $query->join('1:cvterm', 't', 'tc.attr_id = t.cvterm_id');
     $query->join('1:cv', 'v', 't.cv_id = v.cv_id');
 
-    $query
-      ->fields('tc', [
-        'combo_id',
-        'attr_id',
-        'observable_id',
-        'unit_id',
-        'label',
-        'is_archived',
-        'is_required',
-        'was_shared',
-        'was_collected',
-      ])
-      ->fields('t', ['cv_id', 'name'])
-      ->condition('tc.project_id', $experiment_id, '=')
-      ->orderBy('v.name', 'ASC')
-      ->orderBy('t.name', 'ASC')
-      ->orderBy('label', 'ASC');
+    $query->fields('t', ['name', 'definition']);
+    $query->fields('v', ['cv_id']);
+
+    $query->addExpression(
+      "JSON_AGG(JSON_BUILD_OBJECT(
+        'combo_id', tc.combo_id,
+        'attr_id', tc.attr_id,
+        'observable_id', tc.observable_id,
+        'unit_id', tc.unit_id,
+        'label', tc.label,
+        'is_archived', tc.is_archived,
+        'is_required', tc.is_required,
+        'was_shared', tc.was_shared,
+        'was_collected', tc.was_collected
+      ) ORDER BY tc.label ASC)", 'combos'
+    );
 
     if ($genus) {
       $query->condition('t.cv_id', array_search($genus, $genus_map), '=');
     }
 
+    $query
+      ->condition('tc.project_id', $experiment_id, '=')
+      ->orderBy('v.name', 'ASC')
+      ->orderBy('t.name', 'ASC')
+      ->groupBy('t.name')
+      ->groupBy('t.definition')
+      ->groupBy('v.cv_id')
+      ->groupBy('v.name');
+
     $query_result = $query->execute();
 
     $set_genus = [];
     $a_group = FALSE;
+    $trait_combo = 'trait_combo';
 
     foreach ($query_result as $i => $trait_row) {
       $first_row = FALSE;
@@ -380,101 +360,117 @@ class PhenoExperimentConfigurationForm extends FormBase {
         $first_row = TRUE;
       }
 
-      ['trait' => $trait, 'method' => $method, 'unit' => $unit] = $this->service_PhenoTraits->getTraitMethodUnitCombo(
-        $trait_row->attr_id,
-        $trait_row->observable_id,
-        $trait_row->unit_id,
-      );
-
-      // Table column: combo label.
-      $form[$summary_table_name][$i]['label'] = [
-        '#type' => 'html_tag',
-        '#tag' => 'span',
-        '#value' => ($genus) ? $trait_row->label : $trait_row->label . '<br /><span class="marker" title="Genus">' . $trait_genus . '</span>',
-        '#attributes' => [
-          'class' => [
-            'views-field',
-          ],
+      $form[$summary_table_name][$i][$trait_combo] = [
+        '#type' => 'table',
+        '#headers' => [
+          'label' => '',
+          'combo' => '',
+          'operations' => '',
         ],
+        '#rows' => [],
+        '#prefix' => $trait_row->name . '<br /><i>' . $trait_row->definition . '</i>',
       ];
 
-      // Table column: trait combo.
-      $form[$summary_table_name][$i]['trait_combo'] = [
-        '#type' => 'component',
-        '#component' => 'trpcultivate_phenotypes:trait_combo',
-        '#slots' => [],
-        '#props' => [
-          'name' => $trait->name,
-          'definition' => $trait->definition,
-          'multiselect_method' => FALSE,
-          'method_unit_combo' => [
-            [
-              'method_shortname' => $method->name,
-              'unit' => $unit->name,
-              'type' => $this->service_PhenoTraits->getMethodUnitDataType($trait_row->unit_id),
-              'collection_method' => $method->definition,
+      if (!$trait_row->combos) {
+        continue;
+      }
+
+      foreach (json_decode($trait_row->combos, TRUE) as $j => $combo) {
+        $form[$summary_table_name][$i][$trait_combo][$j] = [
+          '#attributes' => [
+            'style' => 'border-bottom: none',
+          ],
+        ];
+
+        $form[$summary_table_name][$i][$trait_combo][$j]['label'] = [
+          '#type' => 'html_tag',
+          '#tag' => 'span',
+          '#value' => ($genus) ? $combo['label'] : $combo['label'] . '<br /><span class="marker" title="Genus">' . $trait_genus . '</span>',
+          '#attributes' => [
+            'style' => 'width: 15%;',
+            'class' => [
+              'views-field',
             ],
           ],
-          'status' => [
-            'archived' => $trait_row->is_archived,
-            'required' => $trait_row->is_required,
-            'shared' => $trait_row->was_shared,
-            'collected' => $trait_row->was_collected,
-          ],
-        ],
-      ];
+        ];
 
-      // Table column: trait combo operations.
-      $is_removable = ($trait_row->is_archived || $trait_row->was_shared || $trait_row->was_collected)
-        ? FALSE : TRUE;
+        ['trait' => $trait, 'method' => $method, 'unit' => $unit] = $this->service_PhenoTraits->getTraitMethodUnitCombo(
+          $combo['attr_id'],
+          $combo['observable_id'],
+          $combo['unit_id'],
+        );
 
-      $form[$summary_table_name][$i]['operations'] = [
-        '#type' => 'dropbutton',
-        '#dropbutton_type' => 'small',
-        '#links' => [
-          'remove' => [
-            'title' => 'Remove',
-            'url' => Url::fromRoute('<current>', [], [
-              'query' => [
-                'remove' => $trait_row->combo_id,
+        $form[$summary_table_name][$i][$trait_combo][$j]['combo'] = [
+          '#type' => 'component',
+          '#component' => 'trpcultivate_phenotypes:trait_combo',
+          '#slots' => [],
+          '#props' => [
+            'multiselect_method' => FALSE,
+            'method_unit_combo' => [
+              [
+                'method_shortname' => $method->name,
+                'unit' => $unit->name,
+                'type' => $this->service_PhenoTraits->getMethodUnitDataType($combo['unit_id']),
+                'collection_method' => $method->definition,
               ],
-              'attributes' => [
-                'onclick' => 'return ' . ($is_removable ? 'confirm("Are you sure you want to Remove trait?")' : 'false'),
-                'style' => 'pointer-events: ' . ($is_removable ? 'auto' : 'none') . '; opacity: ' . ($is_removable ? 1 : 0.3),
-              ],
-            ]),
+            ],
+            'status' => [
+              'archived' => $combo['is_archived'],
+              'required' => $combo['is_required'],
+              'shared' => $combo['was_shared'],
+              'collected' => $combo['was_collected'],
+            ],
           ],
-          'require' => [
-            'title' => 'Set ' . $status = ($trait_row->is_required ? 'Optional' : 'Require'),
-            'url' => Url::fromRoute('<current>', [], [
-              'query' => [
-                strtolower($status) => $trait_row->combo_id,
-              ],
-              'attributes' => [
-                'onclick' => 'return confirm("Are you sure you want to set status to ' . ucfirst($status) . '?")',
-              ],
-            ]),
+          '#attributes' => [
+            'style' => 'width: 84%;',
           ],
-          'archive' => [
-            'title' => 'Set ' . $status = ($trait_row->is_archived ? 'Active' : 'Archive'),
-            'url' => Url::fromRoute('<current>', [], [
-              'query' => [
-                strtolower($status) => $trait_row->combo_id,
-              ],
-              'attributes' => [
-                'onclick' => 'return confirm("Are you sure you want to set status to ' . ucfirst($status) . '?")',
-              ],
-            ]),
-          ],
-        ],
-      ];
+        ];
 
-      // Helps group traits by genus - the first row of each genus has thicker
-      // top border style rule.
-      $form[$summary_table_name][$i]['#attributes'] = [
-        'style' => 'border-top: ' . (($first_row && $i > 0) ? '8px solid #DADADA;' : 'inherit;') ,
-        'valign' => 'top',
-      ];
+        // Table column: trait combo operations.
+        $is_removable = ($combo['is_archived'] || $combo['was_shared'] || $combo['was_collected'])
+          ? FALSE : TRUE;
+
+        $form[$summary_table_name][$i][$trait_combo][$j]['operations'] = [
+          '#type' => 'dropbutton',
+          '#dropbutton_type' => 'small',
+          '#links' => [
+            'remove' => [
+              'title' => 'Remove',
+              'url' => Url::fromRoute('<current>', [], [
+                'query' => [
+                  'remove' => $combo['combo_id'],
+                ],
+                'attributes' => [
+                  'onclick' => 'return ' . ($is_removable ? 'confirm("Are you sure you want to Remove trait?")' : 'false'),
+                  'style' => 'pointer-events: ' . ($is_removable ? 'auto' : 'none') . '; opacity: ' . ($is_removable ? 1 : 0.3),
+                ],
+              ]),
+            ],
+            'require' => [
+              'title' => 'Set ' . $status = ($combo['is_required'] ? 'Optional' : 'Require'),
+              'url' => Url::fromRoute('<current>', [], [
+                'query' => [
+                  strtolower($status) => $combo['combo_id'],
+                ],
+                'attributes' => [
+                  'onclick' => 'return confirm("Are you sure you want to set status to ' . ucfirst($status) . '?")',
+                ],
+              ]),
+            ],
+            'archive' => [
+              'title' => 'Set ' . $status = ($combo['is_archived'] ? 'Active' : 'Archive'),
+              'url' => Url::fromRoute('<current>', [], [
+                'query' => [
+                  strtolower($status) => $combo['combo_id'],
+                ],
+                'attributes' => [
+                  'onclick' => 'return confirm("Are you sure you want to set status to ' . ucfirst($status) . '?")',
+                ],
+              ]),
+            ],
+          ],
+        ];
+      }
     }
 
     return $form;
@@ -604,3 +600,156 @@ class PhenoExperimentConfigurationForm extends FormBase {
   }
 
 }
+
+
+
+
+/*
+
+
+
+
+$first_row = FALSE;
+
+      $trait_genus = $genus_map[$trait_row->cv_id];
+      if (!in_array($trait_genus, $set_genus)) {
+        $this->service_PhenoTraits->setTraitGenus($trait_genus);
+        array_push($set_genus, $trait_genus);
+
+        $a_group = !$a_group;
+        $first_row = TRUE;
+      }
+
+      ['trait' => $trait, 'method' => $method, 'unit' => $unit] = $this->service_PhenoTraits->getTraitMethodUnitCombo(
+        $trait_row->attr_id,
+        $trait_row->observable_id,
+        $trait_row->unit_id,
+      );
+
+      // Table column: combo label.
+      $form[$summary_table_name][$i]['label'] = [
+        '#type' => 'html_tag',
+        '#tag' => 'span',
+        '#value' => ($genus) ? $trait_row->label : $trait_row->label . '<br /><span class="marker" title="Genus">' . $trait_genus . '</span>',
+        '#attributes' => [
+          'class' => [
+            'views-field',
+          ],
+        ],
+      ];
+
+      // Table column: trait combo.
+      $form[$summary_table_name][$i]['trait_combo'] = [
+        '#type' => 'component',
+        '#component' => 'trpcultivate_phenotypes:trait_combo',
+        '#slots' => [],
+        '#props' => [
+          'name' => $trait->name,
+          'definition' => $trait->definition,
+          'multiselect_method' => FALSE,
+          'method_unit_combo' => [
+            [
+              'method_shortname' => $method->name,
+              'unit' => $unit->name,
+              'type' => $this->service_PhenoTraits->getMethodUnitDataType($trait_row->unit_id),
+              'collection_method' => $method->definition,
+            ],
+          ],
+          'status' => [
+            'archived' => $trait_row->is_archived,
+            'required' => $trait_row->is_required,
+            'shared' => $trait_row->was_shared,
+            'collected' => $trait_row->was_collected,
+          ],
+        ],
+      ];
+
+      // Table column: trait combo operations.
+      $is_removable = ($trait_row->is_archived || $trait_row->was_shared || $trait_row->was_collected)
+        ? FALSE : TRUE;
+
+      $form[$summary_table_name][$i]['operations'] = [
+        '#type' => 'dropbutton',
+        '#dropbutton_type' => 'small',
+        '#links' => [
+          'remove' => [
+            'title' => 'Remove',
+            'url' => Url::fromRoute('<current>', [], [
+              'query' => [
+                'remove' => $trait_row->combo_id,
+              ],
+              'attributes' => [
+                'onclick' => 'return ' . ($is_removable ? 'confirm("Are you sure you want to Remove trait?")' : 'false'),
+                'style' => 'pointer-events: ' . ($is_removable ? 'auto' : 'none') . '; opacity: ' . ($is_removable ? 1 : 0.3),
+              ],
+            ]),
+          ],
+          'require' => [
+            'title' => 'Set ' . $status = ($trait_row->is_required ? 'Optional' : 'Require'),
+            'url' => Url::fromRoute('<current>', [], [
+              'query' => [
+                strtolower($status) => $trait_row->combo_id,
+              ],
+              'attributes' => [
+                'onclick' => 'return confirm("Are you sure you want to set status to ' . ucfirst($status) . '?")',
+              ],
+            ]),
+          ],
+          'archive' => [
+            'title' => 'Set ' . $status = ($trait_row->is_archived ? 'Active' : 'Archive'),
+            'url' => Url::fromRoute('<current>', [], [
+              'query' => [
+                strtolower($status) => $trait_row->combo_id,
+              ],
+              'attributes' => [
+                'onclick' => 'return confirm("Are you sure you want to set status to ' . ucfirst($status) . '?")',
+              ],
+            ]),
+          ],
+        ],
+      ];
+
+      // Helps group traits by genus - the first row of each genus has thicker
+      // top border style rule.
+      $form[$summary_table_name][$i]['#attributes'] = [
+        'style' => 'border-top: ' . (($first_row && $i > 0) ? '8px solid #DADADA;' : 'inherit;') ,
+        'valign' => 'top',
+      ];
+
+
+
+
+
+
+
+
+    $table_header = [
+      'label' => [
+        'data' => '',
+        'style' => 'width: 15%',
+      ],
+      'combo' => [
+        'data' => 'Trait Method Unit',
+        'style' => 'width: 84%',
+      ],
+      'operations' => [
+        'data' => 'Operations',
+        'style' => 'width: 1%;',
+      ],
+    ];
+
+    $table_header['label']['data'] = [
+      '#type' => 'html_tag',
+      '#tag' => 'i',
+      '#prefix' => 'Label',
+      '#value' => '',
+      '#attributes' => [
+        'class' => [
+          'fa-solid',
+          'fa-circle-question',
+        ],
+        'title' => 'A short experiment-specific label referring to this Trait-Method-Unit combination. This will be used in the data collection file and must be unique within this experiment',
+      ],
+    ];
+
+    */

--- a/trpcultivate_phenotypes/src/Form/PhenoExperimentConfigurationForm.php
+++ b/trpcultivate_phenotypes/src/Form/PhenoExperimentConfigurationForm.php
@@ -381,7 +381,6 @@ class PhenoExperimentConfigurationForm extends FormBase {
         ],
         '#rows' => [],
         '#attributes' => [
-          'valign' => 'top',
           'class' => [
             'tcp-exp-phenocombo',
           ],

--- a/trpcultivate_phenotypes/src/Form/PhenoExperimentConfigurationForm.php
+++ b/trpcultivate_phenotypes/src/Form/PhenoExperimentConfigurationForm.php
@@ -269,7 +269,7 @@ class PhenoExperimentConfigurationForm extends FormBase {
     // This is the parent table - a trait.
     $form[$summary_table_name] = [
       '#type' => 'table',
-      '#prefix' => 'Trait Method Unit<hr />',
+      '#prefix' => '<hr />',
       '#header' => [],
       '#rows' => [],
       '#sticky' => FALSE,

--- a/trpcultivate_phenotypes/src/Form/PhenoExperimentConfigurationForm.php
+++ b/trpcultivate_phenotypes/src/Form/PhenoExperimentConfigurationForm.php
@@ -192,7 +192,7 @@ class PhenoExperimentConfigurationForm extends FormBase {
         'class' => [
           'container-inline',
         ],
-        'style' => 'text-align: right; margin: 0 0 10px 0',
+        'style' => 'text-align: right;',
       ],
     ];
 
@@ -267,19 +267,24 @@ class PhenoExperimentConfigurationForm extends FormBase {
 
     $summary_table_name = 'experiment_traits_summary_table';
 
+    // This is the parent table - a trait.
     $form[$summary_table_name] = [
       '#type' => 'table',
+      '#prefix' => 'Trait Method Unit<hr />',
       '#header' => [],
       '#rows' => [],
       '#sticky' => FALSE,
       '#allowed_tags' => ['a', 'br', 'em', 'def', 'small', 'span', 'section'],
+      '#attributes' => [
+        'id' => 'tcp-phenocombo-summary-table',
+      ],
       '#empty' => array_merge(
         $form['config_toolbar']['add_trait'],
         [
+          '#prefix' => 'No traits found for this research experiment: ',
           '#attributes' => [
             'style' => 'color: blue; font-weight: 200; text-decoration: underline;',
           ],
-          '#prefix' => 'No traits found for this research experiment: ',
         ]
       ),
     ];
@@ -344,9 +349,9 @@ class PhenoExperimentConfigurationForm extends FormBase {
 
     $query_result = $query->execute();
 
+    $trait_combo = 'trait_combo';
     $set_genus = [];
     $a_group = FALSE;
-    $trait_combo = 'trait_combo';
 
     foreach ($query_result as $i => $trait_row) {
       $first_row = FALSE;
@@ -360,15 +365,27 @@ class PhenoExperimentConfigurationForm extends FormBase {
         $first_row = TRUE;
       }
 
+      // This is a child table - trait methods.
       $form[$summary_table_name][$i][$trait_combo] = [
         '#type' => 'table',
-        '#headers' => [
-          'label' => '',
-          'combo' => '',
-          'operations' => '',
+        '#prefix' => '<p class="tcp-trait-combo">' . $trait_row->name . '<br />
+           <em>' . $trait_row->definition . '</em></p>',
+        '#header' => [
+          'label' => [
+            'style' => 'width: 15%;',
+          ],
+          'combo' => [
+            'style' => 'width: 85%;',
+          ],
+          'operations' => [],
         ],
         '#rows' => [],
-        '#prefix' => $trait_row->name . '<br /><i>' . $trait_row->definition . '</i>',
+        '#attributes' => [
+          'valign' => 'top',
+          'class' => [
+            'tcp-exp-phenocombo',
+          ],
+        ],
       ];
 
       if (!$trait_row->combos) {
@@ -376,18 +393,14 @@ class PhenoExperimentConfigurationForm extends FormBase {
       }
 
       foreach (json_decode($trait_row->combos, TRUE) as $j => $combo) {
-        $form[$summary_table_name][$i][$trait_combo][$j] = [
-          '#attributes' => [
-            'style' => 'border-bottom: none',
-          ],
-        ];
-
+        // Table column: combo label.
         $form[$summary_table_name][$i][$trait_combo][$j]['label'] = [
           '#type' => 'html_tag',
           '#tag' => 'span',
-          '#value' => ($genus) ? $combo['label'] : $combo['label'] . '<br /><span class="marker" title="Genus">' . $trait_genus . '</span>',
+          '#value' => ($genus) ? $combo['label'] : $combo['label'] . '<br />
+            <span class="marker" title="Genus">' . $trait_genus . '</span>',
           '#attributes' => [
-            'style' => 'width: 15%;',
+            'title' => 'Trait Label - A short experiment-specific label referring to this Trait-Method-Unit combination. This will be used in the data collection file and must be unique within this experiment',
             'class' => [
               'views-field',
             ],
@@ -400,6 +413,7 @@ class PhenoExperimentConfigurationForm extends FormBase {
           $combo['unit_id'],
         );
 
+        // Table column: trait combo.
         $form[$summary_table_name][$i][$trait_combo][$j]['combo'] = [
           '#type' => 'component',
           '#component' => 'trpcultivate_phenotypes:trait_combo',
@@ -422,7 +436,7 @@ class PhenoExperimentConfigurationForm extends FormBase {
             ],
           ],
           '#attributes' => [
-            'style' => 'width: 84%;',
+            'title' => $trait->name,
           ],
         ];
 
@@ -432,7 +446,7 @@ class PhenoExperimentConfigurationForm extends FormBase {
 
         $form[$summary_table_name][$i][$trait_combo][$j]['operations'] = [
           '#type' => 'dropbutton',
-          '#dropbutton_type' => 'small',
+          '#dropbutton_type' => 'extrasmall',
           '#links' => [
             'remove' => [
               'title' => 'Remove',
@@ -470,7 +484,19 @@ class PhenoExperimentConfigurationForm extends FormBase {
             ],
           ],
         ];
+
+        // Helps group methods by trait name - a vertical border that stretches
+        // from first to the last method element.
+        $form[$summary_table_name][$i][$trait_combo][$j]['#attributes'] = [
+          'style' => 'border-left: 2px solid #DADADA',
+        ];
       }
+
+      // Helps group traits by genus - the first row of each genus has thicker
+      // top border style rule.
+      $form[$summary_table_name][$i]['#attributes'] = [
+        'style' => 'border-top: ' . (($first_row && $i > 0) ? '8px solid #DADADA;' : 'inherit;'),
+      ];
     }
 
     return $form;
@@ -600,156 +626,3 @@ class PhenoExperimentConfigurationForm extends FormBase {
   }
 
 }
-
-
-
-
-/*
-
-
-
-
-$first_row = FALSE;
-
-      $trait_genus = $genus_map[$trait_row->cv_id];
-      if (!in_array($trait_genus, $set_genus)) {
-        $this->service_PhenoTraits->setTraitGenus($trait_genus);
-        array_push($set_genus, $trait_genus);
-
-        $a_group = !$a_group;
-        $first_row = TRUE;
-      }
-
-      ['trait' => $trait, 'method' => $method, 'unit' => $unit] = $this->service_PhenoTraits->getTraitMethodUnitCombo(
-        $trait_row->attr_id,
-        $trait_row->observable_id,
-        $trait_row->unit_id,
-      );
-
-      // Table column: combo label.
-      $form[$summary_table_name][$i]['label'] = [
-        '#type' => 'html_tag',
-        '#tag' => 'span',
-        '#value' => ($genus) ? $trait_row->label : $trait_row->label . '<br /><span class="marker" title="Genus">' . $trait_genus . '</span>',
-        '#attributes' => [
-          'class' => [
-            'views-field',
-          ],
-        ],
-      ];
-
-      // Table column: trait combo.
-      $form[$summary_table_name][$i]['trait_combo'] = [
-        '#type' => 'component',
-        '#component' => 'trpcultivate_phenotypes:trait_combo',
-        '#slots' => [],
-        '#props' => [
-          'name' => $trait->name,
-          'definition' => $trait->definition,
-          'multiselect_method' => FALSE,
-          'method_unit_combo' => [
-            [
-              'method_shortname' => $method->name,
-              'unit' => $unit->name,
-              'type' => $this->service_PhenoTraits->getMethodUnitDataType($trait_row->unit_id),
-              'collection_method' => $method->definition,
-            ],
-          ],
-          'status' => [
-            'archived' => $trait_row->is_archived,
-            'required' => $trait_row->is_required,
-            'shared' => $trait_row->was_shared,
-            'collected' => $trait_row->was_collected,
-          ],
-        ],
-      ];
-
-      // Table column: trait combo operations.
-      $is_removable = ($trait_row->is_archived || $trait_row->was_shared || $trait_row->was_collected)
-        ? FALSE : TRUE;
-
-      $form[$summary_table_name][$i]['operations'] = [
-        '#type' => 'dropbutton',
-        '#dropbutton_type' => 'small',
-        '#links' => [
-          'remove' => [
-            'title' => 'Remove',
-            'url' => Url::fromRoute('<current>', [], [
-              'query' => [
-                'remove' => $trait_row->combo_id,
-              ],
-              'attributes' => [
-                'onclick' => 'return ' . ($is_removable ? 'confirm("Are you sure you want to Remove trait?")' : 'false'),
-                'style' => 'pointer-events: ' . ($is_removable ? 'auto' : 'none') . '; opacity: ' . ($is_removable ? 1 : 0.3),
-              ],
-            ]),
-          ],
-          'require' => [
-            'title' => 'Set ' . $status = ($trait_row->is_required ? 'Optional' : 'Require'),
-            'url' => Url::fromRoute('<current>', [], [
-              'query' => [
-                strtolower($status) => $trait_row->combo_id,
-              ],
-              'attributes' => [
-                'onclick' => 'return confirm("Are you sure you want to set status to ' . ucfirst($status) . '?")',
-              ],
-            ]),
-          ],
-          'archive' => [
-            'title' => 'Set ' . $status = ($trait_row->is_archived ? 'Active' : 'Archive'),
-            'url' => Url::fromRoute('<current>', [], [
-              'query' => [
-                strtolower($status) => $trait_row->combo_id,
-              ],
-              'attributes' => [
-                'onclick' => 'return confirm("Are you sure you want to set status to ' . ucfirst($status) . '?")',
-              ],
-            ]),
-          ],
-        ],
-      ];
-
-      // Helps group traits by genus - the first row of each genus has thicker
-      // top border style rule.
-      $form[$summary_table_name][$i]['#attributes'] = [
-        'style' => 'border-top: ' . (($first_row && $i > 0) ? '8px solid #DADADA;' : 'inherit;') ,
-        'valign' => 'top',
-      ];
-
-
-
-
-
-
-
-
-    $table_header = [
-      'label' => [
-        'data' => '',
-        'style' => 'width: 15%',
-      ],
-      'combo' => [
-        'data' => 'Trait Method Unit',
-        'style' => 'width: 84%',
-      ],
-      'operations' => [
-        'data' => 'Operations',
-        'style' => 'width: 1%;',
-      ],
-    ];
-
-    $table_header['label']['data'] = [
-      '#type' => 'html_tag',
-      '#tag' => 'i',
-      '#prefix' => 'Label',
-      '#value' => '',
-      '#attributes' => [
-        'class' => [
-          'fa-solid',
-          'fa-circle-question',
-        ],
-        'title' => 'A short experiment-specific label referring to this Trait-Method-Unit combination. This will be used in the data collection file and must be unique within this experiment',
-      ],
-    ];
-
-    */

--- a/trpcultivate_phenotypes/src/Form/PhenoExperimentConfigurationForm.php
+++ b/trpcultivate_phenotypes/src/Form/PhenoExperimentConfigurationForm.php
@@ -132,14 +132,19 @@ class PhenoExperimentConfigurationForm extends FormBase {
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
 
-    $tripal_entity = $this->getRouteMatch()->getParameter('tripal_entity');
+    if (!$tripal_entity = $this->getRouteMatch()->getParameter('tripal_entity')) {
+      $this->tripal_logger->error('The research experiment entity does not exist.');
+      throw new NotFoundHttpException();
+    }
 
-    // Route validates instance of tripal_entity and presence of exp_name field.
-    $experiment = $tripal_entity->get('exp_name')->getValue();
-    ['record_id' => $experiment_id, 'value' => $experiment_name] = $experiment[0];
+    $experiment_id = $tripal_entity->getBackendRecordId('chado_storage');
+    if ($experiment_id === NULL) {
+      $this->tripal_logger->error('The research experiment entity does not contain backend storage values or it cannot be found.');
+      throw new NotFoundHttpException();
+    }
 
     // Update the title to show which reseach experiment is being configured.
-    $form['#title'] = 'Configure Phenotypes for ' . $experiment_name;
+    $form['#title'] = 'Configure Phenotypes for ' . $tripal_entity->label();
 
     $form['tripal_entity_id'] = [
       '#type' => 'hidden',

--- a/trpcultivate_phenotypes/src/Form/PhenoExperimentConfigurationForm.php
+++ b/trpcultivate_phenotypes/src/Form/PhenoExperimentConfigurationForm.php
@@ -458,10 +458,10 @@ class PhenoExperimentConfigurationForm extends FormBase {
               ]),
             ],
             'require' => [
-              'title' => 'Set as ' . $status = ($trait_row->is_required ? 'Optional' : 'Required'),
+              'title' => 'Set as ' . $status = ($combo['is_required'] ? 'Optional' : 'Required'),
               'url' => Url::fromRoute('<current>', [], [
                 'query' => [
-                  ($trait_row->is_required ? 'optional' : 'require') => $combo['combo_id'],
+                  ($combo['is_required'] ? 'optional' : 'require') => $combo['combo_id'],
                 ],
                 'attributes' => [
                   'onclick' => 'return confirm("Are you sure you want to set status to ' . $status . '?")',
@@ -469,10 +469,10 @@ class PhenoExperimentConfigurationForm extends FormBase {
               ]),
             ],
             'archive' => [
-              'title' => $status = ($trait_row->is_archived ? 'Restore' : 'Archive') . ' Trait',
+              'title' => $status = ($combo['is_archived'] ? 'Restore' : 'Archive') . ' Trait',
               'url' => Url::fromRoute('<current>', [], [
                 'query' => [
-                  ($trait_row->is_archived ? 'active' : 'archive') => $combo['combo_id'],
+                  ($combo['is_archived'] ? 'active' : 'archive') => $combo['combo_id'],
                 ],
                 'attributes' => [
                   'onclick' => 'return confirm("Are you sure you want to ' . $status . '?")',

--- a/trpcultivate_phenotypes/src/Form/PhenoExperimentConfigurationForm.php
+++ b/trpcultivate_phenotypes/src/Form/PhenoExperimentConfigurationForm.php
@@ -312,7 +312,7 @@ class PhenoExperimentConfigurationForm extends FormBase {
     }
 
     // Prepare traits that matched the trait search key.
-    // Result is groupped by genus.
+    // Result is grouped by genus.
     $query = $this->chado_connection->select(self::PHENO_COMBO_TABLE, 'tc');
     $query->join('1:cvterm', 't', 'tc.attr_id = t.cvterm_id');
     $query->join('1:cv', 'v', 't.cv_id = v.cv_id');

--- a/trpcultivate_phenotypes/src/Form/PhenoExperimentTraitSelectorForm.php
+++ b/trpcultivate_phenotypes/src/Form/PhenoExperimentTraitSelectorForm.php
@@ -41,7 +41,7 @@ class PhenoExperimentTraitSelectorForm extends FormBase {
    *
    * @var \Drupal\tripal\Services\TripalLogger
    */
-  protected $tripal_logger;
+  protected TripalLogger $tripal_logger;
 
   /**
    * Genus-Ontotology service.

--- a/trpcultivate_phenotypes/src/Form/PhenoExperimentTraitSelectorForm.php
+++ b/trpcultivate_phenotypes/src/Form/PhenoExperimentTraitSelectorForm.php
@@ -138,14 +138,19 @@ class PhenoExperimentTraitSelectorForm extends FormBase {
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
 
-    $tripal_entity = $this->getRouteMatch()->getParameter('tripal_entity');
+    if (!$tripal_entity = $this->getRouteMatch()->getParameter('tripal_entity')) {
+      $this->tripal_logger->error('The research experiment entity does not exist.');
+      throw new NotFoundHttpException();
+    }
 
-    // Route validates instance of tripal_entity and presence of exp_name field.
-    $experiment = $tripal_entity->get('exp_name')->getValue();
-    ['record_id' => $experiment_id, 'value' => $experiment_name] = $experiment[0];
+    $experiment_id = $tripal_entity->getBackendRecordId('chado_storage');
+    if ($experiment_id === NULL) {
+      $this->tripal_logger->error('The research experiment entity does not contain backend storage values or it cannot be found.');
+      throw new NotFoundHttpException();
+    }
 
     // Update the title to show which research experiment is being configured.
-    $form['#title'] = 'Add traits to ' . $experiment_name;
+    $form['#title'] = 'Add traits to ' . $tripal_entity->label();
 
     $form['tripal_entity_id'] = [
       '#type' => 'hidden',
@@ -363,7 +368,7 @@ class PhenoExperimentTraitSelectorForm extends FormBase {
         'a_tip' => [
           '#type' => 'html_tag',
           '#tag' => 'p',
-          '#value' => 'Start typing part of the trait name into the search field to search for specific traits, or click "Show all Traits" button, to explore all available traits for the selected genus.',
+          '#value' => 'Start typing part of the trait name into the search field to search for specific traits, or click "' . $form[$form_dialog_wrapper]['search_toolbar']['show_all']['#value'] . '" button, to explore all available traits for the selected genus.',
         ],
       ],
       '#states' => [
@@ -458,7 +463,7 @@ class PhenoExperimentTraitSelectorForm extends FormBase {
         ->fields('tc', ['cvterm_id', 'name', 'definition'])
         ->condition('tc.cv_id', $genus_config, '=');
 
-      if ($trigger_el['#value'] != 'Show all Traits') {
+      if ($trigger_el['#value'] != $form[$form_dialog_wrapper]['search_toolbar']['show_all']['#value']) {
         $query
           ->condition('tc.name', trim($search_key) . '%', 'LIKE');
       }

--- a/trpcultivate_phenotypes/src/Service/TripalCultivatePhenotypesTermsService.php
+++ b/trpcultivate_phenotypes/src/Service/TripalCultivatePhenotypesTermsService.php
@@ -146,13 +146,8 @@ class TripalCultivatePhenotypesTermsService {
 
     if ($terms) {
       if ($schema) {
-<<<<<<< Updated upstream
         $this->cvterm_buddy->setSchemaName($schema);
         $this->dbxref_buddy->setSchemaName($schema);
-=======
-        // $this->cvterm_buddy->connection->setSchemaName($schema);
-        // $this->dbxref_buddy->connection->setSchemaName($schema);
->>>>>>> Stashed changes
       }
 
       // Install terms.

--- a/trpcultivate_phenotypes/src/Service/TripalCultivatePhenotypesTermsService.php
+++ b/trpcultivate_phenotypes/src/Service/TripalCultivatePhenotypesTermsService.php
@@ -146,8 +146,13 @@ class TripalCultivatePhenotypesTermsService {
 
     if ($terms) {
       if ($schema) {
+<<<<<<< Updated upstream
         $this->cvterm_buddy->setSchemaName($schema);
         $this->dbxref_buddy->setSchemaName($schema);
+=======
+        // $this->cvterm_buddy->connection->setSchemaName($schema);
+        // $this->dbxref_buddy->connection->setSchemaName($schema);
+>>>>>>> Stashed changes
       }
 
       // Install terms.

--- a/trpcultivate_phenotypes/tests/src/Kernel/Forms/PhenoExperimentConfigurationFormTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Forms/PhenoExperimentConfigurationFormTest.php
@@ -407,7 +407,7 @@ class PhenoExperimentConfigurationFormTest extends ChadoTestKernelBase {
     $this->assertStringContainsString(
       'Trait Method Unit',
       (string) $config_form[$summary_table_name]['#prefix'],
-      'The summary table title text does not matche epected title.',
+      'The summary table title text does not match the expected title.',
     );
 
     $db_trait_count = $this->container->get('database')

--- a/trpcultivate_phenotypes/tests/src/Kernel/Forms/PhenoExperimentConfigurationFormTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Forms/PhenoExperimentConfigurationFormTest.php
@@ -94,52 +94,7 @@ class PhenoExperimentConfigurationFormTest extends ChadoTestKernelBase {
    *
    * @var array
    */
-  private $trait_set = [
-    'Lens' => [
-      [
-        'Trait Name' => 'Days to Flower',
-        'Trait Description' => 'DTF trait description text',
-        'Method Short Name' => 'DTF',
-        'Collection Method' => 'DTF trait collection method text',
-        'Unit' => 'days',
-        'Type' => 'Quantitative',
-      ],
-      [
-        'Trait Name' => 'Days to Flower',
-        'Trait Description' => 'DTF trait description text',
-        'Method Short Name' => 'DTF-2',
-        'Collection Method' => 'DTF-2 trait collection method text',
-        'Unit' => 'days',
-        'Type' => 'Quantitative',
-      ],
-      [
-        'Trait Name' => 'Plant Height',
-        'Trait Description' => 'PH trait description text',
-        'Method Short Name' => 'PHT',
-        'Collection Method' => 'PH trait collection method text',
-        'Unit' => 'cm',
-        'Type' => 'Quantitative',
-      ],
-      [
-        'Trait Name' => 'Is Dead',
-        'Trait Description' => 'ID trait description text',
-        'Method Short Name' => 'IS_D',
-        'Collection Method' => 'ID trait collection method text',
-        'Unit' => 'text',
-        'Type' => 'Qualitative',
-      ],
-    ],
-    'Triticum' => [
-      [
-        'Trait Name' => 'Green Cotyledon Colour',
-        'Trait Description' => 'GCC trait description text',
-        'Method Short Name' => 'GCC',
-        'Collection Method' => 'GCC trait collection method text',
-        'Unit' => 'colour',
-        'Type' => 'Qualitative',
-      ],
-    ],
-  ];
+  private $trait_set = [];
 
   /**
    * {@inheritdoc}
@@ -170,6 +125,60 @@ class PhenoExperimentConfigurationFormTest extends ChadoTestKernelBase {
     $config_terms = $this->setTermConfig();
 
     // Create test records.
+    $trait_keys = [
+      'Trait Name',
+      'Trait Description',
+      'Method Short Name',
+      'Collection Method',
+      'Unit',
+      'Type',
+    ];
+
+    $trait_values = [
+      'Lens' => [
+        [
+          'Days to Flower',
+          'DTF trait description text',
+          'DTF',
+          'DTF trait collection method text',
+          'days',
+          'Quantitative',
+        ],
+        [
+          'Plant Height',
+          'PH trait description text',
+          'PHT',
+          'PH trait collection method text',
+          'cm',
+          'Quantitative',
+        ],
+        [
+          'Is Dead',
+          'ID trait description text',
+          'IS_D',
+          'ID trait collection method text',
+          'text',
+          'Qualitative',
+        ],
+      ],
+      'Triticum' => [
+        [
+          'Green Cotyledon Colour',
+          'GCC trait description text',
+          'GCC',
+          'GCC trait collection method text',
+          'colour',
+          'Qualitative',
+        ],
+      ],
+    ];
+
+    foreach ($trait_values as $trait_genus => $values) {
+      foreach ($values as $value) {
+        $this->trait_set[$trait_genus][] = array_combine($trait_keys, $value);
+      }
+    }
+
     $good_research = 'A Good Research Experiment';
     $experiments = [
       $good_research => [

--- a/trpcultivate_phenotypes/tests/src/Kernel/Forms/PhenoExperimentConfigurationFormTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Forms/PhenoExperimentConfigurationFormTest.php
@@ -404,12 +404,6 @@ class PhenoExperimentConfigurationFormTest extends ChadoTestKernelBase {
       'The render array is expected to have a type table.'
     );
 
-    $this->assertStringContainsString(
-      'Trait Method Unit',
-      (string) $config_form[$summary_table_name]['#prefix'],
-      'The summary table title text does not match the expected title.',
-    );
-
     $db_trait_count = $this->container->get('database')
       ->select(self::PHENO_COMBO_TABLE, 'c')
       ->fields('c', ['attr_id'])

--- a/trpcultivate_phenotypes/tests/src/Kernel/Forms/PhenoExperimentConfigurationFormTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Forms/PhenoExperimentConfigurationFormTest.php
@@ -438,6 +438,175 @@ class PhenoExperimentConfigurationFormTest extends ChadoTestKernelBase {
       count($table_items),
       'The table render array #rows property key does not contain the expected number of traits.'
     );
+
+    // Test the summary table rendered markup.
+    $render_config_form = $this->container->get('renderer')
+      ->renderRoot($config_form);
+
+
+    $genus_ontology_service = $this->container->get('trpcultivate_phenotypes.genus_ontology');
+
+    $genus_map = [];
+    foreach (array_keys($this->trait_set) as $genus) {
+      $cv_id = $genus_ontology_service->getGenusOntologyConfigValues($genus)['trait'];
+      $genus_map[$cv_id] = $genus;
+    }
+
+    // Using the same query setup as in the frontend, test that the expected row
+    // is at the same table item row number in the markup.
+    $query = $this->chado_connection->select(self::PHENO_COMBO_TABLE, 'tc');
+    $query->join('1:cvterm', 't', 'tc.attr_id = t.cvterm_id');
+    $query->join('1:cv', 'v', 't.cv_id = v.cv_id');
+
+    $query->fields('t', ['name', 'definition']);
+    $query->fields('v', ['cv_id']);
+
+    $query->addExpression(
+      "JSON_AGG(JSON_BUILD_OBJECT(
+        'combo_id', tc.combo_id,
+        'attr_id', tc.attr_id,
+        'observable_id', tc.observable_id,
+        'unit_id', tc.unit_id,
+        'label', tc.label,
+        'is_archived', tc.is_archived,
+        'is_required', tc.is_required,
+        'was_shared', tc.was_shared,
+        'was_collected', tc.was_collected
+      ) ORDER BY tc.label ASC)", 'combos'
+    );
+
+    $query
+      ->condition('tc.project_id', $experiment_id, '=')
+      ->orderBy('v.name', 'ASC')
+      ->orderBy('t.name', 'ASC')
+      ->groupBy('t.name')
+      ->groupBy('t.definition')
+      ->groupBy('v.cv_id')
+      ->groupBy('v.name');
+
+    $query_result = $query->execute();
+
+    $this->setRawContent($render_config_form);
+    $table_rows = $this->cssSelect('table#tcp-phenocombo-summary-table tbody tr');
+
+    $status_class = [
+      'tcp-pheno-archived',
+      'tcp-pheno-required',
+      'tcp-pheno-shared',
+      'tcp-pheno-collected',
+    ];
+
+    $trait_service = $this->container->get('trpcultivate_phenotypes.traits');
+
+    $genus_set = [];
+    $row_i = 0;
+
+    foreach ($query_result as $i => $trait_row) {
+      $genus = $genus_map[$trait_row->cv_id];
+      if (!in_array($genus, $genus_set)) {
+        $trait_service->setTraitGenus($genus);
+        array_push($genus_set, $genus);
+      }
+
+      $current_trait_row = $this->cssSelect('td p', $table_rows[$i])[$i]
+        ->asXML();
+
+      // The trait name and definition.
+      $this->assertStringContainsString(
+        $trait_row->name,
+        $current_trait_row,
+        'The trait name ' . $trait_row->name . ' is expected in table row #' . $i
+      );
+
+      $this->assertStringContainsString(
+        $trait_row->definition,
+        $current_trait_row,
+        'The trait definition ' . $trait_row->definition . ' is expected in table row #' . $i
+      );
+
+      // Trait methods table.
+      $current_method_row = $this->cssSelect('table.tcp-exp-phenocombo tbody tr', $table_rows[$i]);
+
+      foreach (json_decode($trait_row->combos, TRUE) as $combo) {
+        $method_markup = $current_method_row[$row_i]->asXML();
+
+        $this->assertStringContainsString(
+          $combo['label'],
+          $method_markup,
+          'The trait combo label ' . $combo['label'] . ' is expected in table row #' . $i
+        );
+
+        ['trait' => $trait, 'method' => $method, 'unit' => $unit] = $trait_service->getTraitMethodUnitCombo(
+          $combo['attr_id'],
+          $combo['observable_id'],
+          $combo['unit_id'],
+        );
+
+        $this->assertStringContainsString(
+          $trait->name,
+          $method_markup,
+          'The trait combo name ' . $trait->name . ' is expected in table row #' . $i
+        );
+
+        $this->assertStringContainsString(
+          $method->name,
+          $method_markup,
+          'The trait combo method ' . $method->name . ' is expected in table row #' . $i
+        );
+
+        $this->assertStringContainsString(
+          $unit->name,
+          $method_markup,
+          'The trait combo unit ' . $unit->name . ' is expected in table row #' . $i
+        );
+
+        $trait_status = [
+          $combo['is_archived'],
+          $combo['is_required'],
+          $combo['was_shared'],
+          $combo['was_collected'],
+        ];
+
+        foreach ($trait_status as $j => $status) {
+          if ($status) {
+            // A value 1 will render a coressponding trait status icon.
+            $this->assertStringContainsString(
+              $status_class[$j],
+              $method_markup,
+              'The trait combo is expected to have the icon status CSS class name ' . $status_class[$j] . ' in table row #' . $i
+            );
+          }
+          else {
+            $this->assertStringNotContainsString(
+              $status_class[$j],
+              $method_markup,
+              'The trait combo is expected not to have the icon status CSS class name ' . $status_class[$j] . ' in table row #' . $i
+            );
+          }
+        }
+
+        // Operations options available to the item depend on trait status values.
+        $this->assertStringContainsString(
+          'Remove',
+          $method_markup,
+          'The trait item is expected to contain a remove operation option.',
+        );
+
+        $this->assertStringContainsString(
+          $set_to = 'Set ' . (($combo['is_required']) ? 'Optional' : 'Require'),
+          $method_markup,
+          'The trait item is expected to contain a set to ' . $set_to . ' operation option.',
+        );
+
+        $this->assertStringContainsString(
+          $set_to = 'Set ' . (($combo['is_archived']) ? 'Active' : 'Archive'),
+          $method_markup,
+          'The trait item is expected to contain a set to ' . $set_to . ' operation option.',
+        );
+
+        $row_i++;
+      }
+    }
   }
 
   /**
@@ -485,11 +654,11 @@ class PhenoExperimentConfigurationFormTest extends ChadoTestKernelBase {
         return is_int($i);
       });
 
-      $this->assertEquals(
-        $count = count($all_trait[$genus]),
-        count($table_items),
-        'The number of traits in genus ' . $genus . ' does not match expected count - ' . $count
-      );
+      // $this->assertEquals(
+      //   $count = count($all_trait[$genus]),
+      //   count($table_items),
+      //   'The number of traits in genus ' . $genus . ' does not match expected count - ' . $count
+      // );
 
       foreach ($table_items as $delta) {
         // $this->assertContains(

--- a/trpcultivate_phenotypes/tests/src/Kernel/Forms/PhenoExperimentConfigurationFormTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Forms/PhenoExperimentConfigurationFormTest.php
@@ -443,7 +443,6 @@ class PhenoExperimentConfigurationFormTest extends ChadoTestKernelBase {
     $render_config_form = $this->container->get('renderer')
       ->renderRoot($config_form);
 
-
     $genus_ontology_service = $this->container->get('trpcultivate_phenotypes.genus_ontology');
 
     $genus_map = [];
@@ -585,7 +584,7 @@ class PhenoExperimentConfigurationFormTest extends ChadoTestKernelBase {
           }
         }
 
-        // Operations options available to the item depend on trait status values.
+        // Operation options available to item depend on trait status values.
         $this->assertStringContainsString(
           'Remove',
           $method_markup,
@@ -593,13 +592,13 @@ class PhenoExperimentConfigurationFormTest extends ChadoTestKernelBase {
         );
 
         $this->assertStringContainsString(
-          $set_to = 'Set as ' . (($trait_row->is_required) ? 'Optional' : 'Required'),
+          $set_to = 'Set as ' . (($combo['is_required']) ? 'Optional' : 'Required'),
           $method_markup,
           'The trait item is expected to contain operation option to ' . $set_to,
         );
 
         $this->assertStringContainsString(
-          $set_to = (($trait_row->is_archived) ? 'Restore' : 'Archive') . ' Trait',
+          $set_to = (($combo['is_archived']) ? 'Restore' : 'Archive') . ' Trait',
           $method_markup,
           'The trait item is expected to contain operation option to ' . $set_to,
         );

--- a/trpcultivate_phenotypes/tests/src/Kernel/Forms/PhenoExperimentConfigurationFormTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Forms/PhenoExperimentConfigurationFormTest.php
@@ -103,6 +103,14 @@ class PhenoExperimentConfigurationFormTest extends ChadoTestKernelBase {
         'Type' => 'Quantitative',
       ],
       [
+        'Trait Name' => 'Days to Flower',
+        'Trait Description' => 'DTF trait description text',
+        'Method Short Name' => 'DTF-2',
+        'Collection Method' => 'DTF-2 trait collection method text',
+        'Unit' => 'days',
+        'Type' => 'Quantitative',
+      ],
+      [
         'Trait Name' => 'Plant Height',
         'Trait Description' => 'PH trait description text',
         'Method Short Name' => 'PHT',
@@ -396,22 +404,23 @@ class PhenoExperimentConfigurationFormTest extends ChadoTestKernelBase {
       'The render array is expected to have a type table.'
     );
 
-    $headers = ['label', 'combo', 'operations'];
-    $this->assertEquals(
-      array_keys($config_form[$summary_table_name]['#header']),
-      $headers,
-      'The summary listing table render array is missing expected header.',
+    $this->assertStringContainsString(
+      'Trait Method Unit',
+      (string) $config_form[$summary_table_name]['#prefix'],
+      'The summary table title text does not matche epected title.',
     );
 
     $db_trait_count = $this->container->get('database')
       ->select(self::PHENO_COMBO_TABLE, 'c')
+      ->fields('c', ['attr_id'])
       ->condition('c.project_id', $experiment_id, '=')
+      ->groupBy('c.attr_id')
       ->countQuery()
       ->execute()
       ->fetchField();
 
     $setup_trait_count = array_reduce($this->trait_set, function ($prev, $cur) {
-      return $prev + count($cur);
+      return $prev + count(array_unique(array_column($cur, 'Trait Name')));
     });
 
     $this->assertEquals(
@@ -429,141 +438,6 @@ class PhenoExperimentConfigurationFormTest extends ChadoTestKernelBase {
       count($table_items),
       'The table render array #rows property key does not contain the expected number of traits.'
     );
-
-    // Test the summary table rendered markup.
-    $render_config_form = $this->container->get('renderer')
-      ->renderRoot($config_form);
-
-    $genus_ontology_service = $this->container->get('trpcultivate_phenotypes.genus_ontology');
-
-    $genus_map = [];
-    foreach (array_keys($this->trait_set) as $genus) {
-      $cv_id = $genus_ontology_service->getGenusOntologyConfigValues($genus)['trait'];
-      $genus_map[$cv_id] = $genus;
-    }
-
-    // Using the same query setup, test that the expected row is at the same
-    // table item row number in the markup.
-    $query = $this->chado_connection->select(self::PHENO_COMBO_TABLE, 'tc');
-    $query->join('1:cvterm', 't', 'tc.attr_id = t.cvterm_id');
-    $query->join('1:cv', 'v', 't.cv_id = v.cv_id');
-
-    $query
-      ->fields('tc', [
-        'combo_id',
-        'attr_id',
-        'observable_id',
-        'unit_id',
-        'label',
-        'is_archived',
-        'is_required',
-        'was_shared',
-        'was_collected',
-      ])
-      ->fields('t', ['cv_id', 'name'])
-      ->condition('tc.project_id', $experiment_id, '=')
-      ->orderBy('v.name', 'ASC')
-      ->orderBy('t.name', 'ASC')
-      ->orderBy('label', 'ASC');
-
-    $query_result = $query->execute();
-
-    $this->setRawContent($render_config_form);
-    $table_rows = $this->cssSelect('tbody tr');
-
-    $status_class = [
-      'tcp-pheno-archived',
-      'tcp-pheno-required',
-      'tcp-pheno-shared',
-      'tcp-pheno-collected',
-    ];
-
-    $trait_service = $this->container->get('trpcultivate_phenotypes.traits');
-
-    $genus_set = [];
-    foreach ($query_result as $i => $trait_row) {
-      $genus = $genus_map[$trait_row->cv_id];
-      if (!in_array($genus, $genus_set)) {
-        $trait_service->setTraitGenus($genus);
-        array_push($genus_set, $genus);
-      }
-
-      $current_row = $table_rows[$i]->asXML();
-
-      $this->assertStringContainsString(
-        $trait_row->label,
-        $current_row,
-        'The trait combo label ' . $trait_row->label . ' is expected in table row #' . $i
-      );
-
-      ['trait' => $trait, 'method' => $method, 'unit' => $unit] = $trait_service->getTraitMethodUnitCombo(
-        $trait_row->attr_id,
-        $trait_row->observable_id,
-        $trait_row->unit_id,
-      );
-
-      $this->assertStringContainsString(
-        $trait->name,
-        $current_row,
-        'The trait combo name ' . $trait->name . ' is expected in table row #' . $i
-      );
-
-      $this->assertStringContainsString(
-        $method->name,
-        $current_row,
-        'The trait combo method ' . $method->name . ' is expected in table row #' . $i
-      );
-
-      $this->assertStringContainsString(
-        $unit->name,
-        $current_row,
-        'The trait combo unit ' . $unit->name . ' is expected in table row #' . $i
-      );
-
-      $trait_status = [
-        $trait_row->is_archived,
-        $trait_row->is_required,
-        $trait_row->was_shared,
-        $trait_row->was_collected,
-      ];
-
-      foreach ($trait_status as $j => $status) {
-        if ($status) {
-          // A value 1 will insert a coressponding trait status icon.
-          $this->assertStringContainsString(
-            $status_class[$j],
-            $current_row,
-            'The trait combo is expected to have the icon status CSS class name ' . $status_class[$j] . ' in table row #' . $i
-          );
-        }
-        else {
-          $this->assertStringNotContainsString(
-            $status_class[$j],
-            $current_row,
-            'The trait combo is expected not to have the icon status CSS class name ' . $status_class[$j] . ' in table row #' . $i
-          );
-        }
-      }
-
-      // Operations options available to the item depend on trait status values.
-      $this->assertStringContainsString(
-        'Remove',
-        $current_row,
-        'The trait item is expected to contain a remove operation option.',
-      );
-
-      $this->assertStringContainsString(
-        $set_to = 'Set ' . (($trait_row->is_required) ? 'Optional' : 'Require'),
-        $current_row,
-        'The trait item is expected to contain a set to ' . $set_to . ' operation option.',
-      );
-
-      $this->assertStringContainsString(
-        $set_to = 'Set ' . (($trait_row->is_archived) ? 'Active' : 'Archive'),
-        $current_row,
-        'The trait item is expected to contain a set to ' . $set_to . ' operation option.',
-      );
-    }
   }
 
   /**
@@ -618,11 +492,11 @@ class PhenoExperimentConfigurationFormTest extends ChadoTestKernelBase {
       );
 
       foreach ($table_items as $delta) {
-        $this->assertContains(
-          $trait_name = $config_form[$summary_table_name][$delta]['trait_combo']['#props']['name'],
-          $all_trait[$genus],
-          'The trait name ' . $trait_name . ' is expected in genus ' . $genus . ' filter result.'
-        );
+        // $this->assertContains(
+        //   $trait_name = $config_form[$summary_table_name][$delta]['trait_combo']['#props']['name'],
+        //   $all_trait[$genus],
+        //   'The trait name ' . $trait_name . ' is expected in genus ' . $genus . ' filter result.'
+        // );
       }
     }
   }

--- a/trpcultivate_phenotypes/tests/src/Kernel/Forms/PhenoExperimentConfigurationFormTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Forms/PhenoExperimentConfigurationFormTest.php
@@ -654,18 +654,20 @@ class PhenoExperimentConfigurationFormTest extends ChadoTestKernelBase {
         return is_int($i);
       });
 
-      // $this->assertEquals(
-      //   $count = count($all_trait[$genus]),
-      //   count($table_items),
-      //   'The number of traits in genus ' . $genus . ' does not match expected count - ' . $count
-      // );
+      $this->assertEquals(
+        $count = count(array_unique($all_trait[$genus])),
+        count($table_items),
+        'The number of traits in genus ' . $genus . ' does not match expected count - ' . $count
+      );
 
       foreach ($table_items as $delta) {
-        // $this->assertContains(
-        //   $trait_name = $config_form[$summary_table_name][$delta]['trait_combo']['#props']['name'],
-        //   $all_trait[$genus],
-        //   'The trait name ' . $trait_name . ' is expected in genus ' . $genus . ' filter result.'
-        // );
+        preg_match('/<p class="tcp-trait-combo">(.*?)<br \/>/', $config_form[$summary_table_name][$delta]['trait_combo']['#prefix'], $match);
+
+        $this->assertContains(
+          $trait_name = $match[1],
+          array_unique($all_trait[$genus]),
+          'The trait name ' . $trait_name . ' is expected in genus ' . $genus . ' filter result.'
+        );
       }
     }
   }

--- a/trpcultivate_phenotypes/tests/src/Kernel/Forms/PhenoExperimentTraitSelectorFormTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Forms/PhenoExperimentTraitSelectorFormTest.php
@@ -525,7 +525,7 @@ class PhenoExperimentTraitSelectorFormTest extends ChadoTestKernelBase {
         $method_name = explode(':', strip_tags($render_method->asXML()))[0];
 
         $this->assertContains(
-          $method_name,
+          trim($method_name),
           $trait_group_methods,
           'The rendered markup of the search result does not contain the exact method-unit combo items.',
         );


### PR DESCRIPTION
# Issue #192

## Motivation

<!-- This can usually be copied from the issue. Please do not just say, go see issue but instead copy the relevant details here. -->

Refine the the summary table layout so that methods under the same trait name are grouped together.

<img width="2424" height="3025" alt="Screenshot 2026-01-28 at 13-02-16 Configure Phenotypes for AGILE - Application of Genomic Innovation in the Lentil Economy Tripal Cultivate Docker" src="https://github.com/user-attachments/assets/bee0df05-914b-4ca2-9909-b7beaec86a3f" />


## What does this PR do?
*Please describe each things this PR does. For example, a PR may 1) solve a specific bug, 2) create an automated test to ensure it doesn't return.*

1. Rearrange render array from a top down list of traits to nested table elements.

## Testing

### Automated Testing
*Please describe each automated test this PR creates and provide a list of the assertions it makes using casual language.*
*Do not just say things like "asserts the array is not empty" but rather say "Ensures that the return value of method X with these parameters is not an empty array".*

Automated test remain the same with minor revision to account for the nesting.

### Manual Testing
*Describe in detail how someone should manually test this functionality.*
*Make sure to include whether they need to build a docker from scratch, create any records, etc.*

1. Switch to branch **g0.192---ImproveMethodGrouping.**
2. In a fully working clone, create the following organisms.
Content > Tripal Content > Add Tripal Content > Organism
(**my_site/bio_data/add/organism**)
- Lens culinaris
- Triticum durum


3. Configure the genus (set Trait, Method, Unit and DB) so that it is recognized by the Phenotypes Module.
Tripal > Extensions > TripalCultivate Phenotypes Configuration > Ontology Terms
(**my_site/admin/tripal/extension/tripal-cultivate/phenotypes/ontology**)


4. Create a Research Experiment Tripal Content Type.
Content > Tripal Content > Add Tripal Content > Research Experiment
(**my_site/bio_data/add/research_experiment**)

Provide an experiment name and add the 2 organisms created in step 1 (provide only the genus into the field) into the Germplasm Genus field found in Design tab (use the button Add another item to add a second field). Click Save.

<img width="541" height="477" alt="image" src="https://github.com/user-attachments/assets/27160407-1cae-45c1-a49b-5d0649552f21" />

5. Upload traits. Run Tripal job for each genus.
Tripal > Data Loaders > Tripal Cultivate: Phenotypic Trait Importer
(**my_site/admin/tripal/loaders/trpcultivate-phenotypes-traits-importer**)

[Traits.zip](https://github.com/user-attachments/files/24919913/Traits.zip)


6. Access the Research Experiment.
Content > Tripal Content > The name of the Research Experiment > Phenotypes tab.

<img width="1917" height="896" alt="image" src="https://github.com/user-attachments/assets/9bebfe7d-c4e1-4795-8bdd-164f2587cfe0" />

7. Click <img width="92" height="82" alt="image" src="https://github.com/user-attachments/assets/c2f98388-f23e-4c0b-8491-7a2c002b2619" /> and add as many traits for the test as shown by the screenshot at the start of this PR.

Verify that traits are organized by Genus and in a genus, traits are grouped by trait name
<img width="1379" height="757" alt="Screen Shot 2026-01-29 at 12 49 23 PM" src="https://github.com/user-attachments/assets/aa271049-10d0-414e-b6a1-7858d9c474f2" />

