### PR TITLE
G0.212 - Display allowed file size in backup form

### DIFF
--- a/trpcultivate_phenotypes/src/Form/PhenodataBackupForm.php
+++ b/trpcultivate_phenotypes/src/Form/PhenodataBackupForm.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace Drupal\trpcultivate_phenotypes\Form;
 
+use Drupal\Component\Utility\Environment;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\EntityForm;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\StringTranslation\ByteSizeMarkup;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Drupal\tripal_chado\Controller\ChadoProjectAutocompleteController;
@@ -147,7 +149,10 @@ final class PhenodataBackupForm extends EntityForm {
     $form['backup_file'] = [
       '#type' => 'managed_file',
       '#title' => 'Data File',
-      '#description' => $this->t('Select data file to backup. Only [@ext] file extensions are allowed.', ['@ext' => $importer_file_extension]),
+      '#description' => $this->t('Select data file to backup. Only [@ext] file extensions are allowed. The maximum file size allowed is <strong>@size</strong>.', [
+        '@ext' => $importer_file_extension,
+        '@size' => ByteSizeMarkup::create(Environment::getUploadMaxSize()),
+      ]),
       '#upload_location' => $backup_dir,
       '#multiple' => FALSE,
       '#required' => TRUE,


### PR DESCRIPTION
## Issue #211

## Motivation

<!-- This can usually be copied from the issue. Please do not just say, go see issue but instead copy the relevant details here. -->

This PR improves the backup form to indicate the allowed file size when backing up data file.

## What does this PR do?
*Please describe each things this PR does. For example, a PR may 1) solve a specific bug, 2) create an automated test to ensure it doesn't return.*

1. Display the Drupal environment setting for maximum file size.

## Testing

### Manual Testing
*Describe in detail how someone should manually test this functionality.*
*Make sure to include whether they need to build a docker from scratch, create any records, etc.*

1. Switch to branch **g0.211-MaxUploadSize**
2. In a fully working clone, login as drupaladmin.
3. Navigate to **my_clone/admin/structure/phenodata_backup** and click
<img width="230" height="61" alt="Screenshot 2026-02-11 at 10 19 49 AM" src="https://github.com/user-attachments/assets/88fce9d3-bd90-4ee6-8194-2b26b4dfa7b6" /> 

button to load the backup form.

5. Verify that the file field has file size requirement

<img width="482" height="323" alt="Screenshot 2026-02-11 at 10 25 55 AM" src="https://github.com/user-attachments/assets/704b8f5b-da67-4182-8f92-16c69bb901be" />


6. Verify that the set file size matches the Drupal file size environment by navigating to **myclone/admin/reports/status**

7. Click the more information link of the PHP component.
<img width="297" height="206" alt="image" src="https://github.com/user-attachments/assets/f21ae77a-08ae-44d1-b71a-51c5acb5564a" />

8. Search for upload_max_filesize and verify values match.

<img width="951" height="23" alt="Screenshot 2026-02-11 at 10 24 50 AM" src="https://github.com/user-attachments/assets/6417c3c6-4f79-4b5e-8a08-81d3d4241845" />