### PR TITLE
Devcontainer not building on Mac Silicon

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -8,7 +8,7 @@
       "postgresqlversion": "18"
     }
   },
-  "initializeCommand": "docker pull knowpulse/tripalcultivate-base:drupal11.x-dev-php8.5-pgsql18",
+  "initializeCommand": "docker pull knowpulse/tripalcultivate-base:drupal11.x-dev-php8.5-pgsql18 --platform linux/amd64",
   "workspaceMount": "source=${localWorkspaceFolder},target=/var/www/drupal/web/modules/contrib/TripalCultivate-Phenotypes,type=bind",
   "workspaceFolder": "/var/www/drupal/web/modules/contrib/TripalCultivate-Phenotypes",
   "customizations": {

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 ARG drupalversion=11.3.x-dev
 ARG phpversion=8.5
 ARG postgresqlversion=18
-FROM --platform=amd64 knowpulse/tripalcultivate-base:drupal${drupalversion}-php${phpversion}-pgsql${postgresqlversion}
+ARG buildplatform='linux/amd64'
+FROM --platform=${buildplatform} knowpulse/tripalcultivate-base:drupal${drupalversion}-php${phpversion}-pgsql${postgresqlversion}
 
 COPY . /var/www/drupal/web/modules/contrib/TripalCultivate-Phenotypes
 WORKDIR /var/www/drupal/web/modules/contrib/TripalCultivate-Phenotypes

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG drupalversion=11.3.x-dev
 ARG phpversion=8.5
 ARG postgresqlversion=18
-FROM knowpulse/tripalcultivate-base:drupal${drupalversion}-php${phpversion}-pgsql${postgresqlversion}
+FROM --platform=amd64 knowpulse/tripalcultivate-base:drupal${drupalversion}-php${phpversion}-pgsql${postgresqlversion}
 
 COPY . /var/www/drupal/web/modules/contrib/TripalCultivate-Phenotypes
 WORKDIR /var/www/drupal/web/modules/contrib/TripalCultivate-Phenotypes


### PR DESCRIPTION
**Issue https://github.com/tripal/tripal/pull/2427**

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Indicates the platform `linux/amd64` in both the devcontainer pull command and dockerfile FROM. This will work on all platforms (i.e. both `linux/amd64` and `linux/arm64`) since it's just specifying which version of the base image to pull and there is only one option anyway. On Mac OSX this ensures that docker doesn't complain that it can't find the nonexistent `linux/arm64` version and just fail 🙄 

## Testing?
<!--- Please describe in detail how to test these changes. -->
<!--- Reviewers will use this section to test the submission! -->
<!--- If you've implemented PHPUnit tests, you can describe the test cases here. -->
Test that you can use devcontainer with VSCode on as many different platforms as you have available.