### PR TITLE
Implement db transaction commitOrRelease() in /trpcultivate_phenotypes

### DIFF
--- a/.github/workflows/ALL-PHPUnit.yml
+++ b/.github/workflows/ALL-PHPUnit.yml
@@ -62,7 +62,7 @@ jobs:
             drupal-version: "11.x-dev"
           - php-version: "8.4"
             drupal-version: "11.x-dev"
-          - postgresql-version: "14"
+          - pgsql-version: "14"
             drupal-version: "11.x-dev"
 
     steps:

--- a/.github/workflows/ALL-PHPUnit.yml
+++ b/.github/workflows/ALL-PHPUnit.yml
@@ -55,7 +55,14 @@ jobs:
             drupal-version: "11.2.x-dev"
           - php-version: "8.2"
             drupal-version: "11.3.x-dev"
+          # Only run 11.x on the bleeding edge.
           - php-version: "8.2"
+            drupal-version: "11.x-dev"
+          - php-version: "8.3"
+            drupal-version: "11.x-dev"
+          - php-version: "8.4"
+            drupal-version: "11.x-dev"
+          - postgresql-version: "14"
             drupal-version: "11.x-dev"
 
     steps:

--- a/.github/workflows/ALL-PHPUnit.yml
+++ b/.github/workflows/ALL-PHPUnit.yml
@@ -33,6 +33,7 @@ jobs:
           - "10.6.x-dev"
           - "11.2.x-dev"
           - "11.3.x-dev"
+          - "11.x-dev"
         exclude:
           # Only Drupal 11.3+ supports PHP 8.5.
           - php-version: "8.5"
@@ -54,6 +55,8 @@ jobs:
             drupal-version: "11.2.x-dev"
           - php-version: "8.2"
             drupal-version: "11.3.x-dev"
+          - php-version: "8.2"
+            drupal-version: "11.x-dev"
 
     steps:
       # Check out the repo

--- a/trpcultivate_phenotypes/src/Form/PhenoExperimentConfigurationForm.php
+++ b/trpcultivate_phenotypes/src/Form/PhenoExperimentConfigurationForm.php
@@ -554,6 +554,8 @@ class PhenoExperimentConfigurationForm extends FormBase {
             ->delete(self::PHENO_COMBO_TABLE)
             ->condition('combo_id', $combo->combo_id, '=')
             ->execute();
+
+          $transaction->commitOrRelease();
         }
         catch (\Exception $e) {
           $transaction->rollback();
@@ -588,6 +590,8 @@ class PhenoExperimentConfigurationForm extends FormBase {
             ->condition('combo_id', $combo->combo_id, '=')
             ->condition($field_map[$action], $status, '<>')
             ->execute();
+
+          $transaction->commitOrRelease();
         }
         catch (\Exception $e) {
           $transaction->rollback();

--- a/trpcultivate_phenotypes/src/Form/PhenoExperimentConfigurationForm.php
+++ b/trpcultivate_phenotypes/src/Form/PhenoExperimentConfigurationForm.php
@@ -555,7 +555,9 @@ class PhenoExperimentConfigurationForm extends FormBase {
             ->condition('combo_id', $combo->combo_id, '=')
             ->execute();
 
-          $transaction->commitOrRelease();
+          if (method_exists($transaction, 'commitOrRelease')) {
+            $transaction->commitOrRelease();
+          }
         }
         catch (\Exception $e) {
           $transaction->rollback();
@@ -591,7 +593,9 @@ class PhenoExperimentConfigurationForm extends FormBase {
             ->condition($field_map[$action], $status, '<>')
             ->execute();
 
-          $transaction->commitOrRelease();
+          if (method_exists($transaction, 'commitOrRelease')) {
+            $transaction->commitOrRelease();
+          }
         }
         catch (\Exception $e) {
           $transaction->rollback();

--- a/trpcultivate_phenotypes/src/Form/PhenoExperimentTraitSelectorForm.php
+++ b/trpcultivate_phenotypes/src/Form/PhenoExperimentTraitSelectorForm.php
@@ -439,7 +439,9 @@ class PhenoExperimentTraitSelectorForm extends FormBase {
               ])
               ->execute();
 
-            $transaction->commitOrRelease();
+            if (method_exists($transaction, 'commitOrRelease')) {
+              $transaction->commitOrRelease();
+            }
           }
           catch (Exception $e) {
             $transaction->rollback();

--- a/trpcultivate_phenotypes/src/Form/PhenoExperimentTraitSelectorForm.php
+++ b/trpcultivate_phenotypes/src/Form/PhenoExperimentTraitSelectorForm.php
@@ -438,6 +438,8 @@ class PhenoExperimentTraitSelectorForm extends FormBase {
                 'timestamp' => time(),
               ])
               ->execute();
+
+            $transaction->commitOrRelease();
           }
           catch (Exception $e) {
             $transaction->rollback();


### PR DESCRIPTION
**Issue #234 Database Transaction Deprecation**

## Motivation

This is to address D11 database transaction deprecations:

1. Drupal\pgsql\Driver\Database\pgsql\Connection::addSavepoint() is deprecated in drupal:11.4.0 and is removed from drupal:13.0.0. Use TransactionManager to start a transaction then call ::commitOrRelease() or ::rollback() on it. See https://www.drupal.org/node/3524461

2. Drupal\pgsql\Driver\Database\pgsql\Connection::releaseSavepoint() is deprecated in drupal:11.4.0 and is removed from drupal:13.0.0. Use TransactionManager to start a transaction then call ::commitOrRelease() or ::rollback() on it. See https://www.drupal.org/node/3524461

<!-- This can usually be copied from the issue. Please do not just say, go see issue but instead copy the relevant details here. -->

## What does this PR do?
*Please describe each things this PR does. For example, a PR may 1) solve a specific bug, 2) create an automated test to ensure it doesn't return.*

1. Implement call to commitOrRelease(). This method is checked before use in an if statement to ensure it is not called in previous Drupal version where commitOrRelease() is not defined.

## Testing

### Manual Testing
*Describe in detail how someone should manually test this functionality.*
*Make sure to include whether they need to build a docker from scratch, create any records, etc.*

1. Ensure continued success of automated tests

<img width="548" height="495" alt="image" src="https://github.com/user-attachments/assets/ca0378cb-0bc6-4bbd-93ba-262e1d17dcd6" />
