### PR TITLE
G4.224 Move setup methods from .module to a dedicated service class

### DIFF
--- a/trpcultivate_phenotypes/src/Service/SetupModuleService.php
+++ b/trpcultivate_phenotypes/src/Service/SetupModuleService.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Drupal\trpcultivate_phenotypes\Service;
+
+/**
+ * Service class for setup module functions.
+ */
+class SetupModuleService {
+
+  /**
+   * Install the ontology terms.
+   *
+   * Expected to be run by a Tripal Job.
+   */
+  public static function installOntologyTerms() {
+    // We need the schema to ensure we are inserting into the right one.
+    $connection = \Drupal::service('tripal_chado.database');
+    $schema = $connection->getSchemaName();
+
+    // Create terms defined in config entity.
+    \Drupal::service('trpcultivate_phenotypes.terms')
+      ->loadTerms($schema);
+
+    // Create genus-ontology configuration.
+    \Drupal::service('trpcultivate_phenotypes.genus_ontology')
+      ->loadGenusOntology();
+  }
+
+}

--- a/trpcultivate_phenotypes/tests/src/Kernel/PhenotypeTermInstallTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/PhenotypeTermInstallTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
- * Tests trpcultivate_phenotypes.module.
+ * Tests the setup of the trpcultivate_phenotypes module.
  *
  * @group trpcultivate_phenotypes
  */

--- a/trpcultivate_phenotypes/tests/src/Kernel/PhenotypeTermInstallTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/PhenotypeTermInstallTest.php
@@ -51,11 +51,12 @@ class PhenotypeTermInstallTest extends ChadoTestKernelBase {
   }
 
   /**
-   * Test trpcultivate_phenotypes_install_ontologyterms() method.
+   * Test installOntologyTerms() method.
    */
   public function testInstallOntologyTerms() {
-    // Call the trpcultivate_phenotypes_install_ontologyterms() method.
-    trpcultivate_phenotypes_install_ontologyterms();
+    // Call the installOntologyTerms() method.
+    \Drupal::service('trpcultivate_phenotypes.setup_module_service')
+      ->installOntologyTerms();
 
     // Call defineTerms in Term Service.
     $terms = \Drupal::service('trpcultivate_phenotypes.terms')

--- a/trpcultivate_phenotypes/trpcultivate_phenotypes.install
+++ b/trpcultivate_phenotypes/trpcultivate_phenotypes.install
@@ -41,18 +41,17 @@ function trpcultivate_phenotypes_install() {
   $user = \Drupal::currentUser();
 
   try {
-    tripal_add_job(
-      'Tripal Cultivate Phenotypes: Install Ontology and Terms',
-      'tripal',
-      'trpcultivate_phenotypes_install_ontologyterms',
-      [],
-      $user->id(),
-      10,
-      []
-    );
+    \Drupal::service('tripal.job')->create([
+      'job_name'   => t('Tripal Cultivate Phenotypes: Install Ontology and Terms'),
+      'modulename' => 'trpcultivate',
+      'callback'   => ['Drupal\trpcultivate_phenotypes\Service\SetupModuleService', 'installOntologyTerms'],
+      'arguments'  => [],
+      'uid'        => $user->id(),
+      'priority'   => 10,
+    ]);
   }
   catch (\Exception $e) {
-    throw new \Exception('Cannot create a job to install terms:' . $e->getMessage);
+    throw new \Exception('Cannot create a job to install terms: ' . $e->getMessage());
   }
 }
 

--- a/trpcultivate_phenotypes/trpcultivate_phenotypes.module
+++ b/trpcultivate_phenotypes/trpcultivate_phenotypes.module
@@ -72,26 +72,3 @@ function trpcultivate_phenotypes_form_alter(&$form, FormStateInterface $form_sta
   return \Drupal::service('trpcultivate_phenotypes.alter_hooks')
     ->formAlter($form, $form_state, $form_id);
 }
-
-/**
- * Tripal Job callback.
- *
- * Job registered during install to insert terms used by configuration
- * page default field values.
- *
- * @see config/trpcultivate_phenotypes.settings
- */
-function trpcultivate_phenotypes_install_ontologyterms() {
-
-  // We need the schema to ensure we are inserting into the right one.
-  $connection = \Drupal::service('tripal_chado.database');
-  $schema = $connection->getSchemaName();
-
-  // Create terms defined in config entity.
-  \Drupal::service('trpcultivate_phenotypes.terms')
-    ->loadTerms($schema);
-
-  // Create genus-ontology configuration.
-  \Drupal::service('trpcultivate_phenotypes.genus_ontology')
-    ->loadGenusOntology();
-}

--- a/trpcultivate_phenotypes/trpcultivate_phenotypes.services.yml
+++ b/trpcultivate_phenotypes/trpcultivate_phenotypes.services.yml
@@ -36,3 +36,6 @@ services:
   trpcultivate_phenotypes.alter_hooks:
     class: 'Drupal\trpcultivate_phenotypes\Hook\TripalCultivatePhenotypesAlterHooks'
     arguments: ['@database', '@current_route_match', '@tripal_chado.database', '@trpcultivate_phenotypes.genus_ontology']
+
+  trpcultivate_phenotypes.setup_module_service:
+    class: 'Drupal\trpcultivate_phenotypes\Service\SetupModuleService'


### PR DESCRIPTION
**Issue #224**

## Motivation

<!-- This can usually be copied from the issue. Please do not just say, go see issue but instead copy the relevant details here. -->
The .module file for this module currently includes setup methods, which makes it harder to manage and keeping this logic in the module makes maintenance and testing harder. We need a separate Service class to replace this.

## What does this PR do?
<!-- *Please describe each things this PR does. For example, a PR may 1) solve a specific bug, 2) create an automated test to ensure it doesn't return.* -->

Move all setup methods into a separate service class. Update the .module file and the .install file to use this service instead of containing the setup logic directly.

## Testing

### Automated Testing
<!-- *Please describe each automated test this PR creates and provide a list of the assertions it makes using casual language.*
*Do not just say things like "asserts the array is not empty" but rather say "Ensures that the return value of method X with these parameters is not an empty array".* -->
This PR does not add any new test classes or methods. However the PhenotypeTermInstallTest class has been updated to test the newly implemented installOntologyTerms method of the new class instead of the previous methods on .module file.

### Manual Testing
<!-- *Describe in detail how someone should manually test this functionality.*
*Make sure to include whether they need to build a docker from scratch, create any records, etc.*-->

1.Start a fresh docker image/container on this branch.
2. Check if all the terms that's installed by this service has been installed properly. (Example queries shown below)
<img width="1576" height="495" alt="Screenshot 2026-04-13 at 9 33 35 AM" src="https://github.com/user-attachments/assets/9a5bff0b-14b9-46fd-9544-132955ae2bee" />
