### PR TITLE
G0.244 - Reference new field name and value containing genus

### DIFF
--- a/trpcultivate_phenotypes/src/Form/PhenoExperimentConfigurationForm.php
+++ b/trpcultivate_phenotypes/src/Form/PhenoExperimentConfigurationForm.php
@@ -23,6 +23,13 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 class PhenoExperimentConfigurationForm extends FormBase {
 
   /**
+   * The name of the field that contains the genus.
+   *
+   * @var string
+   */
+  public const FIELD_ORGANISM = 'exp_organism';
+
+  /**
    * Drupal database connection.
    *
    * @var \Drupal\Core\Database\Connection
@@ -154,12 +161,12 @@ class PhenoExperimentConfigurationForm extends FormBase {
     // If the /genus slug is not provided, show all trait for all genus.
     $genus = $this->getRouteMatch()->getParameter('genus') ?: 0;
 
-    if ($tripal_entity->hasField('exp_germgenus')) {
+    if ($tripal_entity->hasField(self::FIELD_ORGANISM)) {
       $invalid_genus = 0;
-      $exp_germgenus = $tripal_entity->get('exp_germgenus')->getValue();
+      $exp_germgenus = $tripal_entity->get(self::FIELD_ORGANISM)->getValue();
 
       foreach ($exp_germgenus as $germgenus) {
-        if (!$this->service_PhenoGenusOntology->getGenusOntologyConfigValues($germgenus['value'])) {
+        if (!$this->service_PhenoGenusOntology->getGenusOntologyConfigValues($germgenus['genus_value'])) {
           $invalid_genus++;
         }
       }

--- a/trpcultivate_phenotypes/src/Hook/TripalCultivatePhenotypesAlterHooks.php
+++ b/trpcultivate_phenotypes/src/Hook/TripalCultivatePhenotypesAlterHooks.php
@@ -161,7 +161,7 @@ class TripalCultivatePhenotypesAlterHooks {
       // Genus as provided in the Design/Germplasm/Germplasm Genus field.
       // Removes the trailing genus field value set to empty string.
       $exp_germgenus = array_filter(
-        array_column($form_state->getValue(self::FIELD_ORGANISM), 'value')
+        array_column($form_state->getValue(self::FIELD_ORGANISM), 'genus_value')
       );
 
       $count_bygenus = array_count_values($exp_germgenus);

--- a/trpcultivate_phenotypes/src/Hook/TripalCultivatePhenotypesAlterHooks.php
+++ b/trpcultivate_phenotypes/src/Hook/TripalCultivatePhenotypesAlterHooks.php
@@ -22,6 +22,13 @@ class TripalCultivatePhenotypesAlterHooks {
   use StringTranslationTrait;
 
   /**
+   * The name of the field that contains the genus.
+   *
+   * @var string
+   */
+  public const FIELD_ORGANISM = 'exp_organism';
+
+  /**
    * A Database query interface for querying Chado using Tripal DBX.
    *
    * @var \Drupal\tripal_chado\Database\ChadoConneciton
@@ -148,13 +155,13 @@ class TripalCultivatePhenotypesAlterHooks {
 
     // All genus configured in Phenotypes.
     $pheno_configgenus = $this->service_PhenoGenusOntology->getConfiguredGenusList();
-    $germgenus_field = FieldStorageConfig::loadByName('tripal_entity', 'exp_germgenus');
+    $germgenus_field = FieldStorageConfig::loadByName('tripal_entity', self::FIELD_ORGANISM);
 
     if (count($pheno_configgenus) > 0 && $this->has_pheno && $germgenus_field) {
       // Genus as provided in the Design/Germplasm/Germplasm Genus field.
       // Removes the trailing genus field value set to empty string.
       $exp_germgenus = array_filter(
-        array_column($form_state->getValue('exp_germgenus'), 'value')
+        array_column($form_state->getValue(self::FIELD_ORGANISM), 'value')
       );
 
       $count_bygenus = array_count_values($exp_germgenus);
@@ -186,7 +193,7 @@ class TripalCultivatePhenotypesAlterHooks {
 
         if ($has_pheno > 0 && (!in_array($genus, $exp_germgenus) || $not_unique)) {
           $form_state->setErrorByName(
-            'exp_germgenus',
+            self::FIELD_ORGANISM,
             $this->t('Update failed: Genus "@genus" of this research experiment is linked to the Phenotypes module and must be a unique entry in the Germplasm Genus field. Click @reload to restore form values if you have removed or altered a genus.', [
               '@genus' => $genus,
               '@reload' => Link::fromTextAndUrl('Restore Values', Url::fromRoute('<current>'))->toString(),

--- a/trpcultivate_phenotypes/tests/src/Kernel/Forms/PhenoExperimentConfigurationFormTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Forms/PhenoExperimentConfigurationFormTest.php
@@ -90,6 +90,13 @@ class PhenoExperimentConfigurationFormTest extends ChadoTestKernelBase {
   const PHENO_COMBO_TABLE = 'trpcultivate_phenocombo';
 
   /**
+   * The name of the field that contains the genus.
+   *
+   * @var string
+   */
+  public const FIELD_ORGANISM = 'exp_organism';
+
+  /**
    * Test genus with a set of test traits.
    *
    * @var array
@@ -235,7 +242,7 @@ class PhenoExperimentConfigurationFormTest extends ChadoTestKernelBase {
             ->execute();
 
           $entity
-            ->set('exp_germgenus', ['record_id' => $project_id, 'value' => $genus]);
+            ->set(self::FIELD_ORGANISM, ['record_id' => $project_id, 'genus_value' => $genus]);
         }
       }
 

--- a/trpcultivate_phenotypes/tests/src/Kernel/Forms/PhenoExperimentTraitSelectorFormTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Forms/PhenoExperimentTraitSelectorFormTest.php
@@ -134,6 +134,13 @@ class PhenoExperimentTraitSelectorFormTest extends ChadoTestKernelBase {
   const FORM_WRAPPER = 'form_wrapper';
 
   /**
+   * The name of the field that contains the genus.
+   *
+   * @var string
+   */
+  public const FIELD_ORGANISM = 'exp_organism';
+
+  /**
    * {@inheritdoc}
    */
   protected function setUp(): void {
@@ -206,7 +213,7 @@ class PhenoExperimentTraitSelectorFormTest extends ChadoTestKernelBase {
         ])
         ->execute();
 
-      $entity->set('exp_germgenus', ['record_id' => $project_id, 'value' => $ins_genus]);
+      $entity->set(self::FIELD_ORGANISM, ['record_id' => $project_id, 'genus_value' => $ins_genus]);
     }
 
     $entity->save();

