### PR TITLE
G5.226 Replace trpcultivate.module methods with SetupModuleService methods

### DIFF
--- a/trpcultivate_phenotypes/tests/src/Kernel/Controllers/PhenoExperimentPhenoBackupControllerTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Controllers/PhenoExperimentPhenoBackupControllerTest.php
@@ -85,11 +85,15 @@ class PhenoExperimentPhenoBackupControllerTest extends ChadoTestKernelBase {
     $this->installEntitySchema('file');
     $this->installEntitySchema('user');
 
-    \trpcultivate_install_terms();
+    $this->container->get('trpcultivate.setup_module_service')
+      ->installTerms();
+
     $this->container->get('tripal_chado.terms_init')
       ->installTerms();
 
-    \trpcultivate_import_contenttypes();
+    $this->container->get('trpcultivate.setup_module_service')
+      ->importContenttypes();
+
     $this->setTermConfig();
 
     // Create Research Experiment Tripal content.

--- a/trpcultivate_phenotypes/tests/src/Kernel/Forms/PhenoExperimentConfigurationFormTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Forms/PhenoExperimentConfigurationFormTest.php
@@ -117,11 +117,15 @@ class PhenoExperimentConfigurationFormTest extends ChadoTestKernelBase {
     $this->installSchema('trpcultivate_phenotypes', [self::PHENO_COMBO_TABLE]);
     $this->installEntitySchema('user');
 
-    \trpcultivate_install_terms();
+    $this->container->get('trpcultivate.setup_module_service')
+      ->installTerms();
+
     $this->container->get('tripal_chado.terms_init')
       ->installTerms();
 
-    \trpcultivate_import_contenttypes();
+    $this->container->get('trpcultivate.setup_module_service')
+      ->importContenttypes();
+
     $config_terms = $this->setTermConfig();
 
     // Create test records.

--- a/trpcultivate_phenotypes/tests/src/Kernel/Forms/PhenoExperimentTraitSelectorFormTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Forms/PhenoExperimentTraitSelectorFormTest.php
@@ -155,11 +155,15 @@ class PhenoExperimentTraitSelectorFormTest extends ChadoTestKernelBase {
     $this->installSchema('trpcultivate_phenotypes', ['trpcultivate_phenocombo']);
     $this->installEntitySchema('user');
 
-    \trpcultivate_install_terms();
+    $this->container->get('trpcultivate.setup_module_service')
+      ->installTerms();
+
     $this->container->get('tripal_chado.terms_init')
       ->installTerms();
 
-    \trpcultivate_import_contenttypes();
+    $this->container->get('trpcultivate.setup_module_service')
+      ->importContenttypes();
+
     $config_terms = $this->setTermConfig();
 
     // Create test records.

--- a/trpcultivate_phenotypes/tests/src/Kernel/Hooks/HookAlterTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Hooks/HookAlterTest.php
@@ -96,11 +96,15 @@ class HookAlterTest extends ChadoTestKernelBase {
     $this->installSchema('trpcultivate_phenotypes', [self::PHENO_COMBO_TABLE]);
     $this->installEntitySchema('user');
 
-    \trpcultivate_install_terms();
+    $this->container->get('trpcultivate.setup_module_service')
+      ->installTerms();
+
     $this->container->get('tripal_chado.terms_init')
       ->installTerms();
 
-    \trpcultivate_import_contenttypes();
+    $this->container->get('trpcultivate.setup_module_service')
+      ->importContenttypes();
+
     $config_terms = $this->setTermConfig();
 
     // Create test records - A research experiment entity with genus set to

--- a/trpcultivate_phenotypes/tests/src/Kernel/Services/ServiceTermTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Services/ServiceTermTest.php
@@ -114,7 +114,8 @@ class ServiceTermTest extends ChadoTestKernelBase {
     $this->prepareEnvironment(['TripalTerm']);
 
     $this->installConfig('trpcultivate');
-    trpcultivate_install_terms();
+    $this->container->get('trpcultivate.setup_module_service')
+      ->installTerms();
 
     // Mock Tripal Logger.
     $mock_logger = $this->getMockBuilder(TripalLogger::class)


### PR DESCRIPTION
**Issue #226**

## Motivation

<!-- This can usually be copied from the issue. Please do not just say, go see issue but instead copy the relevant details here. -->
After moving setup methods such as trpcultivate_install_terms() and trpcultivate_import_contenttypes() from .module to a dedicated SetupModuleService class on TripalCultivate base module, the automated tests started failing due to missing dependencies.

## What does this PR do?
<!-- *Please describe each things this PR does. For example, a PR may 1) solve a specific bug, 2) create an automated test to ensure it doesn't return.* -->
Replaces references to the former methods from trpcultivate.module with the newly implemented methods in the SetupModuleService class.

1. Replaces `trpcultivate_install_terms()` with SetupModuleService->installTerms()
2. Replaces `trpcultivate_import_contenttypes()` with SetupModuleService->importContenttypes()

## Testing

### Automated Testing
<!-- *Please describe each automated test this PR creates and provide a list of the assertions it makes using casual language.*
*Do not just say things like "asserts the array is not empty" but rather say "Ensures that the return value of method X with these parameters is not an empty array".* -->

This PR does not implement any new automated testing. However, ensure all the existing tests passes specially in the following classes.

- `PhenoExperimentPhenoBackupControllerTest`
- `PhenoExperimentConfigurationFormTest`
- `PhenoExperimentTraitSelectorFormTest`
- `HookAlterTest`
- `ServiceTermTest`
