### PR TITLE
Use callable format to ensure hook object is available to callback.

### DIFF
--- a/trpcultivate_phenotypes/src/Hook/TripalCultivatePhenotypesAlterHooks.php
+++ b/trpcultivate_phenotypes/src/Hook/TripalCultivatePhenotypesAlterHooks.php
@@ -132,7 +132,7 @@ class TripalCultivatePhenotypesAlterHooks {
         ];
       }
 
-      $form['#validate'][] = self::class . ':phenoGenusExperimentEditFormValidate';
+      $form['#validate'][] = [$this, 'phenoGenusExperimentEditFormValidate'];
     }
   }
 


### PR DESCRIPTION
**Issue #229**

## Motivation

When saving edits to an existing experiment, we are seeing a WSOD on production sites 🙈 The following error shows up in the logs:

> TypeError: call_user_func_array(): Argument #1 ($callback) must be a valid callback, function "Drupal\trpcultivate_phenotypes\Hook\TripalCultivatePhenotypesAlterHooks:phenoGenusExperimentEditFormValidate" not found or invalid function name in call_user_func_array() (line 82 of /htdoc/grassland-genomics/web/core/lib/Drupal/Core/Form/FormValidator.php).

## What does this PR do?

1. Changes the format of the validation callback added to the Research Experiment form to ensure the initialized hook object is available on edit.

## Testing

### Automated Testing

No additional automated tests.

### Manual Testing

Do the following tests on multiple versions. Specifically test it on Drupal 10.6 where this process would fail on 4.x and on Drupal 11.x where it works on 4.x.

1. Create a fresh docker on one of the versions above on this branch. 
2. Create an organism.
3. Create a Research Experiment. You can set a genus here or not as you want. Both should allow you to create just fine.
4. Edit the research experiment and try to save. On this branch it will work beautifully, on 4.x and Drupal 10.6 it failed.