--- a/trpcultivate_phenotypes/tests/src/Kernel/Hooks/HookAlterTest.php
+++ b/trpcultivate_phenotypes/tests/src/Kernel/Hooks/HookAlterTest.php
@@ -75,6 +75,13 @@ class HookAlterTest extends ChadoTestKernelBase {
   private TripalEntity $exp_entity;
 
   /**
+   * The name of the field that contains the genus.
+   *
+   * @var string
+   */
+  public const FIELD_ORGANISM = 'exp_organism';
+
+  /**
    * {@inheritDoc}
    */
   public function setUp(): void {
@@ -148,7 +155,7 @@ class HookAlterTest extends ChadoTestKernelBase {
       ->execute();
 
     $entity
-      ->set('exp_germgenus', ['record_id' => $project_id, 'value' => $genus]);
+      ->set(self::FIELD_ORGANISM, ['record_id' => $project_id, 'genus_value' => $genus]);
 
     $entity->save();
     $this->exp_entity = $entity;
@@ -247,21 +254,15 @@ class HookAlterTest extends ChadoTestKernelBase {
     $request->attributes->set('tripal_entity', $this->exp_entity);
     $this->container->set('current_route_match', RouteMatch::createFromRequest($request));
 
-    $entity_field = 'exp_germgenus';
-
     $form_state = new FormState();
     $form = [];
 
-    $exp_genus = $this->exp_entity->get($entity_field)[0]
-      ->getValue()['value'];
+    $exp_genus = $this->exp_entity->get(self::FIELD_ORGANISM)
+      ->getValue()[0]['genus_value'];
 
     // The entity has Lens genus and with phenotypes. Omitting said genus will
     // trigger the validation error.
-    $form_state->setValue($entity_field, [
-      0 => ['value' => 'Lenz'],
-      1 => ['value' => 'Triticum'],
-      2 => ['value' => ''],
-    ]);
+    $form_state->setValue([self::FIELD_ORGANISM, 0, 'organism_id'], 'Lenz culinaris');
 
     $form_validator = new TripalCultivatePhenotypesAlterHooks(
       $this->container->get('database'),
@@ -277,20 +278,20 @@ class HookAlterTest extends ChadoTestKernelBase {
 
     // Error emanates form exp_germgenus field.
     $this->assertEquals(
-      $entity_field,
+      self::FIELD_ORGANISM,
       array_keys($errors)[0],
-      'The error is epected to be triggered by field ' . $entity_field,
+      'The error is epected to be triggered by field ' . self::FIELD_ORGANISM,
     );
 
     $this->assertStringContainsString(
       'Update failed: Genus "' . $exp_genus . '" of this research experiment is linked to the Phenotypes module and must be a unique entry in the Germplasm Genus field.',
-      $errors[$entity_field],
+      $errors[self::FIELD_ORGANISM],
       'The validation error does not match expected error message text',
     );
 
     $this->assertStringContainsString(
       Link::fromTextAndUrl('Restore Values', Url::fromRoute('<current>'))->toString(),
-      $errors[$entity_field],
+      $errors[self::FIELD_ORGANISM],
       'The validation does not contain the expected link to restore form values.',
     );
   }


### PR DESCRIPTION
**Issue #243 **

## Motivation

<!-- This can usually be copied from the issue. Please do not just say, go see issue but instead copy the relevant details here. -->

This PR updates all reference to exp_germgenus field name and value key to use the updated field name and value key.

## What does this PR do?
*Please describe each things this PR does. For example, a PR may 1) solve a specific bug, 2) create an automated test to ensure it doesn't return.*

1. Updated class that reference outdated field name and key value containing genus.

## Testing

1. Switch to branch g0.243-UpdateGenusFieldName and build a clone.
2. Execute tests and ensure that all test are passing

<img width="473" height="102" alt="Screenshot 2026-06-30 at 7 44 55 AM" src="https://github.com/user-attachments/assets/2f96621f-e0f6-472a-abfc-a94023fd7106" />

**NOTE:** When testing out research experiment form edit, the genus field cannot be removed and throws an error that points to this hook https://github.com/TripalCultivate/TripalCultivate-Phenotypes/blob/604f0f5812980d9614aab29d4d6ec4755f94f9e1/trpcultivate_phenotypes/src/Hook/TripalCultivatePhenotypesAlterHooks.php#L127, specifically the line where it attaches the validator method:

https://github.com/TripalCultivate/TripalCultivate-Phenotypes/blob/604f0f5812980d9614aab29d4d6ec4755f94f9e1/trpcultivate_phenotypes/src/Hook/TripalCultivatePhenotypesAlterHooks.php#L136

This is resolved in this PR https://github.com/TripalCultivate/TripalCultivate-Phenotypes/pull/222 with a better way of attaching constraint validator.
