### PR TITLE
Remove phased out dependency 'markup' :tada: to fix remaining deprecations!

### DIFF
--- a/trpcultivate_phenotypes/tests/src/Kernel/Forms/PhenoExperimentConfigurationFormTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Forms/PhenoExperimentConfigurationFormTest.php
@@ -42,7 +42,6 @@ class PhenoExperimentConfigurationFormTest extends ChadoTestKernelBase {
     'field',
     'field_ui',
     'field_group',
-    'markup',
     'path',
     'path_alias',
     'system',

--- a/trpcultivate_phenotypes/tests/src/Kernel/Forms/PhenoExperimentTraitSelectorFormTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Forms/PhenoExperimentTraitSelectorFormTest.php
@@ -42,7 +42,6 @@ class PhenoExperimentTraitSelectorFormTest extends ChadoTestKernelBase {
     'field',
     'field_ui',
     'field_group',
-    'markup',
     'path',
     'path_alias',
     'system',


### PR DESCRIPTION
**Issue #217**

## Motivation

The Drupal markup module was no longer being maintained and causing deprecation's in our code base. As such we made a markup field in Tripal core and phased out the markup module in favour for this field.

## What does this PR do?

This PR removes mention of the 'markup' module in functional tests as it is no longer required.

## Testing

### Automated Testing

No new automated testing is needed.

Confirm existing tests all pass now 🎉 

### Manual Testing

Simply create a container on this branch and confirm it builds fine. 

Realistically, manual testing is likely not needed since this process is done during automated testing as well.