### PR TITLE
G0.216 - Update file field description text

### DIFF
--- a/trpcultivate_phenotypes/src/Form/PhenodataBackupForm.php
+++ b/trpcultivate_phenotypes/src/Form/PhenodataBackupForm.php
@@ -149,7 +149,7 @@ final class PhenodataBackupForm extends EntityForm {
     $form['backup_file'] = [
       '#type' => 'managed_file',
       '#title' => 'Data File',
-      '#description' => $this->t('Select data file to backup. Only [@ext] file extensions are allowed. The maximum file size allowed is <strong>@size</strong>.', [
+      '#description' => $this->t('Select data file to backup. Only [@ext] file extensions are allowed. The maximum file size allowed is <strong>@size</strong>. If your file exceeds this size, please contact your administrator.', [
         '@ext' => $importer_file_extension,
         '@size' => ByteSizeMarkup::create(Environment::getUploadMaxSize()),
       ]),


### PR DESCRIPTION
**Issue #211**

## Motivation

<!-- This can usually be copied from the issue. Please do not just say, go see issue but instead copy the relevant details here. -->

Include a directive to the file backup file field, if file for backup exceeds file size limit. 

<img width="659" height="254" alt="Screenshot 2026-03-02 at 7 29 58 AM" src="https://github.com/user-attachments/assets/59c027bd-864c-43d9-b16f-a83ecba0e8a2" />

## What does this PR do?
*Please describe each things this PR does. For example, a PR may 1) solve a specific bug, 2) create an automated test to ensure it doesn't return.*

1. Append the file description text with - **If your file exceeds this size, please contact your administrator.**

### Manual Testing
*Describe in detail how someone should manually test this functionality.*
*Make sure to include whether they need to build a docker from scratch, create any records, etc.*

1. Access backup page and verify the field description to contain this text.
